### PR TITLE
Switch sky_tool to use a Dart-based HTTP server

### DIFF
--- a/sky/sdk/lib/sky_tool
+++ b/sky/sdk/lib/sky_tool
@@ -28,6 +28,7 @@ ANDROID_COMPONENT = '%s/%s.SkyDemoActivity' % (ANDROID_PACKAGE, ANDROID_PACKAGE)
 ADB_PATH = 'adb'
 # FIXME: Do we need to look in $DART_SDK?
 DART_PATH = 'dart'
+PUB_PATH = 'pub'
 
 PID_FILE_PATH = "/tmp/sky_tool.pids"
 PID_FILE_KEYS = frozenset([
@@ -44,10 +45,9 @@ def _port_in_use(port):
     return sock.connect_ex(('localhost', port)) == 0
 
 
-# We need something to serve dart files, python's httpserver is sufficient.
 def _start_http_server(port, root):
     server_command = [
-        'python', '-m', 'SimpleHTTPServer', str(port),
+        PUB_PATH, 'run', 'sky_tools:sky_server', str(port),
     ]
     return subprocess.Popen(server_command, cwd=root).pid
 

--- a/sky/sdk/pubspec.yaml
+++ b/sky/sdk/pubspec.yaml
@@ -1,12 +1,13 @@
 author: Chromium Authors <sky-dev@googlegroups.com>
 dependencies:
   cassowary: ^0.1.7
-  mojo: ^0.0.17
   mojo_services: ^0.0.15
+  mojo: ^0.0.17
   mojom: ^0.0.17
   newton: ^0.1.0
+  sky_tools: ^0.0.2
   vector_math: ^1.4.3
-description: Dart files to support executing inside Sky.
+description: Dart files to support executing inside Sky
 environment:
   sdk: '>=1.8.0 <2.0.0'
 homepage: https://github.com/domokit/mojo/tree/master/sky


### PR DESCRIPTION
The Python HTTP server was caching too agressively. Instead, use an HTTP server
written in Dart from the sky_tools package.