### PR TITLE
Dismissable backgrounds

### DIFF
--- a/sky/sdk/example/widgets/card_collection.dart
+++ b/sky/sdk/example/widgets/card_collection.dart
@@ -9,10 +9,12 @@ import 'package:sky/widgets/basic.dart';
 import 'package:sky/widgets/block_viewport.dart';
 import 'package:sky/widgets/card.dart';
 import 'package:sky/widgets/dismissable.dart';
+import 'package:sky/widgets/icon.dart';
 import 'package:sky/widgets/variable_height_scrollable.dart';
 import 'package:sky/widgets/scaffold.dart';
 import 'package:sky/widgets/theme.dart';
 import 'package:sky/widgets/tool_bar.dart';
+import 'package:sky/theme/typography.dart' as typography;
 import 'package:sky/widgets/widget.dart';
 import 'package:sky/widgets/task_description.dart';
 
@@ -27,8 +29,11 @@ class CardModel {
 
 class CardCollectionApp extends App {
 
-  final TextStyle cardLabelStyle =
-    new TextStyle(color: white, fontSize: 18.0, fontWeight: bold);
+  static const TextStyle cardLabelStyle =
+    const TextStyle(color: white, fontSize: 18.0, fontWeight: bold);
+
+  final TextStyle backgroundTextStyle =
+    typography.white.title.copyWith(textAlign: TextAlign.center);
 
   BlockViewportLayoutState layoutState = new BlockViewportLayoutState();
   List<CardModel> cardModels;
@@ -57,21 +62,50 @@ class CardCollectionApp extends App {
   Widget builder(int index) {
     if (index >= cardModels.length)
       return null;
-    CardModel card = cardModels[index];
 
-    return new Dismissable(
-      key: card.key,
+    CardModel cardModel = cardModels[index];
+    Widget card = new Dismissable(
       onResized: () { layoutState.invalidate([index]); },
-      onDismissed: () { dismissCard(card); },
+      onDismissed: () { dismissCard(cardModel); },
       child: new Card(
-        color: card.color,
+        color: cardModel.color,
         child: new Container(
-          height: card.height,
+          height: cardModel.height,
           padding: const EdgeDims.all(8.0),
-          child: new Center(child: new Text(card.label, style: cardLabelStyle))
+          child: new Center(child: new Text(cardModel.label, style: cardLabelStyle))
         )
       )
     );
+
+    Widget backgroundText = new Center(
+        child: new Text("Swipe in either direction", style: backgroundTextStyle)
+    );
+
+    // The background Widget appears behind the Dismissable card when the card
+    // moves to the left or right. The Positioned widget ensures that the
+    // size of the background,card Stack will be based only on the card. The
+    // Viewport ensures that when the card's resize animation occurs, the
+    // background (text and icons) will just be clipped, not resized.
+    Widget background = new Positioned(
+      top: 0.0,
+      left: 0.0,
+      child: new Container(
+        margin: const EdgeDims.all(4.0),
+        child: new Viewport(
+          child: new Container(
+            height: cardModel.height,
+            decoration: new BoxDecoration(backgroundColor: Theme.of(this).primaryColor),
+            child: new Flex([
+              new Icon(type: 'navigation/arrow_back', size: 36),
+              new Flexible(child: backgroundText),
+              new Icon(type: 'navigation/arrow_forward', size: 36)
+            ])
+          )
+        )
+      )
+    );
+
+    return new Stack([background, card], key: cardModel.key);
   }
 
   Widget build() {
@@ -85,17 +119,20 @@ class CardCollectionApp extends App {
       )
     );
 
-    return new Theme(
-      data: new ThemeData(
-        brightness: ThemeBrightness.light,
-        primarySwatch: Blue,
-        accentColor: RedAccent[200]
-      ),
-      child: new TaskDescription(
-        label: 'Cards',
-        child: new Scaffold(
-          toolbar: new ToolBar(center: new Text('Swipe Away')),
-          body: cardCollection
+    return new IconTheme(
+      data: const IconThemeData(color: IconThemeColor.white),
+      child: new Theme(
+        data: new ThemeData(
+          brightness: ThemeBrightness.light,
+          primarySwatch: Blue,
+          accentColor: RedAccent[200]
+        ),
+        child: new TaskDescription(
+          label: 'Cards',
+          child: new Scaffold(
+            toolbar: new ToolBar(center: new Text('Swipe Away')),
+            body: cardCollection
+          )
         )
       )
     );

--- a/sky/sdk/lib/widgets/dismissable.dart
+++ b/sky/sdk/lib/widgets/dismissable.dart
@@ -53,7 +53,6 @@ class Dismissable extends AnimatedComponent {
       ..duration = _kCardDismissFadeout
       ..variable = new AnimatedList([_position, _opacity])
       ..addListener(_handleFadeProgressChanged);
-    watch(_fadePerformance);
   }
 
   void _handleFadeProgressChanged() {
@@ -85,8 +84,6 @@ class Dismissable extends AnimatedComponent {
   }
 
   void _maybeCallOnDismissed() {
-    _resizePerformance.stop();
-    _resizePerformance.removeListener(_handleResizeProgressChanged);
     if (onDismissed != null)
       onDismissed();
   }
@@ -96,22 +93,19 @@ class Dismissable extends AnimatedComponent {
     assert(_fadePerformance != null);
     assert(_resizePerformance == null);
 
+    // TODO(hansmuller): _fadePerformance is completed; stop shouldn't be needed.
     _fadePerformance.stop();
-    _fadePerformance.removeListener(_handleFadeProgressChanged);
-
-    _maybeCallOnResized();
 
     AnimatedValue<double> dismissHeight = new AnimatedValue<double>(_size.height,
-        end: 0.0,
-        curve: ease,
-        interval: new Interval(_kCardDismissResizeDelay, 1.0)
+      end: 0.0,
+      curve: ease,
+      interval: new Interval(_kCardDismissResizeDelay, 1.0)
     );
     _resizePerformance = new AnimationPerformance()
       ..variable = dismissHeight
       ..duration = _kCardDismissResize
       ..addListener(_handleResizeProgressChanged)
       ..play();
-    watch(_resizePerformance);
   }
 
   void _handleResizeProgressChanged() {

--- a/sky/tests/examples/card_collection-expected.txt
+++ b/sky/tests/examples/card_collection-expected.txt
@@ -19,216 +19,398 @@ PAINT FOR FRAME #2 ----------------------------------------------
 2 |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  | save
 2 |  |  |  |  |  | clipRect(Rect.fromLTRB(8.0, 68.0, 792.0, 588.0))
-2 |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 68.0)
+2 |  |  |  |  |  | paintChild RenderStack at Point(8.0, 68.0)
 2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 68.0)
+2 |  |  |  |  |  |  | paintChild RenderPadding at Point(8.0, 68.0)
 2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 68.0)
+2 |  |  |  |  |  |  |  | paintChild RenderViewport at Point(12.0, 72.0)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  | save
-2 |  |  |  |  |  |  |  |  | translate(8.0, 68.0)
-2 |  |  |  |  |  |  |  |  | concat([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
-2 |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
+2 |  |  |  |  |  |  |  |  | clipRect(Rect.fromLTRB(12.0, 72.0, 788.0, 120.0))
+2 |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(12.0, 72.0)
 2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(12.0, 72.0)
 2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffe57373), drawLooper:true))
-2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  | drawRect(Rect.fromLTRB(12.0, 72.0, 788.0, 120.0), Paint(color:Color(0xff2196f3)))
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderFlex at Point(12.0, 72.0)
 2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 52.0), Paint(color:Color(0xff000000)))
-2 |  |  |  |  |  |  |  |  |  |  |  | clipRRect()
-2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderImage at Point(12.0, 78.0)
 2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(48.0, 82.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(278.0, 82.0)
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(12.0, 12.0)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(359.0, 15.5)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(359.0, 15.5)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -15.5)
-2 |  |  |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(278.0, 82.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-278.0, -82.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderImage at Point(752.0, 78.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  | restore
-2 |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 124.0)
-2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 124.0)
+2 |  |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 68.0)
 2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 124.0)
+2 |  |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 68.0)
+2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 68.0)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  | save
+2 |  |  |  |  |  |  |  |  |  | translate(8.0, 68.0)
+2 |  |  |  |  |  |  |  |  |  | concat([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
+2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffe57373), drawLooper:true))
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 52.0), Paint(color:Color(0xff000000)))
+2 |  |  |  |  |  |  |  |  |  |  |  |  | clipRRect()
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(12.0, 12.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(359.0, 15.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(359.0, 15.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -15.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  | paintChild RenderStack at Point(8.0, 124.0)
+2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  | paintChild RenderPadding at Point(8.0, 124.0)
+2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  | paintChild RenderViewport at Point(12.0, 128.0)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  | save
-2 |  |  |  |  |  |  |  |  | translate(8.0, 124.0)
-2 |  |  |  |  |  |  |  |  | concat([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
-2 |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
+2 |  |  |  |  |  |  |  |  | clipRect(Rect.fromLTRB(12.0, 128.0, 788.0, 191.0))
+2 |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(12.0, 128.0)
 2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(12.0, 128.0)
 2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffdd7174), drawLooper:true))
-2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  | drawRect(Rect.fromLTRB(12.0, 128.0, 788.0, 191.0), Paint(color:Color(0xff2196f3)))
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderFlex at Point(12.0, 128.0)
 2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 67.0), Paint(color:Color(0xff000000)))
