### PR TITLE
Scoped focus, so you can have a dialog with input controls and not lose your focus in the background

### DIFF
--- a/sky/sdk/example/address_book/lib/main.dart
+++ b/sky/sdk/example/address_book/lib/main.dart
@@ -12,7 +12,6 @@ import 'package:sky/widgets/default_text_style.dart';
 import 'package:sky/widgets/dialog.dart';
 import 'package:sky/widgets/floating_action_button.dart';
 import 'package:sky/widgets/flat_button.dart';
-import 'package:sky/widgets/focus.dart';
 import 'package:sky/widgets/icon.dart';
 import 'package:sky/widgets/icon_button.dart';
 import 'package:sky/widgets/material.dart';
@@ -123,13 +122,10 @@ class AddressBookApp extends App {
   }
 
   Widget buildMain(Navigator navigator) {
-    return new Focus(
-      initialFocus: nameKey,
-      child: new Scaffold(
-        toolbar: buildToolBar(navigator),
-        body: buildBody(navigator),
-        floatingActionButton: buildFloatingActionButton(navigator)
-      )
+    return new Scaffold(
+      toolbar: buildToolBar(navigator),
+      body: buildBody(navigator),
+      floatingActionButton: buildFloatingActionButton(navigator)
     );
   }
 

--- a/sky/sdk/example/stocks/lib/main.dart
+++ b/sky/sdk/example/stocks/lib/main.dart
@@ -22,7 +22,6 @@ import 'package:sky/widgets/drawer_divider.dart';
 import 'package:sky/widgets/drawer_header.dart';
 import 'package:sky/widgets/drawer_item.dart';
 import 'package:sky/widgets/floating_action_button.dart';
-import 'package:sky/widgets/focus.dart';
 import 'package:sky/widgets/icon.dart';
 import 'package:sky/widgets/icon_button.dart';
 import 'package:sky/widgets/modal_overlay.dart';

--- a/sky/sdk/example/stocks/lib/stock_home.dart
+++ b/sky/sdk/example/stocks/lib/stock_home.dart
@@ -296,9 +296,6 @@ class StockHome extends StatefulComponent {
       ),
     ];
     addMenuToOverlays(overlays);
-    return new Focus(
-      initialFocus: searchFieldKey,
-      child: new Stack(overlays)
-    );
+    return new Stack(overlays);
   }
 }

--- a/sky/sdk/lib/widgets/dialog.dart
+++ b/sky/sdk/lib/widgets/dialog.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:sky/theme/colors.dart' as colors;
 import 'package:sky/widgets/basic.dart';
 import 'package:sky/widgets/default_text_style.dart';
+import 'package:sky/widgets/focus.dart';
 import 'package:sky/widgets/material.dart';
 import 'package:sky/widgets/navigator.dart';
 import 'package:sky/widgets/scrollable_viewport.dart';
@@ -24,7 +25,7 @@ class Dialog extends Component {
     this.content,
     this.actions,
     this.onDismiss
-  }) : super(key: key);
+  }): super(key: key);
 
   /// The (optional) title of the dialog is displayed in a large font at the top
   /// of the dialog.
