### PR TITLE
Cleanups to network service

### DIFF
--- a/sky/packages/workbench/pubspec.yaml
+++ b/sky/packages/workbench/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/domokit/sky_engine/tree/master/sky/packages/workben
 dependencies:
   sky: any
 dev_dependencies:
-  sky_tools: ^0.0.3
+  sky_tools: ^0.0.4
 dependency_overrides:
   material_design_icons:
     path: ../material_design_icons

--- a/sky/services/oknet/src/org/domokit/oknet/NetworkServiceImpl.java
+++ b/sky/services/oknet/src/org/domokit/oknet/NetworkServiceImpl.java
@@ -13,7 +13,6 @@ import com.squareup.okhttp.OkHttpClient;
 import org.chromium.mojo.bindings.InterfaceRequest;
 import org.chromium.mojo.system.Core;
 import org.chromium.mojo.system.DataPipe;
-import org.chromium.mojo.system.MessagePipeHandle;
 import org.chromium.mojo.system.MojoException;
 import org.chromium.mojom.mojo.CookieStore;
 import org.chromium.mojom.mojo.HostResolver;
@@ -41,7 +40,7 @@ public class NetworkServiceImpl implements NetworkService {
     private static OkHttpClient sClient;
     private Core mCore;
 
-    public NetworkServiceImpl(Context context, Core core, MessagePipeHandle pipe) {
+    public NetworkServiceImpl(Context context, Core core) {
         assert core != null;
         mCore = core;
 
@@ -61,8 +60,6 @@ public class NetworkServiceImpl implements NetworkService {
                 Log.e(TAG, "Unable to create HTTP cache", e);
             }
         }
-
-        NetworkService.MANAGER.bind(this, pipe);
     }
 
     @Override

--- a/sky/shell/android/org/domokit/sky/shell/SkyApplication.java
+++ b/sky/shell/android/org/domokit/sky/shell/SkyApplication.java
@@ -87,8 +87,7 @@ public class SkyApplication extends BaseChromiumApplication {
         registry.register(NetworkService.MANAGER.getName(), new ServiceFactory() {
             @Override
             public void connectToService(Context context, Core core, MessagePipeHandle pipe) {
-                // TODO(eseidel): Refactor ownership to match other services.
-                new NetworkServiceImpl(context, core, pipe);
+                NetworkService.MANAGER.bind(new NetworkServiceImpl(context, core), pipe);
             }
         });
 


### PR DESCRIPTION
This patch contains some minor improvements to the network service:

- We now cache the connection to the network service so we don't need to spin
  it up for each request.
- We now manage the lifetime of NetworkServiceImpl in the same way as other
  services.

Also, update the workbench sky_tools dependency to the latest version.