### PR TITLE
Treat all UITouchPhaseCancelled on raw touches as pointerUp instead o…

### DIFF
--- a/sky/shell/ios/sky_surface.mm
+++ b/sky/shell/ios/sky_surface.mm
@@ -26,9 +26,11 @@ static inline sky::EventType EventTypeFromUITouchPhase(UITouchPhase phase) {
       // with the same coordinates
       return sky::EVENT_TYPE_POINTER_MOVE;
     case UITouchPhaseEnded:
-      return sky::EVENT_TYPE_POINTER_UP;
     case UITouchPhaseCancelled:
-      return sky::EVENT_TYPE_POINTER_CANCEL;
+      // We treat all cancels for raw touches as ups.
+      // All pointers hit UITouchPhaseCancelled as soon as a
+      // gesture is recognized.
+      return sky::EVENT_TYPE_POINTER_UP;
   }
 
   return sky::EVENT_TYPE_UNKNOWN;


### PR DESCRIPTION
…f pointerCancel.

On iOS as soon as a gesture recognizer takes over it cancels all outstanding
touches.

R=@abarth