### PR TITLE
Improve init.dart not to assume `dart` is in your PATH

### DIFF
--- a/sky/sdk/bin/init.dart
+++ b/sky/sdk/bin/init.dart
@@ -5,13 +5,12 @@
 /*
 * This script should be invoked via 'pub run' after 'pub get':
 * $ pub run sky:init
-* NOTE: The 'dart' executable must be on your $PATH for this script to work.
 */
 
 import 'dart:io';
 
 main(List<String> arguments) {
-  ProcessResult result = Process.runSync('dart', ['-p', 'packages', 'packages/mojom/generate.dart']);
+  ProcessResult result = Process.runSync(Platform.executable, ['-p', 'packages', 'packages/mojom/generate.dart']);
   stdout.write(result.stdout);
   stderr.write(result.stderr);
 }


### PR DESCRIPTION
Instead, use Platform.executable, which is the path to the current `dart`
executable.