### PR TITLE
Card Collection dismiss animation

### DIFF
--- a/sky/sdk/example/widgets/block_viewport.dart
+++ b/sky/sdk/example/widgets/block_viewport.dart
@@ -15,6 +15,7 @@ import 'package:sky/widgets/widget.dart';
 
 class BlockViewportApp extends App {
 
+  BlockViewportLayoutState layoutState = new BlockViewportLayoutState();
   List<double> lengths = <double>[];
   double offset = 0.0;
 
@@ -96,7 +97,8 @@ class BlockViewportApp extends App {
                   child: new BlockViewport(
                     builder: builder,
                     startOffset: offset,
-                    token: lengths.length
+                    token: lengths.length,
+                    layoutState: layoutState
                   )
                 )
               ),

--- a/sky/sdk/lib/widgets/block_viewport.dart
+++ b/sky/sdk/lib/widgets/block_viewport.dart
@@ -12,13 +12,6 @@ import 'package:sky/widgets/widget.dart';
 // return null if index is greater than index of last entry
 typedef Widget IndexedBuilder(int index);
 
-typedef void LayoutChangedCallback(
-  int firstVisibleChildIndex,
-  int visibleChildCount,
-  UnmodifiableListView<double> childOffsets,
-  bool didReachLastChild
-);
-
 class _Key {
   const _Key(this.type, this.key);
   factory _Key.fromWidget(Widget widget) => new _Key(widget.runtimeType, widget.key);
@@ -26,24 +19,80 @@ class _Key {
   final String key;
   bool operator ==(other) => other is _Key && other.type == type && other.key == key;
   int get hashCode => 373 * 37 * type.hashCode + key.hashCode;
+  String toString() => "_Key(type: $type, key: $key)";
+}
+
+typedef void LayoutChangedCallback();
+
+class BlockViewportLayoutState {
+  BlockViewportLayoutState()
+    : _childOffsets = <double>[0.0],
+      _firstVisibleChildIndex = 0,
+      _visibleChildCount = 0,
+      _didReachLastChild = false
+  {
+    _readOnlyChildOffsets = new UnmodifiableListView<double>(_childOffsets);
+  }
+
+  Map<_Key, Widget> _childrenByKey = new Map<_Key, Widget>();
+  bool _dirty = true;
+
+  int _firstVisibleChildIndex;
+  int get firstVisibleChildIndex => _firstVisibleChildIndex;
+
+  int _visibleChildCount;
+  int get visibleChildCount => _visibleChildCount;
+
+  // childOffsets contains the offsets of each child from the top of the
+  // list up to the last one we've ever created, and the offset of the
+  // end of the last one. If there are no children, then the only offset
+  // is 0.0.
+  List<double> _childOffsets;
+  UnmodifiableListView<double> _readOnlyChildOffsets;
+  UnmodifiableListView<double> get childOffsets => _readOnlyChildOffsets;
+  double get contentsSize => _childOffsets.last;
+
+  bool _didReachLastChild;
+  bool get didReachLastChild => _didReachLastChild;
+
+  Set<int> _invalidIndices = new Set<int>();
+  bool get isValid => _invalidIndices.length == 0;
+  // Notify the BlockViewport that the children at indices have either
+  // changed size and/or changed type.
+  void invalidate(Iterable<int> indices) {
+    _invalidIndices.addAll(indices);
+  }
+
+  final List<Function> _listeners = new List<Function>();
+  void addListener(Function listener) {
+    _listeners.add(listener);
+  }
+  void removeListener(Function listener) {
+    _listeners.remove(listener);
+  }
+  void _notifyListeners() {
+    List<Function> localListeners = new List<Function>.from(_listeners);
+    for (Function listener in localListeners)
+      listener();
+  }
 }
 
 class BlockViewport extends RenderObjectWrapper {
-  BlockViewport({ this.builder, this.startOffset, this.token, this.onLayoutChanged, String key })
-    : super(key: key);
+  BlockViewport({ this.builder, this.startOffset, this.token, this.layoutState, String key })
+    : super(key: key) {
+    assert(this.layoutState != null);
+  }
 
   IndexedBuilder builder;
   double startOffset;
   Object token;
-  LayoutChangedCallback onLayoutChanged;
+  BlockViewportLayoutState layoutState;
 
   RenderBlockViewport get root => super.root;
   RenderBlockViewport createNode() => new RenderBlockViewport();
 
-  Map<_Key, Widget> _childrenByKey = new Map<_Key, Widget>();
-
   void walkChildren(WidgetTreeWalker walker) {
-    for (Widget child in _childrenByKey.values)
+    for (Widget child in layoutState._childrenByKey.values)
       walker(child);
   }
 
@@ -69,7 +118,7 @@ class BlockViewport extends RenderObjectWrapper {
   }
 
   void remove() {
-    for (Widget child in _childrenByKey.values) {
+    for (Widget child in layoutState._childrenByKey.values) {
       assert(child != null);
       removeChild(child);
     }
@@ -86,23 +135,15 @@ class BlockViewport extends RenderObjectWrapper {
     super.didUnmount();
   }
 
-  // _offsets contains the offsets of each child from the top of the
-  // list up to the last one we've ever created, and the offset of the
-  // end of the last one. If there's no children, then the only offset
-  // is 0.0.
-  List<double> _offsets = <double>[0.0];
-  int _currentStartIndex = 0;
-  int _currentChildCount = 0;
-  bool _didReachLastChild = false;
-
   int _findIndexForOffsetBeforeOrAt(double offset) {
+    final List<double> offsets = layoutState._childOffsets;
     int left = 0;
-    int right = _offsets.length - 1;
+    int right = offsets.length - 1;
     while (right >= left) {
       int middle = left + ((right - left) ~/ 2);
-      if (_offsets[middle] < offset) {
+      if (offsets[middle] < offset) {
         left = middle + 1;
-      } else if (_offsets[middle] > offset) {
+      } else if (offsets[middle] > offset) {
         right = middle - 1;
       } else {
         return middle;
@@ -111,94 +152,154 @@ class BlockViewport extends RenderObjectWrapper {
     return right;
   }
 
-  bool _dirty = true;
-
   bool retainStatefulNodeIfPossible(BlockViewport newNode) {
+    assert(layoutState == newNode.layoutState);
     retainStatefulRenderObjectWrapper(newNode);
     if (startOffset != newNode.startOffset) {
-      _dirty = true;
+      layoutState._dirty = true;
       startOffset = newNode.startOffset;
     }
     if (token != newNode.token || builder != newNode.builder) {
-      _dirty = true;
+      layoutState._dirty = true;
       builder = newNode.builder;
       token = newNode.token;
-      _offsets = <double>[0.0];
-      _didReachLastChild = false;
+      layoutState._didReachLastChild = false;
+      layoutState._childOffsets = <double>[0.0];
+      layoutState._invalidIndices = new Set<int>();
     }
     return true;
   }
 
   void syncRenderObject(BlockViewport old) {
     super.syncRenderObject(old);
-    if (_dirty) {
+    if (layoutState._dirty || !layoutState.isValid) {
       root.markNeedsLayout();
     } else {
-      if (_currentChildCount > 0) {
-        assert(_currentStartIndex >= 0);
+      if (layoutState._visibleChildCount > 0) {
+        assert(layoutState.firstVisibleChildIndex >= 0);
         assert(builder != null);
         assert(root != null);
-        int lastIndex = _currentStartIndex + _currentChildCount - 1;
-        for (int index = _currentStartIndex; index <= lastIndex; index += 1) {
+        final int startIndex = layoutState._firstVisibleChildIndex;
+        int lastIndex = startIndex + layoutState._visibleChildCount - 1;
+        for (int index = startIndex; index <= lastIndex; index += 1) {
           Widget widget = builder(index);
           assert(widget != null);
           assert(widget.key != null);
           _Key key = new _Key.fromWidget(widget);
-          Widget oldWidget = _childrenByKey[key];
+          Widget oldWidget = layoutState._childrenByKey[key];
           assert(oldWidget != null);
           assert(oldWidget.root.parent == root);
           widget = syncChild(widget, oldWidget, root.childAfter(oldWidget.root));
           assert(widget != null);
-          _childrenByKey[key] = widget;
+          layoutState._childrenByKey[key] = widget;
         }
       }
     }
   }
 
+  // Build the widget at index, and use its maxIntrinsicHeight to fix up
+  // the offsets from index+1 to endIndex. Return the newWidget.
+  Widget _getWidgetAndRecomputeOffsets(int index, int endIndex, BoxConstraints innerConstraints) {
+    final List<double> offsets = layoutState._childOffsets;
+    // Create the newWidget at index.
+    assert(index >= 0);
+    assert(endIndex > index);
+    assert(endIndex < offsets.length);
+    assert(builder != null);
+    Widget newWidget = builder(index);
+    assert(newWidget != null);
+    assert(newWidget.key != null);
+    final _Key key = new _Key.fromWidget(newWidget);
+    Widget oldWidget = layoutState._childrenByKey[key];
+    newWidget = syncChild(newWidget, oldWidget, _omit);
+    assert(newWidget != null);
+    // Update the offsets based on the newWidget's height.
+    RenderBox widgetRoot = newWidget.root;
+    assert(widgetRoot is RenderBox);
+    double newHeight = widgetRoot.getMaxIntrinsicHeight(innerConstraints);
+    double oldHeight = offsets[index + 1] - offsets[index];
+    double heightDelta = newHeight - oldHeight;
+    for (int i = index + 1; i <= endIndex; i++)
+      offsets[i] += heightDelta;
+    return newWidget;
+  }
+
   Widget _getWidget(int index, BoxConstraints innerConstraints) {
-    LayoutCallbackBuilderHandle handle = enterLayoutCallbackBuilder();
-    try {
-      assert(index >= 0);
-      Widget widget = builder == null ? null : builder(index);
-      if (widget == null)
-        return null;
-      assert(widget.key != null); // items in lists must have keys
-      final _Key key = new _Key.fromWidget(widget);
-      Widget oldWidget = _childrenByKey[key];
-      widget = syncChild(widget, oldWidget, _omit);
-      if (oldWidget != null)
-        _childrenByKey[key] = widget;
-      if (index >= _offsets.length - 1) {
-        assert(index == _offsets.length - 1);
-        final double widgetStartOffset = _offsets[index];
-        RenderBox widgetRoot = widget.root;
-        assert(widgetRoot is RenderBox);
-        final double widgetEndOffset = widgetStartOffset + widgetRoot.getMaxIntrinsicHeight(innerConstraints);
-        _offsets.add(widgetEndOffset);
-      }
-      return widget;
-    } finally {
-      exitLayoutCallbackBuilder(handle);
+    final List<double> offsets = layoutState._childOffsets;
+    assert(index >= 0);
+    Widget widget = builder == null ? null : builder(index);
+    if (widget == null)
+      return null;
+    assert(widget.key != null); // items in lists must have keys
+    final _Key key = new _Key.fromWidget(widget);
+    Widget oldWidget = layoutState._childrenByKey[key];
+    widget = syncChild(widget, oldWidget, _omit);
+    if (index >= offsets.length - 1) {
+      assert(index == offsets.length - 1);
+      final double widgetStartOffset = offsets[index];
+      RenderBox widgetRoot = widget.root;
+      assert(widgetRoot is RenderBox);
+      final double widgetEndOffset = widgetStartOffset + widgetRoot.getMaxIntrinsicHeight(innerConstraints);
+      offsets.add(widgetEndOffset);
     }
+    return widget;
   }
 
   void layout(BoxConstraints constraints) {
-    if (!_dirty)
+    if (!layoutState._dirty && layoutState.isValid)
       return;
-    _dirty = false;
+    layoutState._dirty = false;
 
+    LayoutCallbackBuilderHandle handle = enterLayoutCallbackBuilder();
+    try {
+      _doLayout(constraints);
+    } finally {
+      exitLayoutCallbackBuilder(handle);
+    }
+
+    layoutState._notifyListeners();
+  }
+
+  void _doLayout(BoxConstraints constraints) {
     Map<_Key, Widget> newChildren = new Map<_Key, Widget>();
     Map<int, Widget> builtChildren = new Map<int, Widget>();
 
+    final List<double> offsets = layoutState._childOffsets;
+    final Map<_Key, Widget> childrenByKey = layoutState._childrenByKey;
     final double height = root.size.height;
     final double endOffset = startOffset + height;
     BoxConstraints innerConstraints = new BoxConstraints.tightFor(width: constraints.constrainWidth());
+
+    // Before doing the actual layout, fix the offsets for the widgets
+    // whose size or type has changed.
+    if (!layoutState.isValid && offsets.length > 0) {
+      List<int> invalidIndices = layoutState._invalidIndices.toList();
+      invalidIndices.sort();
+      // Ensure all of the offsets after invalidIndices[0] are updated.
+      if (invalidIndices.last < offsets.length - 1)
+        invalidIndices.add(offsets.length - 1);
+      for (int i = 0; i < invalidIndices.length - 1; i += 1) {
+        int index = invalidIndices[i];
+        int endIndex = invalidIndices[i + 1];
+        Widget widget = _getWidgetAndRecomputeOffsets(index, endIndex, innerConstraints);
+        _Key widgetKey = new _Key.fromWidget(widget);
+        bool isVisible = offsets[index] < endOffset && offsets[index + 1] >= startOffset;
+        if (isVisible) {
+          newChildren[widgetKey] = widget;
+          builtChildren[index] = widget;
+        } else {
+          childrenByKey.remove(widgetKey);
+          syncChild(null, widget, null);
+        }
+      }
+    }
+    layoutState._invalidIndices.clear();
 
     int startIndex;
     bool haveChildren;
     if (startOffset <= 0.0) {
       startIndex = 0;
-      if (_offsets.length > 1) {
+      if (offsets.length > 1) {
         haveChildren = true;
       } else {
         Widget widget = _getWidget(startIndex, innerConstraints);
@@ -208,41 +309,41 @@ class BlockViewport extends RenderObjectWrapper {
           haveChildren = true;
         } else {
           haveChildren = false;
-          _didReachLastChild = true;
+          layoutState._didReachLastChild = true;
         }
       }
     } else {
       startIndex = _findIndexForOffsetBeforeOrAt(startOffset);
-      if (startIndex == _offsets.length - 1) {
+      if (startIndex == offsets.length - 1) {
         // We don't have an offset on the list that is beyond the start offset.
-        assert(_offsets.last <= startOffset);
+        assert(offsets.last <= startOffset);
         // Fill the list until this isn't true or until we know that the
         // list is complete (and thus we are overscrolled).
         while (true) {
           Widget widget = _getWidget(startIndex, innerConstraints);
           if (widget == null) {
-            _didReachLastChild = true;
+            layoutState._didReachLastChild = true;
             break;
           }
           _Key widgetKey = new _Key.fromWidget(widget);
-          if (_offsets.last > startOffset) {
+          if (offsets.last > startOffset) {
             newChildren[widgetKey] = widget;
             builtChildren[startIndex] = widget;
             break;
           }
-          if (!_childrenByKey.containsKey(widgetKey)) {
+          if (!childrenByKey.containsKey(widgetKey)) {
             // we don't actually need this one, release it
             syncChild(null, widget, null);
           } // else we'll get rid of it later, when we remove old children
           startIndex += 1;
-          assert(startIndex == _offsets.length - 1);
+          assert(startIndex == offsets.length - 1);
         }
-        if (_offsets.last > startOffset) {
+        if (offsets.last > startOffset) {
           // If we're here, we have at least one child, so our list has
           // at least two offsets, the top of the child and the bottom
           // of the child.
-          assert(_offsets.length >= 2);
-          assert(startIndex == _offsets.length - 2);
+          assert(offsets.length >= 2);
+          assert(startIndex == offsets.length - 2);
           haveChildren = true;
         } else {
           // If we're here, there are no children to show.
@@ -253,20 +354,20 @@ class BlockViewport extends RenderObjectWrapper {
       }
     }
     assert(haveChildren != null);
-    assert(haveChildren || _didReachLastChild);
+    assert(haveChildren || layoutState._didReachLastChild);
 
     assert(startIndex >= 0);
-    assert(startIndex < _offsets.length);
+    assert(startIndex < offsets.length);
 
     int index = startIndex;
     if (haveChildren) {
       // Build all the widgets we need.
-      root.startOffset = _offsets[index] - startOffset;
-      while (_offsets[index] < endOffset) {
+      root.startOffset = offsets[index] - startOffset;
+      while (offsets[index] < endOffset) {
         if (!builtChildren.containsKey(index)) {
           Widget widget = _getWidget(index, innerConstraints);
           if (widget == null) {
-            _didReachLastChild = true;
+            layoutState._didReachLastChild = true;
             break;
           }
           newChildren[new _Key.fromWidget(widget)] = widget;
@@ -278,9 +379,9 @@ class BlockViewport extends RenderObjectWrapper {
     }
 
     // Remove any old children.
-    for (_Key oldChildKey in _childrenByKey.keys) {
+    for (_Key oldChildKey in childrenByKey.keys) {
       if (!newChildren.containsKey(oldChildKey))
-        syncChild(null, _childrenByKey[oldChildKey], null); // calls detachChildRoot()
+        syncChild(null, childrenByKey[oldChildKey], null); // calls detachChildRoot()
     }
 
     if (haveChildren) {
@@ -302,18 +403,9 @@ class BlockViewport extends RenderObjectWrapper {
       }
     }
 
-    _childrenByKey = newChildren;
-    _currentStartIndex = startIndex;
-    _currentChildCount = _childrenByKey.length;
-
-    if (onLayoutChanged != null) {
-      onLayoutChanged(
-        _currentStartIndex,
-        _currentChildCount,
-        new UnmodifiableListView<double>(_offsets),
-        _didReachLastChild
-     );
-    }
+    layoutState._childrenByKey = newChildren;
+    layoutState._firstVisibleChildIndex = startIndex;
+    layoutState._visibleChildCount = newChildren.length;
   }
 
 }

--- a/sky/sdk/lib/widgets/card.dart
+++ b/sky/sdk/lib/widgets/card.dart
@@ -5,6 +5,8 @@
 import 'package:sky/widgets/basic.dart';
 import 'package:sky/widgets/material.dart';
 
+const EdgeDims kCardMargins = const EdgeDims.all(4.0);
+
 /// A material design card
 ///
 /// <https://www.google.com/design/spec/components/cards.html>
@@ -16,7 +18,7 @@ class Card extends Component {
 
   Widget build() {
     return new Container(
-      margin: const EdgeDims.all(4.0),
+      margin: kCardMargins,
       child: new Material(
         color: color,
         type: MaterialType.card,

--- a/sky/tests/examples/card_collection-expected.txt
+++ b/sky/tests/examples/card_collection-expected.txt
@@ -32,7 +32,7 @@ PAINT FOR FRAME #2 ----------------------------------------------
 2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
 2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xfff44336), drawLooper:true))
+2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffe57373), drawLooper:true))
 2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
 2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 52.0), Paint(color:Color(0xff000000)))
@@ -62,10 +62,10 @@ PAINT FOR FRAME #2 ----------------------------------------------
 2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
 2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffee453b), drawLooper:true))
+2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffdd7174), drawLooper:true))
 2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
 2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 68.0), Paint(color:Color(0xff000000)))
+2 |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 67.0), Paint(color:Color(0xff000000)))
 2 |  |  |  |  |  |  |  |  |  |  |  | clipRRect()
 2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(4.0, 4.0)
 2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
@@ -73,26 +73,26 @@ PAINT FOR FRAME #2 ----------------------------------------------
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(12.0, 12.0)
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(359.0, 23.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(359.0, 23.0)
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(359.0, 23.5)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -23.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(359.0, 23.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -23.0)
 2 |  |  |  |  |  |  |  |  |  |  |  | restore
 2 |  |  |  |  |  |  |  |  | restore
-2 |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 196.0)
+2 |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 195.0)
 2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 196.0)
+2 |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 195.0)
 2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 196.0)
+2 |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 195.0)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  | save
-2 |  |  |  |  |  |  |  |  | translate(8.0, 196.0)
+2 |  |  |  |  |  |  |  |  | translate(8.0, 195.0)
 2 |  |  |  |  |  |  |  |  | concat([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
 2 |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
 2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
 2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffe84740), drawLooper:true))
+2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffd56f76), drawLooper:true))
 2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
 2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 86.0), Paint(color:Color(0xff000000)))
