### PR TITLE
Add sky_services pub package

### DIFF
--- a/sky/packages/BUILD.gn
+++ b/sky/packages/BUILD.gn
@@ -7,5 +7,6 @@ group("packages") {
 
   deps = [
     "//sky/packages/sky_engine",
+    "//sky/packages/sky_services",
   ]
 }

--- a/sky/packages/sky_services/BUILD.gn
+++ b/sky/packages/sky_services/BUILD.gn
@@ -1,0 +1,20 @@
+# Copyright 2015 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//mojo/public/dart/rules.gni")
+
+dart_pkg("sky_services") {
+  sources = [
+    "README.md",
+    "pubspec.yaml",
+  ]
+
+  deps = [
+    "//mojo/services/asset_bundle/public/interfaces",
+    "//mojo/services/keyboard/public/interfaces",
+    "//sky/services/activity:interfaces",
+    "//sky/services/media:interfaces",
+    "//sky/services/testing:interfaces",
+  ]
+}

--- a/sky/packages/sky_services/README.md
+++ b/sky/packages/sky_services/README.md
@@ -1,0 +1,6 @@
+Sky Services
+============
+
+This packages contains `mojom` interfaces to services associated with Sky. Most
+developers should depend on the [Sky package](https://pub.dartlang.org/packages/sky)
+instead of using this package directly.

--- a/sky/packages/sky_services/pubspec.yaml
+++ b/sky/packages/sky_services/pubspec.yaml
@@ -1,0 +1,8 @@
+name: sky_services
+version: 0.0.1
+author: Chromium Authors <sky-dev@googlegroups.com>
+description: Mojom interfaces associated with Sky
+homepage: https://github.com/domokit/sky_engine/tree/master/sky/packages/sky_services
+dependencies:
+  mojo: ^0.0.17
+  mojom: ^0.0.17

--- a/sky/sdk/BUILD.gn
+++ b/sky/sdk/BUILD.gn
@@ -92,22 +92,12 @@ dart_pkg("sky") {
     "pubspec.yaml",
   ]
 
-  # List of mojom targets that the sky pkg exports
-  deps = [
-    "//mojo/services/asset_bundle/public/interfaces",
-    "//mojo/services/keyboard/public/interfaces",
-    "//sky/services/activity:interfaces",
-    "//sky/services/engine:interfaces",
-  ]
-
   datadeps = [
     "//mojo/dart/mojo_services",
     "//mojo/dart/mojom",
     "//mojo/public/dart:mojo",
-    "//sky/engine/bindings",
     "//sky/packages/sky_engine",
-    "//sky/services/media:interfaces",
-    "//sky/services/testing:interfaces",
+    "//sky/packages/sky_services",
     "//third_party/dart-pkg",
   ]
 }

--- a/sky/sdk/pubspec.yaml
+++ b/sky/sdk/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   mojom: ^0.0.17
   newton: ^0.1.0
   sky_engine: ^0.0.1
+  sky_services: ^0.0.1
   sky_tools: ^0.0.2
   vector_math: ^1.4.3
 environment:


### PR DESCRIPTION
This package contains the mojom.dart files we generate from the sky_engine
repository.