-2 |  |  |  |  |  |  |  |  |  |  |  | clipRRect()
-2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderImage at Point(12.0, 141.5)
 2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(48.0, 145.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(278.0, 145.5)
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(12.0, 12.0)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(359.0, 23.0)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(359.0, 23.0)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -23.0)
-2 |  |  |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(278.0, 145.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-278.0, -145.5)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderImage at Point(752.0, 141.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  | restore
-2 |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 195.0)
-2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 195.0)
+2 |  |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 124.0)
 2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 195.0)
+2 |  |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 124.0)
+2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 124.0)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  | save
+2 |  |  |  |  |  |  |  |  |  | translate(8.0, 124.0)
+2 |  |  |  |  |  |  |  |  |  | concat([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
+2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffdd7174), drawLooper:true))
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 67.0), Paint(color:Color(0xff000000)))
+2 |  |  |  |  |  |  |  |  |  |  |  |  | clipRRect()
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(12.0, 12.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(359.0, 23.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(359.0, 23.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -23.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  | paintChild RenderStack at Point(8.0, 195.0)
+2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  | paintChild RenderPadding at Point(8.0, 195.0)
+2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  | paintChild RenderViewport at Point(12.0, 199.0)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  | save
-2 |  |  |  |  |  |  |  |  | translate(8.0, 195.0)
-2 |  |  |  |  |  |  |  |  | concat([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
-2 |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
+2 |  |  |  |  |  |  |  |  | clipRect(Rect.fromLTRB(12.0, 199.0, 788.0, 281.0))
+2 |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(12.0, 199.0)
 2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(12.0, 199.0)
 2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffd56f76), drawLooper:true))
-2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  | drawRect(Rect.fromLTRB(12.0, 199.0, 788.0, 281.0), Paint(color:Color(0xff2196f3)))
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderFlex at Point(12.0, 199.0)
 2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 86.0), Paint(color:Color(0xff000000)))
