### PR TITLE
Fix 2 crashes found by Hixie's fuzzer.

### DIFF
--- a/sky/engine/bindings/exception_state.cc
+++ b/sky/engine/bindings/exception_state.cc
@@ -23,12 +23,15 @@ ExceptionState::~ExceptionState() {
 // TODO(iansf): Implement exceptions.
 void ExceptionState::ThrowDOMException(const ExceptionCode&,
                                        const String& message) {
+    had_exception_ = true;
 }
 
 void ExceptionState::ThrowTypeError(const String& message) {
+    had_exception_ = true;
 }
 
 void ExceptionState::ThrowRangeError(const String& message) {
+    had_exception_ = true;
 }
 
 bool ExceptionState::ThrowIfNeeded() {
@@ -36,13 +39,15 @@ bool ExceptionState::ThrowIfNeeded() {
 }
 
 void ExceptionState::ClearException() {
+    had_exception_ = false;
 }
 
 Dart_Handle ExceptionState::GetDartException(Dart_NativeArguments args,
                                              bool auto_scope) {
   // TODO(abarth): Still don't understand autoscope.
   DCHECK(auto_scope);
-  return exception_.Release();
+  // TODO(eseidel): This should be a real exception object!
+  return Dart_NewStringFromCString("Exception support missing. See exception_state.cc");
 }
 
 }  // namespace blink

--- a/sky/engine/core/dom/ContainerNode.cpp
+++ b/sky/engine/core/dom/ContainerNode.cpp
@@ -84,7 +84,7 @@ void ContainerNode::checkAcceptChildType(const Node* newChild, ExceptionState& e
     }
 }
 
-void ContainerNode::checkAcceptChildHierarchy(const Node& newChild, const Node* oldChild, ExceptionState& exceptionState) const
+void ContainerNode::checkAcceptChildHierarchy(const Node& newChild, ExceptionState& exceptionState) const
 {
     if (newChild.contains(this)) {
         exceptionState.ThrowDOMException(HierarchyRequestError, "The new child element contains the parent.");
@@ -109,7 +109,7 @@ PassRefPtr<Node> ContainerNode::insertBefore(PassRefPtr<Node> newChild, Node* re
     if (exceptionState.had_exception())
         return nullptr;
 
-    checkAcceptChildHierarchy(*newChild, 0, exceptionState);
+    checkAcceptChildHierarchy(*newChild, exceptionState);
     if (exceptionState.had_exception())
         return nullptr;
 
@@ -134,7 +134,8 @@ PassRefPtr<Node> ContainerNode::insertBefore(PassRefPtr<Node> newChild, Node* re
     if (targets.isEmpty())
         return newChild;
 
-    checkAcceptChildHierarchy(*newChild, 0, exceptionState);
+    // Guard against mutation events changing hierarchy.
+    checkAcceptChildHierarchy(*newChild, exceptionState);
     if (exceptionState.had_exception())
         return nullptr;
 
@@ -223,7 +224,7 @@ PassRefPtr<Node> ContainerNode::replaceChild(PassRefPtr<Node> newChild, PassRefP
     if (exceptionState.had_exception())
         return nullptr;
 
-    checkAcceptChildHierarchy(*newChild, child.get(), exceptionState);
+    checkAcceptChildHierarchy(*newChild, exceptionState);
     if (exceptionState.had_exception())
         return nullptr;
 
@@ -250,7 +251,7 @@ PassRefPtr<Node> ContainerNode::replaceChild(PassRefPtr<Node> newChild, PassRefP
     if (exceptionState.had_exception())
         return nullptr;
 
-    checkAcceptChildHierarchy(*newChild, child.get(),exceptionState);
+    checkAcceptChildHierarchy(*newChild, exceptionState);
     if (exceptionState.had_exception())
         return nullptr;
 
@@ -481,7 +482,7 @@ PassRefPtr<Node> ContainerNode::appendChild(PassRefPtr<Node> newChild, Exception
     if (exceptionState.had_exception())
         return nullptr;
 
-    checkAcceptChildHierarchy(*newChild, 0, exceptionState);
+    checkAcceptChildHierarchy(*newChild, exceptionState);
     if (exceptionState.had_exception())
         return nullptr;
 
@@ -498,7 +499,7 @@ PassRefPtr<Node> ContainerNode::appendChild(PassRefPtr<Node> newChild, Exception
     if (targets.isEmpty())
         return newChild;
 
-    checkAcceptChildHierarchy(*newChild, 0, exceptionState);
+    checkAcceptChildHierarchy(*newChild, exceptionState);
     if (exceptionState.had_exception())
         return nullptr;
 

--- a/sky/engine/core/dom/ContainerNode.h
+++ b/sky/engine/core/dom/ContainerNode.h
@@ -155,7 +155,7 @@ private:
     void notifyNodeRemoved(Node&);
 
     inline void checkAcceptChildType(const Node* newChild, ExceptionState&) const;
-    inline void checkAcceptChildHierarchy(const Node& newChild, const Node* oldChild, ExceptionState&) const;
+    inline void checkAcceptChildHierarchy(const Node& newChild, ExceptionState&) const;
 
     void attachChildren(const AttachContext& = AttachContext());
     void detachChildren(const AttachContext& = AttachContext());

--- a/sky/engine/core/painting/LayoutRoot.cpp
+++ b/sky/engine/core/painting/LayoutRoot.cpp
@@ -83,7 +83,7 @@ void LayoutRoot::layout()
 
 void LayoutRoot::paint(Canvas* canvas)
 {
-    if (m_document && canvas && canvas->skCanvas())
+    if (m_document && rootElement() && canvas && canvas->skCanvas())
         rootElement()->paint(canvas);
 }
 

--- a/sky/sdk/example/raw/mutating-dom.dart
+++ b/sky/sdk/example/raw/mutating-dom.dart
@@ -48,9 +48,12 @@ void doFrame(double timeStamp) {
       node = root;
     } else if (node != root && other != null && pickThis(0.1)) {
       report("insertBefore()");
-      node.insertBefore([other]);
+      try {
+        node.insertBefore([other]);
+      } catch (_) {
+      }
       break;
-    } else if (pickThis(0.001)) {
+    } else if (node != root && pickThis(0.001)) {
       report("remove()");
       node.remove();
     } else if (node is sky.Element) {
@@ -148,7 +151,7 @@ void doFrame(double timeStamp) {
         break;
       }
     } else {
-      assert(node is sky.Text); //
+      assert(node is sky.Text);
       final sky.Text text = node;
       if (pickThis(0.1)) {
         report("appending a new text node (ASCII)");


### PR DESCRIPTION
The first one is that we weren't setting up a
FontCachePurgePreventer during drawText.  It's not clear
that this is the correct fix, since Blink doesn't have
this FontCachePurgePreventer here either, but it's also
possible that they would hit this same ASSERT and just
not care (since ASSERTs are disabled on clusterfuzz).

The second fix is making ExceptionState actually track
whether it has thrown an exception or not. The c++ code
was depending on this working in order to return early
from dom functions and not crash!

R=abarth@google.com