### PR TITLE
Remove scheduleBuild()

### DIFF
--- a/sky/sdk/example/widgets/piano.dart
+++ b/sky/sdk/example/widgets/piano.dart
@@ -68,7 +68,6 @@ class PianoApp extends App {
     }
     mediaService.close();
     // Are we leaking all the player connections?
-    scheduleBuild();
   }
 
   Widget build() {

--- a/sky/sdk/lib/widgets/animated_component.dart
+++ b/sky/sdk/lib/widgets/animated_component.dart
@@ -13,22 +13,29 @@ abstract class AnimatedComponent extends StatefulComponent {
 
   final List<AnimationPerformance> _watchedPerformances = new List<AnimationPerformance>();
 
+  void _performanceChanged() {
+    setState(() {
+      // We don't actually have any state to change, per se,
+      // we just know that we have in fact changed state.
+    });
+  }
+
   void watch(AnimationPerformance performance) {
     assert(!_watchedPerformances.contains(performance));
     _watchedPerformances.add(performance);
     if (mounted)
-      performance.addListener(scheduleBuild);
+      performance.addListener(_performanceChanged);
   }
 
   void didMount() {
     for (AnimationPerformance performance in _watchedPerformances)
-      performance.addListener(scheduleBuild);
+      performance.addListener(_performanceChanged);
     super.didMount();
   }
 
   void didUnmount() {
     for (AnimationPerformance performance in _watchedPerformances)
-      performance.removeListener(scheduleBuild);
+      performance.removeListener(_performanceChanged);
     super.didUnmount();
   }
 

--- a/sky/sdk/lib/widgets/widget.dart
+++ b/sky/sdk/lib/widgets/widget.dart
@@ -530,7 +530,7 @@ abstract class Component extends Widget {
   }
   void _dependenciesChanged() {
     // called by Inherited.sync()
-    scheduleBuild();
+    _scheduleBuild();
   }
 
   // order corresponds to _build_ order, not depth in the tree.
@@ -585,7 +585,7 @@ abstract class Component extends Widget {
     _sync(null, _slot);
   }
 
-  void scheduleBuild() {
+  void _scheduleBuild() {
     if (_isBuilding || _dirty || !_mounted)
       return;
     _dirty = true;
@@ -662,7 +662,7 @@ abstract class StatefulComponent extends Component {
   void setState(void fn()) {
     assert(!_disqualifiedFromEverAppearingAgain);
     fn();
-    scheduleBuild();
+    _scheduleBuild();
   }
 }
 
@@ -1190,7 +1190,7 @@ void runApp(App app, { RenderView renderViewOverride, bool enableProfilingLoop: 
   _container = new AppContainer(app);
   if (enableProfilingLoop) {
     new Timer.periodic(const Duration(milliseconds: 20), (_) {
-      app.scheduleBuild();
+      app._scheduleBuild();
     });
   }
 }


### PR DESCRIPTION
I've noticed an anti-pattern emerge where people call scheduleBuild()
when they think they've changed enough state that they should rebuild,
instead of just wrapping their changes in setState(). This leads to
them missing state changes, having extraneous scheduleBuild() calls,
and other similar bugs.

By removing scheduleBuild(), the only way to actually schedule a build
now is to call setState(), and hopefully that'll make it much clearer
that you're only supposed to do this when you change state.