### PR TITLE
Fix type error found by dartanalyzer --strong

### DIFF
--- a/sky/sdk/lib/widgets/widget.dart
+++ b/sky/sdk/lib/widgets/widget.dart
@@ -585,7 +585,7 @@ abstract class StatefulComponent extends Component {
     return super.syncChild(node, oldNode, slot);
   }
 
-  void setState(Function fn()) {
+  void setState(void fn()) {
     assert(!_disqualifiedFromEverAppearingAgain);
     fn();
     scheduleBuild();


### PR DESCRIPTION
We were declaring that the function passed to setState should return a
Function. In reality, we want the function to return void (and everyone calls
it with a function that returns void).