### PR TITLE
Rationalise usage of keys in navigator.dart.

### DIFF
--- a/sky/sdk/example/stocks/lib/stock_home.dart
+++ b/sky/sdk/example/stocks/lib/stock_home.dart
@@ -69,7 +69,8 @@ class StockHome extends AnimatedComponent {
   }
 
   void _handleSearchEnd() {
-    assert(navigator.currentRoute.key == this);
+    assert(navigator.currentRoute is RouteState);
+    assert((navigator.currentRoute as RouteState).owner == this); // TODO(ianh): remove cast once analyzer is cleverer
     navigator.pop();
     setState(() {
       _isSearching = false;

--- a/sky/sdk/example/stocks/lib/stock_settings.dart
+++ b/sky/sdk/example/stocks/lib/stock_settings.dart
@@ -61,7 +61,7 @@ class StockSettings extends StatefulComponent {
         break;
       case StockMode.pessimistic:
         showModeDialog = true;
-        navigator.pushState("/settings/confirm", (_) {
+        navigator.pushState(this, (_) {
           showModeDialog = false;
         });
         break;

--- a/sky/sdk/lib/widgets/drawer.dart
+++ b/sky/sdk/lib/widgets/drawer.dart
@@ -143,7 +143,8 @@ class Drawer extends AnimatedComponent {
     if (_lastStatus != null && status != _lastStatus) {
       if (status == DrawerStatus.inactive &&
           navigator != null &&
-          navigator.currentRoute.key == this)
+          navigator.currentRoute is RouteState &&
+          (navigator.currentRoute as RouteState).owner == this) // TODO(ianh): remove cast once analyzer is cleverer
         navigator.pop();
       if (onStatusChanged != null)
         onStatusChanged(status);

--- a/sky/sdk/lib/widgets/popup_menu.dart
+++ b/sky/sdk/lib/widgets/popup_menu.dart
@@ -122,8 +122,9 @@ class PopupMenu extends AnimatedComponent {
     PopupMenuStatus status = _status;
     if (_lastStatus != null && status != _lastStatus) {
       if (status == PopupMenuStatus.inactive &&
-          navigator != null &&
-          navigator.currentRoute.key == this)
+          navigator != null && 
+          navigator.currentRoute is RouteState &&
+          (navigator.currentRoute as RouteState).owner == this) // TODO(ianh): remove cast once analyzer is cleverer
         navigator.pop();
       if (onStatusChanged != null)
         onStatusChanged(status);


### PR DESCRIPTION
Route (named routes) no longer have a key, and have their own storage for their names.
RouseState no longer has a key, and uses an owner field pointing to a StatefulComponent instead.
As such, RouteBase no longer has a key.

HistoryEntry no longer uses a global int to ensure uniqueness.

Propagated this to stocks app.