### PR TITLE
Track global keys globally.

### DIFF
--- a/sky/sdk/lib/editing/input.dart
+++ b/sky/sdk/lib/editing/input.dart
@@ -19,7 +19,7 @@ const EdgeDims _kTextfieldPadding = const EdgeDims.symmetric(vertical: 8.0);
 class Input extends StatefulComponent {
 
   Input({
-    Key key,
+    GlobalKey key,
     this.placeholder,
     this.onChanged
   }): super(key: key);

--- a/sky/sdk/lib/widgets/basic.dart
+++ b/sky/sdk/lib/widgets/basic.dart
@@ -22,7 +22,7 @@ import 'package:sky/widgets/widget.dart';
 export 'package:sky/rendering/box.dart' show BackgroundImage, BoxConstraints, BoxDecoration, Border, BorderSide, EdgeDims;
 export 'package:sky/rendering/flex.dart' show FlexDirection, FlexJustifyContent, FlexAlignItems;
 export 'package:sky/rendering/object.dart' show Point, Offset, Size, Rect, Color, Paint, Path;
-export 'package:sky/widgets/widget.dart' show Key, Widget, Component, StatefulComponent, App, runApp, Listener, ParentDataNode;
+export 'package:sky/widgets/widget.dart' show Key, GlobalKey, Widget, Component, StatefulComponent, App, runApp, Listener, ParentDataNode;
 
 
 // PAINTING NODES

--- a/sky/sdk/lib/widgets/focus.dart
+++ b/sky/sdk/lib/widgets/focus.dart
@@ -14,11 +14,11 @@ class Focus extends Inherited {
 
   Focus({
     GlobalKey key,
-    GlobalKey initialFocus,
+    this.initialFocus,
     Widget child
   }) : super(key: key, child: child);
 
-  GlobalKey initialFocus;
+  final GlobalKey initialFocus;
 
   GlobalKey _currentlyFocusedKey;
   GlobalKey get currentlyFocusedKey {


### PR DESCRIPTION
Assert that there are no duplicates.
Export GlobalKey from basic.dart, so that people don't have to import widgets.dart just for that.
Fix the "initialFocus" feature which actually didn't work.