### PR TITLE
Enable scrollable tabs fling scrolling

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   'cassowary_dart_revision': '7e5afc5b3956a18636d5b37b1dcba1705865564b',
   'collection_dart_revision': '79ebc6fc2dae581cb23ad50a5c600c1b7dd132f8',
   'crypto_dart_revision': 'd4558dea1639e5ad2a41d045265b8ece270c2d90',
-  'newton_dart_revision': '9fbe5fbac809246f7ace4176feca13bdf731e393',
+  'newton_dart_revision': '11cd659e1650591402b69f91b9c4d2a0841fd5bd',
   'path_dart_revision': '2f3dcdec32011f1bc41194ae3640d6d9292a7096',
   'quiver_dart_revision': '6bab7dec34189eee579178eb16d3063c8ae69031',
   'source_span_dart_revision': '5c6c13f62fc111adaace3aeb4a38853d64481d06',

--- a/sky/sdk/example/widgets/tabs.dart
+++ b/sky/sdk/example/widgets/tabs.dart
@@ -16,11 +16,12 @@ class TabbedNavigatorApp extends App {
   // The index of the selected tab for each of the TabNavigators constructed below.
   List<int> selectedIndices = new List<int>.filled(5, 0);
 
-  TabNavigator _buildTabNavigator(int n, List<TabNavigatorView> views, {scrollable: false}) {
+  TabNavigator _buildTabNavigator(int n, List<TabNavigatorView> views, Key key, {isScrollable: false}) {
     return new TabNavigator(
+      key: key,
       views: views,
       selectedIndex: selectedIndices[n],
-      scrollable: scrollable,
+      isScrollable: isScrollable,
       onChanged: (tabIndex) {
         setState(() { selectedIndices[n] = tabIndex; } );
       }
@@ -41,7 +42,7 @@ class TabbedNavigatorApp extends App {
           builder: () => _buildContent(text)
         );
       });
-    return _buildTabNavigator(n, views.toList());
+    return _buildTabNavigator(n, views.toList(), new Key('textLabelsTabNavigator'));
   }
 
   TabNavigator _buildIconLabelsTabNavigator(int n) {
@@ -52,7 +53,7 @@ class TabbedNavigatorApp extends App {
           builder: () => _buildContent(icon_name)
         );
       });
-    return _buildTabNavigator(n, views.toList());
+    return _buildTabNavigator(n, views.toList(), new Key('iconLabelsTabNavigator'));
   }
 
   TabNavigator _buildTextAndIconLabelsTabNavigator(int n) {
@@ -70,7 +71,7 @@ class TabbedNavigatorApp extends App {
         builder: () => _buildContent("Summary")
       )
     ];
-    return _buildTabNavigator(n, views);
+    return _buildTabNavigator(n, views, new Key('textAndIconLabelsTabNavigator'));
   }
 
   TabNavigator _buildScrollableTabNavigator(int n) {
@@ -80,7 +81,7 @@ class TabbedNavigatorApp extends App {
       "THIS TAB IS PRETTY WIDE TOO",
       "MORE",
       "TABS",
-      "TO", 
+      "TO",
       "STRETCH",
       "OUT",
       "THE",
@@ -92,7 +93,7 @@ class TabbedNavigatorApp extends App {
           builder: () => _buildContent(text)
         );
       });
-    return _buildTabNavigator(n, views.toList(), scrollable: true);
+    return _buildTabNavigator(n, views.toList(), new Key('scrollableTabNavigator'), isScrollable: true);
   }
 
 
@@ -124,7 +125,7 @@ class TabbedNavigatorApp extends App {
       )
     ];
 
-    TabNavigator tabNavigator = _buildTabNavigator(4, views);
+    TabNavigator tabNavigator = _buildTabNavigator(4, views, new Key('tabs'));
     assert(selectedIndices.length == 5);
 
     ToolBar toolbar = new ToolBar(

--- a/sky/sdk/lib/animation/scroll_behavior.dart
+++ b/sky/sdk/lib/animation/scroll_behavior.dart
@@ -60,7 +60,7 @@ class FlingBehavior extends BoundedBehavior {
     : super(contentsSize: contentsSize, containerSize: containerSize);
 
   Simulation release(double position, double velocity) {
-    return createDefaultScrollSimulation(position, 0.0, minScrollOffset, maxScrollOffset);
+    return createDefaultScrollSimulation(position, velocity, minScrollOffset, maxScrollOffset);
   }
 }
 

--- a/sky/sdk/pubspec.yaml
+++ b/sky/sdk/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   mojo_services: ^0.0.15
   mojo: ^0.0.17
   mojom: ^0.0.17
-  newton: ^0.1.0
+  newton: ^0.1.2
   sky_engine: ^0.0.1
   sky_services: ^0.0.1
   sky_tools: ^0.0.4


### PR DESCRIPTION
Enable fling scrolling in TabBar.

Also changed the TabBar scrollable: parameter to isScrollable: and used Keys to distinguish the different TabNavigators in the tabs.dart example.