@@ -109,23 +109,23 @@ PAINT FOR FRAME #2 ----------------------------------------------
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -32.5)
 2 |  |  |  |  |  |  |  |  |  |  |  | restore
 2 |  |  |  |  |  |  |  |  | restore
-2 |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 286.0)
+2 |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 285.0)
 2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 286.0)
+2 |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 285.0)
 2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 286.0)
+2 |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 285.0)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  | save
-2 |  |  |  |  |  |  |  |  | translate(8.0, 286.0)
+2 |  |  |  |  |  |  |  |  | translate(8.0, 285.0)
 2 |  |  |  |  |  |  |  |  | concat([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
 2 |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
 2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
 2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffe24945), drawLooper:true))
+2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffcd6e78), drawLooper:true))
 2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
 2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 50.0), Paint(color:Color(0xff000000)))
+2 |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 150.0), Paint(color:Color(0xff000000)))
 2 |  |  |  |  |  |  |  |  |  |  |  | clipRRect()
 2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(4.0, 4.0)
 2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
@@ -133,26 +133,26 @@ PAINT FOR FRAME #2 ----------------------------------------------
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(12.0, 12.0)
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(359.0, 14.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(359.0, 64.5)
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(359.0, 14.5)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -14.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(359.0, 64.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -64.5)
 2 |  |  |  |  |  |  |  |  |  |  |  | restore
 2 |  |  |  |  |  |  |  |  | restore
-2 |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 340.0)
+2 |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 439.0)
 2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 340.0)