-2 |  |  |  |  |  |  |  |  |  |  |  | clipRRect()
-2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderImage at Point(12.0, 222.0)
 2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(48.0, 226.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(278.0, 226.0)
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(12.0, 12.0)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(359.0, 32.5)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(359.0, 32.5)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -32.5)
-2 |  |  |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(278.0, 226.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-278.0, -226.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderImage at Point(752.0, 222.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  | restore
-2 |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 285.0)
-2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 285.0)
+2 |  |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 195.0)
 2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 285.0)
+2 |  |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 195.0)
+2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 195.0)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  | save
+2 |  |  |  |  |  |  |  |  |  | translate(8.0, 195.0)
+2 |  |  |  |  |  |  |  |  |  | concat([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
+2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffd56f76), drawLooper:true))
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 86.0), Paint(color:Color(0xff000000)))
+2 |  |  |  |  |  |  |  |  |  |  |  |  | clipRRect()
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(12.0, 12.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(359.0, 32.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(359.0, 32.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -32.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  | paintChild RenderStack at Point(8.0, 285.0)
+2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  | paintChild RenderPadding at Point(8.0, 285.0)
+2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  | paintChild RenderViewport at Point(12.0, 289.0)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  | save
-2 |  |  |  |  |  |  |  |  | translate(8.0, 285.0)
-2 |  |  |  |  |  |  |  |  | concat([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
-2 |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
+2 |  |  |  |  |  |  |  |  | clipRect(Rect.fromLTRB(12.0, 289.0, 788.0, 435.0))
+2 |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(12.0, 289.0)
 2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(12.0, 289.0)
 2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffcd6e78), drawLooper:true))
-2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  | drawRect(Rect.fromLTRB(12.0, 289.0, 788.0, 435.0), Paint(color:Color(0xff2196f3)))
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderFlex at Point(12.0, 289.0)
 2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 150.0), Paint(color:Color(0xff000000)))
