### PR TITLE
Fix the crash when going to settings after showing the popup menu.

### DIFF
--- a/sky/sdk/lib/rendering/object.dart
+++ b/sky/sdk/lib/rendering/object.dart
@@ -158,6 +158,10 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
     assert(parent == null);
     assert(_relayoutSubtreeRoot == null);
     _relayoutSubtreeRoot = this;
+    assert(() {
+      _debugCanParentUseSize = false;
+      return true;
+    });
     _nodesNeedingLayout.add(this);
     _nodesNeedingPaint.add(this);
     scheduler.ensureVisualUpdate();
@@ -183,9 +187,9 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
       RenderObject debugPreviousActiveLayout;
       assert(!_debugMutationsLocked);
       assert(!_debugDoingThisLayoutWithCallback);
+      assert(_debugCanParentUseSize != null);
       assert(() {
         _debugMutationsLocked = true;
-        _debugCanParentUseSize = false;
         _debugDoingThisLayout = true;
         debugPreviousActiveLayout = _debugActiveLayout;
         _debugActiveLayout = this;
@@ -195,7 +199,6 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
       assert(() {
         _debugActiveLayout = debugPreviousActiveLayout;
         _debugDoingThisLayout = false;
-        _debugCanParentUseSize = null;
         _debugMutationsLocked = false;
         return true;
       });
@@ -243,7 +246,6 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
     assert(() {
       _debugActiveLayout = debugPreviousActiveLayout;
       _debugDoingThisLayout = false;
-      _debugCanParentUseSize = null;
       _debugMutationsLocked = false;
       return true;
     });


### PR DESCRIPTION
If your constraints are tight when you get laid out, you don't get a
relayout subtree root.

If you don't have a relayout subtree root, and you get marked dirty,
you go through layoutWithoutResize() rather than layout(), so we don't
get a parentUsesSize.

If you're not dirty and your constraints didn't change, layout() skips
your layout.

So then if your initial layout had parentUsesSize:true, and then you
got marked dirty directly, you would set your size with
parentCanUseSize=false, and then later if your parent tried to lay you
out then read your size, it would crash because your size wasn't set
up to allow you to get your size.

The fix is to actually remember the last setting of parentUsesSize,
even in the case of the constraints being tight and you later being
marked as needing layout directly.