@@ -111,7 +112,11 @@ Future showDialog(Navigator navigator, DialogBuilder builder) {
   navigator.push(new DialogRoute(
     completer: completer,
     builder: (navigator, route) {
-      return builder(navigator);
+      return new Focus(
+        key: new GlobalKey.fromObjectIdentity(route),
+        autofocus: true,
+        child: builder(navigator)
+      );
     }
   ));
   return completer.future;

--- a/sky/sdk/lib/widgets/focus.dart
+++ b/sky/sdk/lib/widgets/focus.dart
@@ -4,53 +4,239 @@
 
 import 'package:sky/widgets/widget.dart';
 
-class Focus extends Inherited {
+typedef void FocusChanged(GlobalKey key);
 
-  // TODO(ianh): This doesn't yet support nested scopes. We should not
-  // be telling our _currentlyFocusedKey that they are focused if we
-  // ourselves are not focused. Otherwise if you have a dialog with a
-  // text field over the top of a pane with a text field, they'll
-  // fight over control of the keyboard.
+// _noFocusedScope is used by Focus to track the case where none of the Focus
+// component's subscopes (e.g. dialogs) are focused. This is distinct from the
+// focused scope being null, which means that we haven't yet decided which scope
+// is focused and whichever is the first scope to ask for focus will get it.
+final GlobalKey _noFocusedScope = new GlobalKey();
 
-  Focus({
-    GlobalKey key,
-    this.initialFocus,
+class _FocusScope extends Inherited {
+
+  _FocusScope({
+    Key key,
+    this.scopeFocused: true, // are we focused in our ancestor scope?
+    this.focusedScope, // which of our descendant scopes is focused, if any?
+    this.focusedWidget,
     Widget child
   }) : super(key: key, child: child);
 
-  final GlobalKey initialFocus;
+  final bool scopeFocused;
 
-  GlobalKey _currentlyFocusedKey;
-  GlobalKey get currentlyFocusedKey {
-    if (_currentlyFocusedKey != null)
-      return _currentlyFocusedKey;
-    return initialFocus;
+  // These are mutable because we implicitly changed them when they're null in
+  // certain cases, basically pretending retroactively that we were constructed
+  // with the right keys.
+  GlobalKey focusedScope;
+  GlobalKey focusedWidget;
+
+  // The ...IfUnset() methods don't need to notify descendants because by
+  // definition they are only going to make a change the very first time that
+  // our state is checked.
+
+  void _setFocusedWidgetIfUnset(GlobalKey key) {
+    assert(parent is Focus);
+    (parent as Focus)._setFocusedWidgetIfUnset(key); // TODO(ianh): remove cast once analyzer is cleverer
+    focusedWidget = (parent as Focus)._focusedWidget;
+    focusedScope = (parent as Focus)._focusedScope == _noFocusedScope ? null : (parent as Focus)._focusedScope;
   }
-  void set currentlyFocusedKey(GlobalKey value) {
-    if (value != _currentlyFocusedKey) {
-      _currentlyFocusedKey = value;
-      notifyDescendants();
+
+  void _setFocusedScopeIfUnset(GlobalKey key) {
+    assert(parent is Focus);
+    (parent as Focus)._setFocusedScopeIfUnset(key); // TODO(ianh): remove cast once analyzer is cleverer
+    assert(focusedWidget == (parent as Focus)._focusedWidget);
+    focusedScope = (parent as Focus)._focusedScope == _noFocusedScope ? null : (parent as Focus)._focusedScope;
+  }
+
+  bool syncShouldNotify(_FocusScope old) {
+    assert(parent is Focus);
+    if (scopeFocused != old.scopeFocused)
+      return true;
+    if (!scopeFocused)
+      return false;
+    if (focusedScope != old.focusedScope)
+      return true;
+    if (focusedScope != null)
+      return false;
+    if (focusedWidget != old.focusedWidget)
+      return true;
+    return false;
+  }
+
+}
+
+class Focus extends StatefulComponent {
+
+  Focus({
+    GlobalKey key, // key is required if this is a nested Focus scope
+    this.autofocus: false,
+    this.child
+  }) : super(key: key) {
+    assert(!autofocus || key != null);
+  }
+
+  bool autofocus;
+  Widget child;
+
+  void syncFields(Focus source) {
+    autofocus = source.autofocus;
+    child = source.child;
+  }
+
+
+  GlobalKey _focusedWidget; // when null, the first component to ask if it's focused will get the focus
+  GlobalKey _currentlyRegisteredWidgetRemovalListenerKey;
+
+  void _setFocusedWidget(GlobalKey key) {
+    setState(() {
+      _focusedWidget = key;
+      if (_focusedScope == null)
+        _focusedScope = _noFocusedScope;
+    });
+    _updateWidgetRemovalListener(key);
+  }
+
+  void _setFocusedWidgetIfUnset(GlobalKey key) {
+    if (_focusedWidget == null && (_focusedScope == null || _focusedScope == _noFocusedScope)) {
+      _focusedWidget = key;
+      _focusedScope = _noFocusedScope;
+      _updateWidgetRemovalListener(key);
     }
   }
 
-  void syncState(Focus old) {
-    _currentlyFocusedKey = old._currentlyFocusedKey;
-    super.syncState(old);
-  }  
+  void _widgetRemoved(GlobalKey key) {
+    assert(_focusedWidget == key);
+    _currentlyRegisteredWidgetRemovalListenerKey = null;
+    setState(() {
+      _focusedWidget = null;
+    });
+  }
 
-  static bool at(Component component) {
+  void _updateWidgetRemovalListener(GlobalKey key) {
+    if (_currentlyRegisteredWidgetRemovalListenerKey != key) {
+      if (_currentlyRegisteredWidgetRemovalListenerKey != null)
+        GlobalKey.unregisterRemovalListener(_currentlyRegisteredWidgetRemovalListenerKey, _widgetRemoved);
+      if (key != null)
+        GlobalKey.registerRemovalListener(key, _widgetRemoved);
+      _currentlyRegisteredWidgetRemovalListenerKey = key;
+    }
+  }
+
+
+  GlobalKey _focusedScope; // when null, the first scope to ask if it's focused will get the focus
+  GlobalKey _currentlyRegisteredScopeRemovalListenerKey;
+
+  void _setFocusedScope(GlobalKey key) {
+    setState(() {
+      _focusedScope = key;
+    });
+    _updateScopeRemovalListener(key);
+  }
+
+  void _setFocusedScopeIfUnset(GlobalKey key) {
+    if (_focusedScope == null) {
+      _focusedScope = key;
+      _updateScopeRemovalListener(key);
+    }
+  }
+
+  void _scopeRemoved(GlobalKey key) {
+    assert(_focusedScope == key);
+    _currentlyRegisteredScopeRemovalListenerKey = null;
+    setState(() {
+      _focusedScope = null;
+    });
+  }
+
+  void _updateScopeRemovalListener(GlobalKey key) {
+    if (_currentlyRegisteredScopeRemovalListenerKey != key) {
+      if (_currentlyRegisteredScopeRemovalListenerKey != null)
+        GlobalKey.unregisterRemovalListener(_currentlyRegisteredScopeRemovalListenerKey, _scopeRemoved);
+      if (key != null)
+        GlobalKey.registerRemovalListener(key, _scopeRemoved);
+      _currentlyRegisteredScopeRemovalListenerKey = key;
+    }
+  }
+
+
+  bool _didAutoFocus = false;
+  void didMount() {
+    if (autofocus && !_didAutoFocus) {
+      _didAutoFocus = true;
+      Focus._moveScopeTo(this);
+    }
+    _updateWidgetRemovalListener(_focusedWidget);
+    _updateScopeRemovalListener(_focusedScope);
+    super.didMount();
+  }
+
+  void didUnmount() {
+    _updateWidgetRemovalListener(null);
+    _updateScopeRemovalListener(null);
+    super.didUnmount();
+  }
+
+  Widget build() {
+    return new _FocusScope(
+      scopeFocused: Focus._atScope(this),
+      focusedScope: _focusedScope == _noFocusedScope ? null : _focusedScope,
+      focusedWidget: _focusedWidget,
+      child: child
+    );
+  }
+
+  static bool at(Component component, { bool autofocus: true }) {
     assert(component != null);
     assert(component.key is GlobalKey);
-    Focus focus = component.inheritedOfType(Focus);
-    return focus == null || focus.currentlyFocusedKey == component.key;
+    _FocusScope focusScope = component.inheritedOfType(_FocusScope);
+    if (focusScope != null) {
+      if (autofocus)
+        focusScope._setFocusedWidgetIfUnset(component.key);
+      return focusScope.scopeFocused &&
+             focusScope.focusedScope == null &&
+             focusScope.focusedWidget == component.key;
+    }
+    return true;
   }
+
+  static bool _atScope(Focus component, { bool autofocus: true }) {
+    assert(component != null);
+    _FocusScope focusScope = component.inheritedOfType(_FocusScope);
+    if (focusScope != null) {
+      if (autofocus)
+        focusScope._setFocusedScopeIfUnset(component.key);
+      assert(component.key != null);
+      return focusScope.scopeFocused &&
+             focusScope.focusedScope == component.key;
+    }
+    return true;
+  }
+
+  // Don't call moveTo() from your build() function, it's intended to be called
+  // from event listeners, e.g. in response to a finger tap or tab key.
 
   static void moveTo(Component component) {
     assert(component != null);
     assert(component.key is GlobalKey);
-    Focus focus = component.inheritedOfType(Focus);
-    if (focus != null)
-      focus.currentlyFocusedKey = component.key;
+    _FocusScope focusScope = component.inheritedOfType(_FocusScope);
+    if (focusScope != null) {
+      assert(focusScope.parent is Focus);
+      (focusScope.parent as Focus)._setFocusedWidget(component.key); // TODO(ianh): remove cast once analyzer is cleverer
+    }
+  }
+
+  static void _moveScopeTo(Focus component) {
+    assert(component != null);
+    assert(component.key != null);
+    _FocusScope focusScope = component.inheritedOfType(_FocusScope);
+    if (focusScope != null) {
+      assert(focusScope.parent is Focus);
+      (focusScope.parent as Focus)._setFocusedScope(component.key); // TODO(ianh): remove cast once analyzer is cleverer
+    }
+  }
+
+  String toStringName() {
+    return '${super.toStringName()}(focusedScope=$_focusedScope; focusedWidget=$_focusedWidget)';
   }
 
 }

--- a/sky/sdk/lib/widgets/navigator.dart
+++ b/sky/sdk/lib/widgets/navigator.dart
@@ -9,6 +9,7 @@ import 'package:sky/animation/animation_performance.dart';
 import 'package:sky/animation/curves.dart';
 import 'package:sky/widgets/animated_component.dart';
 import 'package:sky/widgets/basic.dart';
+import 'package:sky/widgets/focus.dart';
 import 'package:vector_math/vector_math.dart';
 
 typedef Widget RouteBuilder(Navigator navigator, RouteBase route);
@@ -280,6 +281,6 @@ class Navigator extends StatefulComponent {
       );
       visibleRoutes.add(transition);
     }
-    return new Stack(visibleRoutes);
+    return new Focus(child: new Stack(visibleRoutes));
   }
 }


### PR DESCRIPTION
This introduces a GlobalKey registry so that you can tell when a key
has gone away (so you can unfocus dead dialogs).

Also I added an assert that you're not calling setState() during a
build. It turns out that doing so means you have a bug, because since
you're dirty already (you're building), you won't get rebuilt.

The focus code itself is gnarly. It uses a Component and an internal
Inherited TagNode to manage the focus state, and does crazy things
like updating its state during build to pretend retroactively that it
was built with some other state, once someone asks for focus the first
time (i.e. the first time it's examined, so you can't tell that it was
in a different state before). It does this so that it can autofocus
controls which otherwise wouldn't be focused.

This moves all the focus management into Navigator and showDialog(),
so the complexity is all buried deep and not visible to apps,
hopefully.

To do something like two tabs that each have an Input widget that
needs to be focused when you switch panes, you'd need to have two
Focus objects, one in each tab, and you need to set their autofocus to
true (maybe that should be the default?).