-2 |  |  |  |  |  |  |  |  |  |  |  | clipRRect()
-2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderImage at Point(12.0, 344.0)
 2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(48.0, 348.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(278.0, 348.0)
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(12.0, 12.0)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(359.0, 64.5)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(359.0, 64.5)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -64.5)
-2 |  |  |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(278.0, 348.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-278.0, -348.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderImage at Point(752.0, 344.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  | restore
-2 |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 439.0)
-2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 439.0)
+2 |  |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 285.0)
 2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 439.0)
+2 |  |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 285.0)
+2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 285.0)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  | save
+2 |  |  |  |  |  |  |  |  |  | translate(8.0, 285.0)
+2 |  |  |  |  |  |  |  |  |  | concat([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
+2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffcd6e78), drawLooper:true))
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 150.0), Paint(color:Color(0xff000000)))
+2 |  |  |  |  |  |  |  |  |  |  |  |  | clipRRect()
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(12.0, 12.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(359.0, 64.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(359.0, 64.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -64.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  | paintChild RenderStack at Point(8.0, 439.0)
+2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  | paintChild RenderPadding at Point(8.0, 439.0)
+2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  | paintChild RenderViewport at Point(12.0, 443.0)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  | save
-2 |  |  |  |  |  |  |  |  | translate(8.0, 439.0)
-2 |  |  |  |  |  |  |  |  | concat([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
-2 |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
+2 |  |  |  |  |  |  |  |  | clipRect(Rect.fromLTRB(12.0, 443.0, 788.0, 503.0))
+2 |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(12.0, 443.0)
 2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(12.0, 443.0)
 2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffc56c79), drawLooper:true))
-2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  | drawRect(Rect.fromLTRB(12.0, 443.0, 788.0, 503.0), Paint(color:Color(0xff2196f3)))
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderFlex at Point(12.0, 443.0)
 2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 64.0), Paint(color:Color(0xff000000)))
-2 |  |  |  |  |  |  |  |  |  |  |  | clipRRect()
-2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderImage at Point(12.0, 455.0)
 2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(48.0, 459.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(278.0, 459.0)
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(12.0, 12.0)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(359.0, 21.5)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(359.0, 21.5)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -21.5)
-2 |  |  |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(278.0, 459.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-278.0, -459.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderImage at Point(752.0, 455.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  | restore
-2 |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 507.0)
-2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 507.0)
+2 |  |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 439.0)
 2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 507.0)
