### PR TITLE
Fix sky_tool's installing of SkyShell.apk

### DIFF
--- a/sky/sdk/lib/sky_tool
+++ b/sky/sdk/lib/sky_tool
@@ -16,10 +16,9 @@ import urlparse
 import time
 
 # TODO(eseidel): This should be BIN_DIR.
-LIB_DIR = os.path.realpath(os.path.dirname(os.path.abspath(__file__)))
-SKY_PACKAGE_ROOT = os.path.realpath(os.path.dirname(LIB_DIR))
-SKY_ENGINE_PACKAGE_ROOT = os.path.realpath(os.path.join(SKY_PACKAGE_ROOT,
-    os.pardir, 'sky_engine'))
+PACKAGE_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SKY_ENGINE_PACKAGE = os.path.join(PACKAGE_ROOT, 'sky_engine')
+APK_DIR = os.path.join(os.path.realpath(SKY_ENGINE_PACKAGE), os.pardir, 'apks')
 
 SKY_SERVER_PORT = 9888
 OBSERVATORY_PORT = 8181
@@ -166,7 +165,7 @@ class StartSky(object):
             args.install = True
 
         if args.install:
-            apk_path = os.path.join(SKY_ENGINE_PACKAGE_ROOT, 'apks', APK_NAME)
+            apk_path = os.path.join(APK_DIR, APK_NAME)
             if not os.path.exists(apk_path):
                 print "'%s' does not exist?" % apk_path
                 return 2


### PR DESCRIPTION
We were walking over to the realdir too quickly, which meant we lost which
version of the sky_engine package we were supposed to use.