### PR TITLE
Run sky:init before creating a snapshot

### DIFF
--- a/sky/build/sky_init.py
+++ b/sky/build/sky_init.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# Copyright 2015 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import argparse
+import os
+import subprocess
+import sys
+
+SKY_BUILD_DIR = os.path.dirname(os.path.abspath(__file__))
+SRC_ROOT = os.path.dirname(os.path.dirname(SKY_BUILD_DIR))
+WORKBENCH = os.path.join(SRC_ROOT, 'sky', 'packages', 'workbench')
+DART_SDK = os.path.join(SRC_ROOT, 'third_party', 'dart-sdk', 'dart-sdk', 'bin')
+PUB = os.path.join(DART_SDK, 'pub')
+
+def main():
+    parser = argparse.ArgumentParser(description='Packaging tool for Sky apps')
+    parser.add_argument('--touch', type=str)
+    args = parser.parse_args()
+
+    subprocess.check_call([PUB, 'run', 'sky:init'], cwd=WORKBENCH)
+
+    if args.touch:
+        with open(os.path.abspath(args.touch), 'w') as f:
+            pass
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/sky/build/skyx.gni
+++ b/sky/build/skyx.gni
@@ -41,8 +41,9 @@ template("skyx") {
     ]
 
     deps = [
-      "//sky/tools/sky_snapshot($host_toolchain)",
+      "//sky/packages/workbench:init",
       "//sky/sdk",
+      "//sky/tools/sky_snapshot($host_toolchain)",
     ]
 
     if (defined(invoker.deps)) {

--- a/sky/packages/workbench/BUILD.gn
+++ b/sky/packages/workbench/BUILD.gn
@@ -1,0 +1,16 @@
+# Copyright 2015 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+action("init") {
+  stamp = "$target_gen_dir/sky_init.stamp"
+
+  script = "//sky/build/sky_init.py"
+  sources = [ "//sky/sdk/pubspec.yaml" ]
+  outputs = [ stamp ]
+
+  args = [
+    "--touch",
+    rebase_path(stamp, root_build_dir),
+  ]
+}


### PR DESCRIPTION
If we've never run sky:init before, the mojom package will be empty and the
snapshot will fail.