### PR TITLE
Fix sky/tools/gn --ios --simulator to set the correct target_cpu

### DIFF
--- a/sky/engine/core/BUILD.gn
+++ b/sky/engine/core/BUILD.gn
@@ -77,6 +77,7 @@ static_library("core") {
     "//dart/runtime/bin:embedded_dart_io",
     "//dart/runtime:libdart",
     "//dart/runtime/vm:libdart_platform",
+    "//mojo/services/navigation/public/interfaces",
   ]
 
   sources = sky_core_files

--- a/sky/tools/gn
+++ b/sky/tools/gn
@@ -52,7 +52,7 @@ def to_gn_args(args):
         gn_args['use_glib'] = False
         gn_args['use_system_harfbuzz'] = False
 
-    if args.target_os in ['android', 'ios']:
+    if args.target_os in ['android', 'ios'] and not args.simulator:
         gn_args['target_cpu'] = 'arm'
     else:
         gn_args['target_cpu'] = 'x64'

--- a/sky/tools/gn_test.py
+++ b/sky/tools/gn_test.py
@@ -22,6 +22,15 @@ class GNTestCase(unittest.TestCase):
         self._expect_build_dir(['--android'], 'out/android_Debug')
         self._expect_build_dir(['--android', '--release'], 'out/android_Release')
 
+    def _gn_args(self, arg_list):
+        args = gn.parse_args(['gn'] + arg_list)
+        return gn.to_gn_args(args)
+
+    def test_to_gn_args(self):
+        # This would not necesarily be true on a 32-bit machine?
+        self.assertEquals(self._gn_args(['--ios', '--simulator'])['target_cpu'], 'x64')
+        self.assertEquals(self._gn_args(['--ios'])['target_cpu'], 'arm')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Also fixed missing dependency from LocalDOMWindow.cpp on
mojo's navigation service.  Not sure why gn check missed that.

R=abarth@google.com