### PR TITLE
Fix build issues related to symlink.py

### DIFF
--- a/build/symlink.py
+++ b/build/symlink.py
@@ -9,6 +9,7 @@
 import errno
 import optparse
 import os.path
+import shutil
 import sys
 
 
@@ -25,11 +26,16 @@ def Main(argv):
   sources = args[:-1]
   for s in sources:
     t = os.path.join(target, os.path.basename(s))
+    if len(sources) == 1 and not os.path.isdir(target):
+      t = target
     try:
       os.symlink(s, t)
     except OSError, e:
       if e.errno == errno.EEXIST and options.force:
-        os.remove(t)
+        if os.path.isdir(t):
+          shutil.rmtree(t, ignore_errors=True)
+        else:
+          os.remove(t)
         os.symlink(s, t)
       else:
         raise

--- a/sky/build/symlink.py
+++ b/sky/build/symlink.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# Copyright (c) 2013 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import errno
+import optparse
+import os.path
+import shutil
+import sys
+
+
+def main(argv):
+    parser = optparse.OptionParser()
+    parser.add_option('--touch')
+
+    options, args = parser.parse_args(argv[1:])
+    if len(args) != 2:
+        parser.error('Two arguments required.')
+
+    source = os.path.abspath(args[0])
+    target = os.path.abspath(args[1])
+    try:
+        os.symlink(source, target)
+    except OSError, e:
+        if e.errno == errno.EEXIST:
+            os.remove(target)
+            os.symlink(source, target)
+
+    if options.touch:
+        with open(os.path.abspath(options.touch), 'w') as f:
+            pass
+
+
+if __name__ == '__main__':
+  sys.exit(main(sys.argv))

--- a/sky/sdk/BUILD.gn
+++ b/sky/sdk/BUILD.gn
@@ -125,8 +125,8 @@ dart_pkg("sky") {
 }
 
 action("material_design_icons") {
-  input_dir = "lib/assets/material-design-icons"
-  output_dir = "$root_gen_dir/dart-pkg/sky/lib/assets"
+  source_file = "lib/assets/material-design-icons"
+  target_file = "$root_gen_dir/dart-pkg/sky/lib/assets/material-design-icons"
   stamp = "$target_gen_dir/material_design_icons_linked"
 
   sources = [
@@ -136,11 +136,10 @@ action("material_design_icons") {
     stamp,
   ]
 
-  script = "//build/symlink.py"
+  script = "//sky/build/symlink.py"
   args = [
-    "--force",
-    rebase_path(input_dir, output_dir),
-    rebase_path(output_dir, root_build_dir),
+    rebase_path(source_file, root_build_dir),
+    rebase_path(target_file, root_build_dir),
     "--touch",
     rebase_path(stamp, root_build_dir),
   ]

--- a/sky/tools/roll/roll.py
+++ b/sky/tools/roll/roll.py
@@ -97,7 +97,6 @@ files_not_to_roll = [
     'build/config/ui.gni',
     'build/ls.py',
     'build/module_args/mojo.gni',
-    'build/symlink.py',
     'tools/android/VERSION_LINUX_NDK',
     'tools/android/VERSION_LINUX_SDK',
     'tools/android/VERSION_MACOSX_NDK',


### PR DESCRIPTION
There are actually two uses cases for symlink.py. This CL restores
//build/symlink.py to match the version in Chromium and adds a new version in
////sky/build/symlink.py that works properly for the material-design-icons.