### PR TITLE
Teach big_red_button how to publish sky, sky_engine, sky_services

### DIFF
--- a/sky/dist/BUILD.gn
+++ b/sky/dist/BUILD.gn
@@ -50,10 +50,9 @@ copy("sky_shell") {
 if (is_android) {
   import("//build/config/android/rules.gni")
 
-  sky_engine_package_dir = "$root_dist_dir/packages/sky_engine"
-
-  copy_ex("copy_sky_engine_package") {
+  copy_ex("sky_engine") {
     clear_dir = true
+    # Note: The package actually ends up in $root_dist_dir/packages/sky_engine/sky_engine
     dest = "$root_dist_dir/packages"
     sources = [
       "$root_gen_dir/dart-pkg/sky_engine",
@@ -63,35 +62,18 @@ if (is_android) {
     ]
   }
 
-  copy("copy_sky_engine_license") {
+  copy_ex("sky_services") {
+    clear_dir = true
+    # Note: The package actually ends up in $root_dist_dir/packages/sky_services/sky_services
+    dest = "$root_dist_dir/packages/sky_services"
     sources = [
-      "//AUTHORS",
-      "//LICENSE",
+      "$root_gen_dir/dart-pkg/sky_services",
     ]
-    outputs = [ "$sky_engine_package_dir/{{source_file_part}}" ]
     deps = [
-      ":copy_sky_engine_package"
+      "//sky/packages/sky_services",
     ]
   }
 
-  copy("copy_sky_engine_apks") {
-    sources = [
-      "$root_dist_dir/shell/SkyShell.apk",
-    ]
-    outputs = [ "$sky_engine_package_dir/apks/{{source_file_part}}" ]
-    deps = [
-      ":copy_sky_engine_package",
-      ":sky_shell",
-    ]
-  }
-
-  group("sky_engine") {
-    deps = [
-      ":copy_sky_engine_package",
-      ":copy_sky_engine_license",
-      ":copy_sky_engine_apks",
-    ]
-  }
 }
 
 group("dist") {

--- a/sky/packages/sky_engine/BUILD.gn
+++ b/sky/packages/sky_engine/BUILD.gn
@@ -4,6 +4,33 @@
 
 import("//mojo/public/dart/rules.gni")
 
+copy("copy_sky_engine_license") {
+  sources = [
+    "//AUTHORS",
+    "//LICENSE",
+  ]
+
+  outputs = [
+    "$root_gen_dir/dart-pkg/sky_engine/{{source_file_part}}",
+  ]
+}
+
+if (is_android) {
+  copy("copy_sky_engine_apks") {
+    sources = [
+      "$root_build_dir/apks/SkyShell.apk",
+    ]
+
+    outputs = [
+      "$root_gen_dir/dart-pkg/sky_engine/apks/SkyShell.apk",
+    ]
+
+    deps = [
+      "//sky/shell",
+    ]
+  }
+}
+
 dart_pkg("sky_engine") {
   sources = [
     "README.md",
@@ -11,8 +38,13 @@ dart_pkg("sky_engine") {
   ]
 
   deps = [
+    ":copy_sky_engine_license",
     "//sky/engine/bindings",
   ]
+
+  if (is_android) {
+    deps += [ ":copy_sky_engine_apks" ]
+  }
 
   sdk_ext_directory = "$root_gen_dir/sky/bindings"
   sdk_ext_files = [

--- a/sky/packages/sky_services/BUILD.gn
+++ b/sky/packages/sky_services/BUILD.gn
@@ -4,6 +4,17 @@
 
 import("//mojo/public/dart/rules.gni")
 
+copy("copy_sky_services_license") {
+  sources = [
+    "//AUTHORS",
+    "//LICENSE",
+  ]
+
+  outputs = [
+    "$root_gen_dir/dart-pkg/sky_services/{{source_file_part}}",
+  ]
+}
+
 dart_pkg("sky_services") {
   sources = [
     "README.md",
@@ -11,6 +22,7 @@ dart_pkg("sky_services") {
   ]
 
   deps = [
+    ":copy_sky_services_license",
     "//mojo/services/asset_bundle/public/interfaces",
     "//mojo/services/keyboard/public/interfaces",
     "//sky/services/activity:interfaces",

--- a/sky/sdk/.gitignore
+++ b/sky/sdk/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .pub/
-lib/_sdkext
+AUTHORS
+LICENSE
 packages
 pubspec.lock

--- a/sky/tools/big_red_button.py
+++ b/sky/tools/big_red_button.py
@@ -96,7 +96,9 @@ def main():
     pub_path = os.path.join(dart_sdk_root, 'bin/pub')
     android_dist_root = os.path.join(sky_engine_root, 'out/android_Release/dist')
     linux_dist_root = os.path.join(sky_engine_root, 'out/Release/dist')
-    sky_package_root = os.path.join(linux_dist_root, 'sdk/sky')
+    sky_package_root = os.path.join(sky_engine_root, 'sky/sdk')
+    sky_engine_package_root = os.path.join(android_dist_root, 'packages/sky_engine/sky_engine')
+    sky_services_package_root = os.path.join(android_dist_root, 'packages/sky_services/sky_services')
 
     run(sky_engine_root, ['git', 'fetch', 'upstream'])
     run(sky_engine_root, ['git', 'reset', 'upstream/master', '--hard'])
@@ -110,10 +112,14 @@ def main():
     run(sky_engine_root, ['sky/tools/gn', '--release'])
     run(sky_engine_root, ['ninja', '-C', 'out/Release', ':dist'])
 
+    run(sky_engine_root, ['cp', 'AUTHORS', 'LICENSE', 'sky/sdk'])
+
     upload_artifacts(android_dist_root, 'android-arm', commit_hash)
     upload_artifacts(linux_dist_root, 'linux-x64', commit_hash)
 
     if args.publish:
+        run(sky_engine_package_root, [pub_path, 'publish', '--force'])
+        run(sky_services_package_root, [pub_path, 'publish', '--force'])
         run(sky_package_root, [pub_path, 'publish', '--force'])
 
 


### PR DESCRIPTION
This CL makess big_red_button.py work for the sky_engine and sky_services
packages. The next step is to make it work for the sky package again.