### PR TITLE
Make Drawer animate using a spring force instead of a linear curve.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -34,7 +34,7 @@ vars = {
   'cassowary_dart_revision': '7e5afc5b3956a18636d5b37b1dcba1705865564b',
   'collection_dart_revision': '79ebc6fc2dae581cb23ad50a5c600c1b7dd132f8',
   'crypto_dart_revision': 'd4558dea1639e5ad2a41d045265b8ece270c2d90',
-  'newton_dart_revision': '26da04f0c441d005a6ecbf62ae047cd02ec9abc5',
+  'newton_dart_revision': '9fbe5fbac809246f7ace4176feca13bdf731e393',
   'path_dart_revision': '2f3dcdec32011f1bc41194ae3640d6d9292a7096',
   'quiver_dart_revision': '6bab7dec34189eee579178eb16d3063c8ae69031',
   'source_span_dart_revision': '5c6c13f62fc111adaace3aeb4a38853d64481d06',

--- a/sky/sdk/BUILD.gn
+++ b/sky/sdk/BUILD.gn
@@ -11,6 +11,7 @@ dart_pkg("sky") {
     "lib/animation/animated_simulation.dart",
     "lib/animation/animation_performance.dart",
     "lib/animation/curves.dart",
+    "lib/animation/forces.dart",
     "lib/animation/scroll_behavior.dart",
     "lib/animation/timeline.dart",
     "lib/assets/.gitignore",

--- a/sky/sdk/lib/animation/scroll_behavior.dart
+++ b/sky/sdk/lib/animation/scroll_behavior.dart
@@ -5,10 +5,11 @@
 import 'dart:math' as math;
 
 import 'package:newton/newton.dart';
+import 'package:sky/animation/forces.dart';
 
 const double _kSecondsPerMillisecond = 1000.0;
 
-abstract class ScrollBehavior {
+abstract class ScrollBehavior extends Force {
   Simulation release(double position, double velocity) => null;
 
   // Returns the new scroll offset.

--- a/sky/sdk/lib/animation/timeline.dart
+++ b/sky/sdk/lib/animation/timeline.dart
@@ -7,8 +7,6 @@ import 'dart:async';
 import 'package:newton/newton.dart';
 import 'package:sky/animation/animated_simulation.dart';
 
-const  double _kEpsilon = 0.001;
-
 // Simple simulation that linearly varies from |begin| to |end| over |duration|.
 class TweenSimulation extends Simulation {
   final double _durationInSeconds;
@@ -66,17 +64,6 @@ class Timeline {
 
   void stop() {
     _animation.stop();
-  }
-
-  static final SpringDescription _kDefaultSpringDesc =
-      new SpringDescription.withDampingRatio(
-          mass: 1.0, springConstant: 500.0, ratio: 1.0);
-
-  Simulation defaultSpringSimulation({double velocity: 0.0}) {
-    // Target just past the 0 or 1 endpoint, because the animation will stop
-    // once the Spring gets within the epsilon, and we want to stop at 0 or 1.
-    double target = velocity < 0.0 ? -_kEpsilon : 1.0 + _kEpsilon;
-    return new SpringSimulation(_kDefaultSpringDesc, value, target, velocity);
   }
 
   // Give |simulation| control over the timeline.

--- a/sky/sdk/lib/widgets/dismissable.dart
+++ b/sky/sdk/lib/widgets/dismissable.dart
@@ -13,6 +13,7 @@ import 'package:vector_math/vector_math.dart';
 const Duration _kCardDismissFadeout = const Duration(milliseconds: 300);
 const double _kMinFlingVelocity = 700.0;
 const double _kMinFlingVelocityDelta = 400.0;
+const double _kFlingVelocityScale = 1.0/300.0;
 const double _kDismissCardThreshold = 0.6;
 
 typedef void DismissedCallback();
@@ -129,7 +130,7 @@ class Dismissable extends AnimatedComponent {
       _dragUnderway = false;
       _dragX = event.velocityX.sign;
       _position.end = _activeCardDragEndPoint;
-      _performance.fling(velocity: event.velocityX.abs() / _width);
+      _performance.fling(velocity: event.velocityX.abs() * _kFlingVelocityScale);
     }
   }
 


### PR DESCRIPTION
Make Drawer animate using a spring force instead of a linear curve.

This gives it a nice springy effect while still allowing us to track the user's finger while dragging (which requires a linear animation curve).