### PR TITLE
Symlink Material Design Icons into Dart packages in the out dir

### DIFF
--- a/sky/packages/BUILD.gn
+++ b/sky/packages/BUILD.gn
@@ -8,5 +8,6 @@ group("packages") {
   deps = [
     "//sky/packages/sky_engine",
     "//sky/packages/sky_services",
+    "//sky/packages/material_design_icons",
   ]
 }

--- a/sky/packages/material_design_icons/BUILD.gn
+++ b/sky/packages/material_design_icons/BUILD.gn
@@ -1,0 +1,23 @@
+# Copyright 2015 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+action("material_design_icons") {
+  script = "//sky/build/symlink.py"
+
+  stamp_file = "$target_gen_dir/symlink.stamp"
+
+  sources = [ ".version.sha1" ]
+  outputs = [ stamp_file ]
+
+  args = [
+    rebase_path(".", root_build_dir),
+    rebase_path("$root_gen_dir/dart-pkg/packages/material_design_icons", root_build_dir),
+    "--touch",
+    rebase_path(stamp_file, root_build_dir)
+  ]
+
+  deps = [
+    "//third_party/dart-pkg",
+  ]
+}


### PR DESCRIPTION
Otherwise they won't be visible to the web server.