### PR TITLE
add --fatal-warnings to dartanalyzer command line

### DIFF
--- a/sky/tools/skyanalyzer
+++ b/sky/tools/skyanalyzer
@@ -57,7 +57,8 @@ def main():
     try:
       subprocess.check_output([
           DARTANALYZER, "--package-warnings", args.app_path,
-          "--package-root", os.path.join(WORKBENCH, "packages")
+          "--package-root", os.path.join(WORKBENCH, "packages"),
+          "--fatal-warnings"
       ], stderr=subprocess.STDOUT, cwd=WORKBENCH)
     except subprocess.CalledProcessError as e:
       errors = [l for l in e.output.split('\n')


### PR DESCRIPTION
add --fatal-warnings to the dartanalyzer command line generated by skyanalyzer

This is a quick hack to address https://github.com/domokit/sky_engine/issues/332

The command-line help for --fatal-warnings says: "treat non-type warnings as fatal". Which implies we're still not seeing all warnings.

