### PR TITLE
Remove redundant operator== and hashCode functions in card example.

### DIFF
--- a/sky/sdk/example/widgets/card_collection.dart
+++ b/sky/sdk/example/widgets/card_collection.dart
@@ -28,8 +28,6 @@ class CardModel {
   AnimationPerformance performance;
   String get label => "Item $value";
   String get key => value.toString();
-  bool operator ==(other) => other is CardModel && other.value == value;
-  int get hashCode => 373 * 37 * value.hashCode;
 }
 
 class ShrinkingCard extends AnimatedComponent {

--- a/sky/sdk/lib/animation/timeline.dart
+++ b/sky/sdk/lib/animation/timeline.dart
@@ -54,11 +54,12 @@ class Timeline {
     double end: 1.0
   }) {
     assert(!_animation.isAnimating);
-
+    assert(duration > Duration.ZERO);
     return _animation.start(new TweenSimulation(duration, begin, end));
   }
 
   Future animateTo(double target, { Duration duration }) {
+    assert(duration > Duration.ZERO);
     return _start(duration: duration, begin: value, end: target);
   }
 


### PR DESCRIPTION
It turns out that we aren't really using these. The identity logic is sufficient.

Also, add some asserts for a crash I had once but couldn't reproduce, in case that helps catch it next time.