### PR TITLE
Don't set keys on images, etc, pre-emptively.

### DIFF
--- a/sky/sdk/lib/widgets/basic.dart
+++ b/sky/sdk/lib/widgets/basic.dart
@@ -488,9 +488,7 @@ class Text extends Component {
 }
 
 class Image extends LeafRenderObjectWrapper {
-  Image({ sky.Image image, this.width, this.height, this.colorFilter })
-    : image = image,
-      super(key: new Key.fromObjectIdentity(image));
+  Image({ Key key, this.image, this.width, this.height, this.colorFilter }) : super(key: key);
 
   final sky.Image image;
   final double width;
@@ -510,8 +508,7 @@ class Image extends LeafRenderObjectWrapper {
 }
 
 class FutureImage extends StatefulComponent {
-  FutureImage({ Key key, this.image, this.width, this.height, this.colorFilter })
-    : super(key: key);
+  FutureImage({ Key key, this.image, this.width, this.height, this.colorFilter }) : super(key: key);
 
   Future<sky.Image> image;
   double width;
@@ -555,9 +552,7 @@ class FutureImage extends StatefulComponent {
 }
 
 class NetworkImage extends Component {
-  NetworkImage({ String src, this.width, this.height, this.colorFilter })
-    : src = src,
-      super(key: new Key(src));
+  NetworkImage({ Key key, this.src, this.width, this.height, this.colorFilter }) : super(key: key);
 
   final String src;
   final double width;
@@ -575,9 +570,7 @@ class NetworkImage extends Component {
 }
 
 class AssetImage extends Component {
-  AssetImage({ String name, this.bundle, this.width, this.height, this.colorFilter })
-    : name = name,
-      super(key: new Key(name));
+  AssetImage({ Key key, this.name, this.bundle, this.width, this.height, this.colorFilter }) : super(key: key);
 
   final String name;
   final AssetBundle bundle;

--- a/sky/sdk/lib/widgets/icon_button.dart
+++ b/sky/sdk/lib/widgets/icon_button.dart
@@ -11,8 +11,7 @@ import 'package:sky/widgets/widget.dart';
 
 class IconButton extends Component {
 
-  IconButton({ String icon: '', this.onPressed, this.color })
-    : super(key: new Key(icon)), icon = icon;
+  IconButton({ Key key, this.icon, this.onPressed, this.color }) : super(key: key);
 
   final String icon;
   final Function onPressed;

--- a/sky/sdk/lib/widgets/tabs.dart
+++ b/sky/sdk/lib/widgets/tabs.dart
@@ -249,14 +249,14 @@ class RenderTabBar extends RenderBox with
 
 class TabBarWrapper extends MultiChildRenderObjectWrapper {
   TabBarWrapper({
+    Key key,
     List<Widget> children,
     this.selectedIndex,
     this.backgroundColor,
     this.indicatorColor,
     this.textAndIcons,
     this.scrollable: false,
-    this.onLayoutChanged,
-    Key key
+    this.onLayoutChanged
   }) : super(key: key, children: children);
 
   final int selectedIndex;
@@ -378,13 +378,11 @@ class TabBar extends Scrollable {
   }
 
   Widget _toTab(TabLabel label, int tabIndex) {
-    Tab tab = new Tab(
-      label: label,
-      selected: tabIndex == selectedIndex,
-      key: new Key(label.text == null ? label.icon : label.text)
-    );
     return new Listener(
-      child: tab,
+      child: new Tab(
+        label: label,
+        selected: tabIndex == selectedIndex
+      ),
       onGestureTap: (_) => _handleTap(tabIndex)
     );
   }


### PR DESCRIPTION
In theory, before, if you had the same image twice in a scrolling container, you'd get an assertion with no way around it.
This makes those nodes not bother making keys by default, which is cheaper and more correct.