### PR TITLE
Create a SkyShell.apk

### DIFF
--- a/sky/BUILD.gn
+++ b/sky/BUILD.gn
@@ -25,13 +25,10 @@ group("sky_dev") {
   deps = [
     "//sky/sdk",
     "//sky/sdk/example/demo_launcher",
+    "//sky/shell",
   ]
 
   if (is_android) {
     deps += [ "//sky/services/activity" ]
-  }
-
-  if (is_linux || is_ios) {
-    deps += [ "//sky/shell" ]
   }
 }

--- a/sky/dist/BUILD.gn
+++ b/sky/dist/BUILD.gn
@@ -18,11 +18,11 @@ copy("sky_viewer") {
 copy("sky_shell") {
   if (is_android) {
     sources = [
-      "$root_build_dir/apks/SkyDemo.apk",
+      "$root_build_dir/apks/SkyShell.apk",
     ]
 
     deps = [
-      "//sky/sdk/example/demo_launcher",
+      "//sky/shell",
     ]
   } else if (is_ios) {
     sources = [
@@ -76,7 +76,7 @@ if (is_android) {
 
   copy("copy_sky_sdk_apks") {
     sources = [
-      "$root_dist_dir/shell/SkyDemo.apk",
+      "$root_dist_dir/shell/SkyShell.apk",
     ]
     outputs = [ "$sky_sdk_dir/apks/{{source_file_part}}" ]
     deps = [

--- a/sky/sdk/README.md
+++ b/sky/sdk/README.md
@@ -68,19 +68,19 @@ Running a Sky application
 -------------------------
 
 The `sky` pub package includes a `sky_tool` script to assist in running
-Sky applications inside the `SkyDemo.apk` harness.  The `sky_tool` script
+Sky applications inside the `SkyShell.apk` harness.  The `sky_tool` script
 expects to be run from the root directory of your application's package (i.e.,
 the same directory that contains the `pubspec.yaml` file). To run your app,
 follow these instructions:
 
  - `./packages/sky/sky_tool start` to start the dev server and upload your
    app to the device.
-   (NOTE: add a `--install` flag to install `SkyDemo.apk` if it is not already
+   (NOTE: add a `--install` flag to install `SkyShell.apk` if it is not already
    installed on the device.)
 
  - Use `adb logcat` to view any errors or Dart `print()` output from the app.
    `adb logcat -s sky` can be used to filter only adb messages from
-   `SkyDemo.apk`.
+   `SkyShell.apk`.
 
 Debugging
 ---------

--- a/sky/sdk/example/demo_launcher/apk/BUILD.gn
+++ b/sky/sdk/example/demo_launcher/apk/BUILD.gn
@@ -17,10 +17,6 @@ android_library("java") {
     "//base:base_java",
     "//mojo/public/java:bindings",
     "//mojo/public/java:system",
-    "//mojo/services/sensors/public/interfaces:interfaces_java",
-    "//services/sensors:sensors_lib",
-    "//sky/services/media:media_lib",
-    "//sky/services/media:interfaces_java",
     "//sky/shell:java",
   ]
 }

--- a/sky/sdk/example/demo_launcher/apk/org/domokit/sky/demo/SkyDemoApplication.java
+++ b/sky/sdk/example/demo_launcher/apk/org/domokit/sky/demo/SkyDemoApplication.java
@@ -6,15 +6,7 @@ package org.domokit.sky.demo;
 
 import android.content.Context;
 
-import org.chromium.mojo.sensors.SensorServiceImpl;
-import org.chromium.mojo.system.Core;
-import org.chromium.mojo.system.MessagePipeHandle;
-import org.chromium.mojom.media.MediaService;
-import org.chromium.mojom.sensors.SensorService;
-import org.domokit.media.MediaServiceImpl;
 import org.domokit.sky.shell.ResourceExtractor;
-import org.domokit.sky.shell.ServiceFactory;
-import org.domokit.sky.shell.ServiceRegistry;
 import org.domokit.sky.shell.SkyApplication;
 
 /**
@@ -34,24 +26,5 @@ public class SkyDemoApplication extends SkyApplication {
     protected void onBeforeResourceExtraction(ResourceExtractor extractor) {
         super.onBeforeResourceExtraction(extractor);
         extractor.addResources(DEMO_RESOURCES);
-    }
-
-    @Override
-    public void onServiceRegistryAvailable(ServiceRegistry registry) {
-        super.onServiceRegistryAvailable(registry);
-
-        registry.register(SensorService.MANAGER.getName(), new ServiceFactory() {
-            @Override
-            public void connectToService(Context context, Core core, MessagePipeHandle pipe) {
-                SensorService.MANAGER.bind(new SensorServiceImpl(context), pipe);
-            }
-        });
-
-        registry.register(MediaService.MANAGER.getName(), new ServiceFactory() {
-            @Override
-            public void connectToService(Context context, Core core, MessagePipeHandle pipe) {
-                MediaService.MANAGER.bind(new MediaServiceImpl(context, core), pipe);
-            }
-        });
     }
 }

--- a/sky/sdk/lib/sky_tool
+++ b/sky/sdk/lib/sky_tool
@@ -21,9 +21,9 @@ SKY_PACKAGE_ROOT = os.path.realpath(os.path.dirname(LIB_DIR))
 
 SKY_SERVER_PORT = 9888
 OBSERVATORY_PORT = 8181
-APK_NAME = 'SkyDemo.apk'
-ANDROID_PACKAGE = "org.domokit.sky.demo"
-ANDROID_COMPONENT = '%s/%s.SkyDemoActivity' % (ANDROID_PACKAGE, ANDROID_PACKAGE)
+APK_NAME = 'SkyShell.apk'
+ANDROID_PACKAGE = "org.domokit.sky.shell"
+ANDROID_COMPONENT = '%s/%s.SkyActivity' % (ANDROID_PACKAGE, ANDROID_PACKAGE)
 # FIXME: This assumes adb is in $PATH, we could look for ANDROID_HOME, etc?
 ADB_PATH = 'adb'
 # FIXME: Do we need to look in $DART_SDK?
@@ -243,7 +243,7 @@ class StartTracing(object):
     def run(self, args, pids):
         subprocess.check_output([ADB_PATH, 'shell',
             'am', 'broadcast',
-            '-a', 'org.domokit.sky.demo.TRACING_START'])
+            '-a', 'org.domokit.sky.shell.TRACING_START'])
 
 
 TRACE_COMPLETE_REGEXP = re.compile('Trace complete')
@@ -260,7 +260,7 @@ class StopTracing(object):
         subprocess.check_output([ADB_PATH, 'logcat', '-c'])
         subprocess.check_output([ADB_PATH, 'shell',
             'am', 'broadcast',
-            '-a', 'org.domokit.sky.demo.TRACING_STOP'])
+            '-a', 'org.domokit.sky.shell.TRACING_STOP'])
         device_path = None
         is_complete = False
         while not is_complete:

--- a/sky/shell/BUILD.gn
+++ b/sky/shell/BUILD.gn
@@ -121,10 +121,14 @@ if (is_android) {
       "//mojo/public/java:system",
       "//mojo/services/keyboard/public/interfaces:interfaces_java",
       "//mojo/services/network/public/interfaces:interfaces_java",
+      "//mojo/services/sensors/public/interfaces:interfaces_java",
       "//services/keyboard",
+      "//services/sensors:sensors_lib",
       "//sky/services/activity:activity_lib",
       "//sky/services/activity:interfaces_java",
       "//sky/services/engine:interfaces_java",
+      "//sky/services/media:interfaces_java",
+      "//sky/services/media:media_lib",
       "//sky/services/oknet",
     ]
   }
@@ -139,6 +143,23 @@ if (is_android) {
       "//third_party/icu:icudata",
     ]
   }
+
+  android_apk("shell") {
+    apk_name = "SkyShell"
+    android_manifest = "android/AndroidManifest.xml"
+
+    native_libs = [ "libsky_shell.so" ]
+    asset_location = "$root_build_dir/sky_shell/assets"
+
+    deps = [
+      ":assets",
+      ":assets",
+      ":java",
+      ":sky_shell",
+      "//base:base_java",
+    ]
+  }
+
 } else if (is_ios) {
   import("//build/config/ios/rules.gni")
   import("//build/config/ios/ios_sdk.gni")

--- a/sky/shell/android/AndroidManifest.xml
+++ b/sky/shell/android/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2015 The Chromium Authors. All rights reserved.
+     Use of this source code is governed by a BSD-style license that can be
+     found in the LICENSE file.
+ -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.domokit.sky.shell" android:versionCode="1" android:versionName="0.0.1">
+
+    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="21" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-feature android:name="android.hardware.sensor.accelerometer" android:required="true" />
+
+    <application android:label="Sky Shell" android:name="SkyApplication">
+        <activity android:configChanges="orientation|keyboardHidden|keyboard|screenSize"
+                  android:hardwareAccelerated="true"
+                  android:launchMode="standard"
+                  android:name="SkyActivity"
+                  android:theme="@android:style/Theme.Black.NoTitleBar">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+ </manifest>

--- a/sky/shell/android/org/domokit/sky/shell/SkyActivity.java
+++ b/sky/shell/android/org/domokit/sky/shell/SkyActivity.java
@@ -5,6 +5,7 @@
 package org.domokit.sky.shell;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
@@ -96,6 +97,9 @@ public class SkyActivity extends Activity {
       * Override this function to customize startup behavior.
       */
     protected void onSkyReady() {
+        if (loadIntent(getIntent())) {
+            return;
+        }
         File dataDir = new File(PathUtils.getDataDirectory(this));
         File snapshot = new File(dataDir, SkyApplication.SNAPSHOT);
         if (snapshot.exists()) {
@@ -107,6 +111,21 @@ public class SkyActivity extends Activity {
             mView.getEngine().runFromBundle(appBundle.getPath());
             return;
         }
+    }
+
+    protected void onNewIntent(Intent intent) {
+        loadIntent(intent);
+    }
+
+    public boolean loadIntent(Intent intent) {
+        String action = intent.getAction();
+
+        if (Intent.ACTION_VIEW.equals(action)) {
+            loadUrl(intent.getDataString());
+            return true;
+        }
+
+        return false;
     }
 
     public void loadUrl(String url) {

--- a/sky/shell/android/org/domokit/sky/shell/SkyApplication.java
+++ b/sky/shell/android/org/domokit/sky/shell/SkyApplication.java
@@ -8,17 +8,21 @@ import android.content.Context;
 import android.util.Log;
 
 import org.chromium.base.BaseChromiumApplication;
-import org.chromium.base.PathUtils;
 import org.chromium.base.library_loader.LibraryLoader;
 import org.chromium.base.library_loader.LibraryProcessType;
 import org.chromium.base.library_loader.ProcessInitException;
+import org.chromium.base.PathUtils;
 import org.chromium.mojo.keyboard.KeyboardServiceImpl;
+import org.chromium.mojo.sensors.SensorServiceImpl;
 import org.chromium.mojo.system.Core;
 import org.chromium.mojo.system.MessagePipeHandle;
 import org.chromium.mojom.activity.Activity;
 import org.chromium.mojom.keyboard.KeyboardService;
+import org.chromium.mojom.media.MediaService;
 import org.chromium.mojom.mojo.NetworkService;
+import org.chromium.mojom.sensors.SensorService;
 import org.domokit.activity.ActivityImpl;
+import org.domokit.media.MediaServiceImpl;
 import org.domokit.oknet.NetworkServiceImpl;
 
 /**
@@ -59,11 +63,10 @@ public class SkyApplication extends BaseChromiumApplication {
       * Override this function to register more services.
       */
     protected void onServiceRegistryAvailable(ServiceRegistry registry) {
-        registry.register(NetworkService.MANAGER.getName(), new ServiceFactory() {
+        registry.register(Activity.MANAGER.getName(), new ServiceFactory() {
             @Override
             public void connectToService(Context context, Core core, MessagePipeHandle pipe) {
-                // TODO(eseidel): Refactor ownership to match other services.
-                new NetworkServiceImpl(context, core, pipe);
+                Activity.MANAGER.bind(new ActivityImpl(), pipe);
             }
         });
 
@@ -74,10 +77,25 @@ public class SkyApplication extends BaseChromiumApplication {
             }
         });
 
-        registry.register(Activity.MANAGER.getName(), new ServiceFactory() {
+        registry.register(MediaService.MANAGER.getName(), new ServiceFactory() {
             @Override
             public void connectToService(Context context, Core core, MessagePipeHandle pipe) {
-                Activity.MANAGER.bind(new ActivityImpl(), pipe);
+                MediaService.MANAGER.bind(new MediaServiceImpl(context, core), pipe);
+            }
+        });
+
+        registry.register(NetworkService.MANAGER.getName(), new ServiceFactory() {
+            @Override
+            public void connectToService(Context context, Core core, MessagePipeHandle pipe) {
+                // TODO(eseidel): Refactor ownership to match other services.
+                new NetworkServiceImpl(context, core, pipe);
+            }
+        });
+
+        registry.register(SensorService.MANAGER.getName(), new ServiceFactory() {
+            @Override
+            public void connectToService(Context context, Core core, MessagePipeHandle pipe) {
+                SensorService.MANAGER.bind(new SensorServiceImpl(context), pipe);
             }
         });
     }

--- a/sky/tools/big_red_button.py
+++ b/sky/tools/big_red_button.py
@@ -49,7 +49,7 @@ GS_URL = 'gs://mojo/sky/%(category)s/%(config)s/%(commit_hash)s/%(name)s'
 
 ARTIFACTS = {
     'android-arm': [
-        Artifact('shell', 'SkyDemo.apk'),
+        Artifact('shell', 'SkyShell.apk'),
         Artifact('viewer', 'sky_viewer.mojo'),
     ],
     'linux-x64': [

--- a/sky/tools/shelldb
+++ b/sky/tools/shelldb
@@ -27,14 +27,14 @@ GDB_PORT = 8888
 SKY_SERVER_PORT = 9888
 OBSERVATORY_PORT = 8181
 DEFAULT_URL = "https://domokit.github.io/home.dart"
-APK_NAME = 'SkyDemo.apk'
+APK_NAME = 'SkyShell.apk'
 ADB_PATH = os.path.join(SRC_ROOT,
     'third_party/android_tools/sdk/platform-tools/adb')
-ANDROID_PACKAGE = "org.domokit.sky.demo"
-ANDROID_COMPONENT = '%s/%s.SkyDemoActivity' % (ANDROID_PACKAGE, ANDROID_PACKAGE)
+ANDROID_PACKAGE = "org.domokit.sky.shell"
+ANDROID_COMPONENT = '%s/%s.SkyActivity' % (ANDROID_PACKAGE, ANDROID_PACKAGE)
 SHA1_PATH = '/sdcard/%s/%s.sha1' % (ANDROID_PACKAGE, APK_NAME)
 
-PID_FILE_PATH = "/tmp/skydemo.pids"
+PID_FILE_PATH = "/tmp/shelldb.pids"
 PID_FILE_KEYS = frozenset([
     'remote_sky_server_port',
     'sky_server_pid',
@@ -141,7 +141,7 @@ class StartSky(object):
             default=DEFAULT_URL)
         start_parser.add_argument('--no_install', action="store_false",
             default=True, dest="install",
-            help="Don't install SkyDemo.apk before starting")
+            help="Don't install SkyShell.apk before starting")
         start_parser.set_defaults(func=self.run)
 
     def _server_root_for_url(self, url_or_path):
@@ -435,7 +435,7 @@ class StartTracing(object):
     def run(self, args, pids):
         subprocess.check_output([ADB_PATH, 'shell',
             'am', 'broadcast',
-            '-a', 'org.domokit.sky.demo.TRACING_START'])
+            '-a', 'org.domokit.sky.shell.TRACING_START'])
 
 
 TRACE_COMPLETE_REGEXP = re.compile('Trace complete')
@@ -451,7 +451,7 @@ class StopTracing(object):
         subprocess.check_output([ADB_PATH, 'logcat', '-c'])
         subprocess.check_output([ADB_PATH, 'shell',
             'am', 'broadcast',
-            '-a', 'org.domokit.sky.demo.TRACING_STOP'])
+            '-a', 'org.domokit.sky.shell.TRACING_STOP'])
         device_path = None
         is_complete = False
         while not is_complete:


### PR DESCRIPTION
This CL introduces a SkyShell.apk that is separate from the SkyDemo.apk that we
upload to the store to show our demos.  The SkyShell.apk is just an empty shell
that can run Sky applications on Android.