### PR TITLE
Use the build system to build artifacts for distribution

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -17,3 +17,11 @@ group("default") {
     ]
   }
 }
+
+group("dist") {
+  testonly = true
+
+  deps = [
+    "//sky/dist",
+  ]
+}

--- a/mojo/public/dart/rules.gni
+++ b/mojo/public/dart/rules.gni
@@ -249,6 +249,7 @@ template("dart_pkg") {
   pkg_directory = rebase_path("$root_gen_dir/dart-pkg")
   package_root = rebase_path("$root_gen_dir/dart-pkg/packages")
   stamp_file = "$root_gen_dir/dart-pkg/${package_name}.stamp"
+  output_dir = "$root_gen_dir/dart-pkg/${package_name}"
 
   assert(defined(invoker.sources) || defined(invoker.pkg_dir))
 
@@ -294,6 +295,7 @@ template("dart_pkg") {
 
     script = rebase_path("mojo/public/tools/dart_pkg.py", ".", mojo_sdk_root)
     outputs = [
+      output_dir,
       stamp_file,
     ]
 

--- a/sky/build/clean_sky_package.py
+++ b/sky/build/clean_sky_package.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# Copyright 2015 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import argparse
+import os
+import shutil
+
+def remove_empty_dirs(root_dir):
+    for root, dirs, _ in os.walk(root_dir):
+         for name in dirs:
+             fname = os.path.join(root, name)
+             if not os.listdir(fname):
+                 os.removedirs(fname)
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Clean Sky package for distribution')
+    parser.add_argument('package_dir', type=str)
+    parser.add_argument('--touch', type=str)
+    args = parser.parse_args()
+
+    remove_empty_dirs(args.package_dir)
+
+    material_design_icons = os.path.join(args.package_dir, 'lib/assets/material-design-icons')
+    if os.path.exists(material_design_icons):
+        shutil.rmtree(material_design_icons)
+
+    with open(args.touch, 'w') as f:
+        pass
+
+
+if __name__ == '__main__':
+    main()

--- a/sky/dist/BUILD.gn
+++ b/sky/dist/BUILD.gn
@@ -1,0 +1,111 @@
+# Copyright 2015 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+root_dist_dir = "$root_build_dir/dist"
+
+copy("sky_viewer") {
+  sources = [
+    "$root_build_dir/sky_viewer.mojo",
+  ]
+  outputs = [ "$root_dist_dir/viewer/{{source_file_part}}" ]
+
+  deps = [
+    "//services/sky",
+  ]
+}
+
+copy("sky_shell") {
+  if (is_android) {
+    sources = [
+      "$root_build_dir/apks/SkyDemo.apk",
+    ]
+
+    deps = [
+      "//sky/sdk/example/demo_launcher",
+    ]
+  } else {
+    sources = [
+      "$root_build_dir/sky_shell",
+      "$root_build_dir/icudtl.dat",
+    ]
+
+    deps = [
+      "//sky/shell",
+    ]
+  }
+
+  outputs = [ "$root_dist_dir/shell/{{source_file_part}}" ]
+}
+
+if (is_android) {
+  import("//build/config/android/rules.gni")
+
+  sky_sdk_dir = "$root_dist_dir/sdk/sky"
+
+  copy_ex("create_sky_sdk") {
+    clear_dir = true
+    dest = "$root_dist_dir/sdk"
+    sources = [
+      "$root_gen_dir/dart-pkg/sky",
+    ]
+    deps = [
+      "//sky/sdk:sky",
+    ]
+  }
+
+  copy("copy_sky_sdk_license") {
+    sources = [
+      "//AUTHORS",
+      "//LICENSE",
+    ]
+    outputs = [ "$sky_sdk_dir/{{source_file_part}}" ]
+    deps = [
+      ":create_sky_sdk"
+    ]
+  }
+
+  copy("copy_sky_sdk_apks") {
+    sources = [
+      "$root_dist_dir/shell/SkyDemo.apk",
+    ]
+    outputs = [ "$sky_sdk_dir/apks/{{source_file_part}}" ]
+    deps = [
+      ":create_sky_sdk",
+      ":sky_shell",
+    ]
+  }
+
+  action("sky_sdk") {
+    stamp_file = "$target_gen_dir/sky_sdk_cleaned.stamp"
+
+    script = "//sky/build/clean_sky_package.py"
+
+    inputs = [ "$root_gen_dir/dart-pkg/sky.stamp" ]
+    outputs = [ stamp_file ]
+
+    args = [
+      rebase_path(sky_sdk_dir, root_build_dir),
+      "--touch",
+      rebase_path(stamp_file, root_build_dir),
+    ]
+
+    deps = [
+      ":copy_sky_sdk_apks",
+      ":copy_sky_sdk_license",
+      ":create_sky_sdk",
+      "//sky/sdk:sky",
+    ]
+  }
+}
+
+group("dist") {
+  deps = [
+    ":sky_shell",
+    ":sky_viewer",
+  ]
+
+  if (is_android) {
+    deps += [ ":sky_sdk" ]
+  }
+}


### PR DESCRIPTION
Instead of using a collection of Python scripts to generate the artifacts we
want to distribute from this repository, we should just use the build system.
This CL adds a top-level |dist| target that creates these artifacts in a "dist"
directory of the build output.