+2 |  |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 439.0)
+2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 439.0)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  | save
+2 |  |  |  |  |  |  |  |  |  | translate(8.0, 439.0)
+2 |  |  |  |  |  |  |  |  |  | concat([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
+2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffc56c79), drawLooper:true))
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 64.0), Paint(color:Color(0xff000000)))
+2 |  |  |  |  |  |  |  |  |  |  |  |  | clipRRect()
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(12.0, 12.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(359.0, 21.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(359.0, 21.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -21.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  | paintChild RenderStack at Point(8.0, 507.0)
+2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  | paintChild RenderPadding at Point(8.0, 507.0)
+2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  | paintChild RenderViewport at Point(12.0, 511.0)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  | save
-2 |  |  |  |  |  |  |  |  | translate(8.0, 507.0)
-2 |  |  |  |  |  |  |  |  | concat([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
-2 |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
+2 |  |  |  |  |  |  |  |  | clipRect(Rect.fromLTRB(12.0, 511.0, 788.0, 566.0))
+2 |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(12.0, 511.0)
 2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(12.0, 511.0)
 2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffbd6a7b), drawLooper:true))
-2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  | drawRect(Rect.fromLTRB(12.0, 511.0, 788.0, 566.0), Paint(color:Color(0xff2196f3)))
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderFlex at Point(12.0, 511.0)
 2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 59.0), Paint(color:Color(0xff000000)))
-2 |  |  |  |  |  |  |  |  |  |  |  | clipRRect()
-2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderImage at Point(12.0, 520.5)
 2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(48.0, 524.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(278.0, 524.5)
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(12.0, 12.0)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(359.0, 19.0)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(359.0, 19.0)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -19.0)
-2 |  |  |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(278.0, 524.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-278.0, -524.5)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderImage at Point(752.0, 520.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  | restore
-2 |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 570.0)
-2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 570.0)
+2 |  |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 507.0)
 2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 570.0)
+2 |  |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 507.0)
+2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 507.0)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  | save
+2 |  |  |  |  |  |  |  |  |  | translate(8.0, 507.0)
+2 |  |  |  |  |  |  |  |  |  | concat([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
+2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffbd6a7b), drawLooper:true))
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 59.0), Paint(color:Color(0xff000000)))
+2 |  |  |  |  |  |  |  |  |  |  |  |  | clipRRect()
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(12.0, 12.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(359.0, 19.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(359.0, 19.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -19.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  | paintChild RenderStack at Point(8.0, 570.0)
+2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  | paintChild RenderPadding at Point(8.0, 570.0)
+2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  | paintChild RenderViewport at Point(12.0, 574.0)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  | save
-2 |  |  |  |  |  |  |  |  | translate(8.0, 570.0)
-2 |  |  |  |  |  |  |  |  | concat([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
-2 |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
+2 |  |  |  |  |  |  |  |  | clipRect(Rect.fromLTRB(12.0, 574.0, 788.0, 658.0))
+2 |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(12.0, 574.0)
 2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(12.0, 574.0)
 2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffb5697d), drawLooper:true))
-2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  | drawRect(Rect.fromLTRB(12.0, 574.0, 788.0, 658.0), Paint(color:Color(0xff2196f3)))
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderFlex at Point(12.0, 574.0)
 2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 88.0), Paint(color:Color(0xff000000)))
-2 |  |  |  |  |  |  |  |  |  |  |  | clipRRect()
-2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderImage at Point(12.0, 598.0)
 2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(48.0, 602.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(278.0, 602.0)
 2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(12.0, 12.0)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(359.0, 33.5)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(359.0, 33.5)
-2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -33.5)
-2 |  |  |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(278.0, 602.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-278.0, -602.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderImage at Point(752.0, 598.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 570.0)
+2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  | paintChild RenderOpacity at Point(8.0, 570.0)
+2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | paintChild RenderTransform at Point(8.0, 570.0)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  | save
+2 |  |  |  |  |  |  |  |  |  | translate(8.0, 570.0)
+2 |  |  |  |  |  |  |  |  |  | concat([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
+2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffb5697d), drawLooper:true))
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(4.0, 4.0, 780.0, 88.0), Paint(color:Color(0xff000000)))
+2 |  |  |  |  |  |  |  |  |  |  |  |  | clipRRect()
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(4.0, 4.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(12.0, 12.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(359.0, 33.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(359.0, 33.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-359.0, -33.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  |  |  |  | restore
 2 |  |  |  |  |  | restore
 2 |  | paintChild RenderDecoratedBox at Point(0.0, 0.0)
 2 |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0


### PR DESCRIPTION
Added a background behind each Dismissable CardCollection demo card. Backgrounds are sometimes used to let the user know what the dismiss gesture means.

Simplified Dismissable AnimationPerformance usage a little
