### PR TITLE
Move build() off microtasks

### DIFF
--- a/sky/packages/sky/lib/rendering/sky_binding.dart
+++ b/sky/packages/sky/lib/rendering/sky_binding.dart
@@ -47,7 +47,7 @@ class SkyBinding {
       _renderView = renderViewOverride;
     }
     assert(_renderView != null);
-    scheduler.addPersistentFrameCallback(_beginFrame);
+    scheduler.addPersistentFrameCallback(beginFrame);
 
     assert(_instance == this);
   }
@@ -69,7 +69,7 @@ class SkyBinding {
   void set root(RenderBox value) {
     _renderView.child = value;
   }
-  void _beginFrame(double timeStamp) {
+  void beginFrame(double timeStamp) {
     RenderObject.flushLayout();
     RenderObject.flushPaint();
     _renderView.paintFrame();

--- a/sky/tests/resources/display_list.dart
+++ b/sky/tests/resources/display_list.dart
@@ -149,6 +149,7 @@ class TestRenderView extends RenderView {
   // TEST API:
 
   void syncCheckFrame() {
+    Component.flushBuild();
     RenderObject.flushLayout();
     paintFrame();
     print(lastPaint); // TODO(ianh): figure out how to make this fit the unit testing framework better


### PR DESCRIPTION
Rather than using a microtask to schedule component build functions, instead
use the scheduler. We now tread building just like layout and painting as a
visual update.