### PR TITLE
Compress assets in APKs

### DIFF
--- a/sky/build/sky_app.gni
+++ b/sky/build/sky_app.gni
@@ -75,6 +75,8 @@ template("sky_app") {
       native_libs = [ "libsky_shell.so" ]
       asset_location = "$target_gen_dir/assets"
 
+      extensions_to_not_compress = ".skyx"
+
       deps = [
         "//base:base_java",
         "//sky/shell:assets",

--- a/sky/shell/BUILD.gn
+++ b/sky/shell/BUILD.gn
@@ -155,6 +155,8 @@ if (is_android) {
     native_libs = [ "libsky_shell.so" ]
     asset_location = "$root_build_dir/sky_shell/assets"
 
+    extensions_to_not_compress = ".skyx"
+
     deps = [
       ":assets",
       ":assets",


### PR DESCRIPTION
This patch moves us back to compressing assets in APKs. We lost compression
when we updated Chromium recently. This brings typical Sky APKs down to 7.2MB.