### PR TITLE
Fix dart_pkg.py build crash

### DIFF
--- a/mojo/public/tools/dart_pkg.py
+++ b/mojo/public/tools/dart_pkg.py
@@ -48,8 +48,9 @@ def mojom_filter(path):
 
 
 def ensure_dir_exists(path):
-    if not os.path.exists(path):
-        os.makedirs(path)
+    abspath = os.path.abspath(path)
+    if not os.path.exists(abspath):
+        os.makedirs(abspath)
 
 
 def has_pubspec_yaml(paths):


### PR DESCRIPTION
We need to work in absolute paths because os.path.exists("foo/..") is False but
os.mkdirs("foo/..") will generate an error.