+2 |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 439.0)
 2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 340.0)
+2 |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 439.0)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  | save
-2 |  |  |  |  |  |  |  |  | translate(8.0, 340.0)
+2 |  |  |  |  |  |  |  |  | translate(8.0, 439.0)
 2 |  |  |  |  |  |  |  |  | concat([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
 2 |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
 2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
 2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffdc4c4b), drawLooper:true))
+2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffc56c79), drawLooper:true))
 2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
 2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 64.0), Paint(color:Color(0xff000000)))
@@ -169,20 +169,20 @@ PAINT FOR FRAME #2 ----------------------------------------------
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -21.5)
 2 |  |  |  |  |  |  |  |  |  |  |  | restore
 2 |  |  |  |  |  |  |  |  | restore
-2 |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 408.0)
+2 |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 507.0)
 2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 408.0)
+2 |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 507.0)
 2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 408.0)
+2 |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 507.0)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  | save
-2 |  |  |  |  |  |  |  |  | translate(8.0, 408.0)
+2 |  |  |  |  |  |  |  |  | translate(8.0, 507.0)
 2 |  |  |  |  |  |  |  |  | concat([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
 2 |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
 2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
 2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffd64e50), drawLooper:true))
+2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffbd6a7b), drawLooper:true))
 2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
 2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 59.0), Paint(color:Color(0xff000000)))
