### PR TITLE
Improve pipeline accounting

### DIFF
--- a/sky/shell/ui/animator.h
+++ b/sky/shell/ui/animator.h
@@ -27,7 +27,7 @@ class Animator {
 
   Engine::Config config_;
   Engine* engine_;
-  int outstanding_draw_requests_;
+  int outstanding_requests_;
   bool did_defer_frame_request_;
   bool engine_requested_frame_;
   bool paused_;


### PR DESCRIPTION
Previously, there was a race condition whereby we could end up with three
requests in the pipeline. Now we update the number of outstanding requests
synchronously, which avoids the race.