@@ -199,20 +199,20 @@ PAINT FOR FRAME #2 ----------------------------------------------
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -19.0)
 2 |  |  |  |  |  |  |  |  |  |  |  | restore
 2 |  |  |  |  |  |  |  |  | restore
-2 |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 471.0)
+2 |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 570.0)
 2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 471.0)
+2 |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 570.0)
 2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 471.0)
+2 |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 570.0)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  | save
-2 |  |  |  |  |  |  |  |  | translate(8.0, 471.0)
+2 |  |  |  |  |  |  |  |  | translate(8.0, 570.0)
 2 |  |  |  |  |  |  |  |  | concat([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
 2 |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
 2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
 2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffd05055), drawLooper:true))
+2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffb5697d), drawLooper:true))
 2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
 2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 88.0), Paint(color:Color(0xff000000)))
@@ -227,36 +227,6 @@ PAINT FOR FRAME #2 ----------------------------------------------
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(359.0, 33.5)
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -33.5)
-2 |  |  |  |  |  |  |  |  |  |  |  | restore
-2 |  |  |  |  |  |  |  |  | restore
-2 |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 563.0)
-2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 563.0)
-2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 563.0)
-2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  | save
-2 |  |  |  |  |  |  |  |  | translate(8.0, 563.0)
-2 |  |  |  |  |  |  |  |  | concat([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
-2 |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
-2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
-2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffca535a), drawLooper:true))
-2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
-2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 100.0), Paint(color:Color(0xff000000)))
-2 |  |  |  |  |  |  |  |  |  |  |  | clipRRect()
-2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(4.0, 4.0)
-2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(4.0, 4.0)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(12.0, 12.0)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(359.0, 39.5)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(359.0, 39.5)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -39.5)
 2 |  |  |  |  |  |  |  |  |  |  |  | restore
 2 |  |  |  |  |  |  |  |  | restore
 2 |  |  |  |  |  | restore


### PR DESCRIPTION
Factored BlockViewport's layout state into a separate class. BlockViewport can be constructed with a BlockViewportState object that's owned by the app.

BlockViewportState.invalidate([index1, ...]) notifies the viewport that the children at the specified indices have changed size and/or type. Before laying out its children, BlockViewport updates the cached offsets for its invalid children.

A BlockViewportState object is now passed to the onLayoutChanged callback.

The card_collection demo has been updated.
