### PR TITLE
Drive frames from the vsync provider on Android

### DIFF
--- a/sky/packages/sky_services/BUILD.gn
+++ b/sky/packages/sky_services/BUILD.gn
@@ -28,5 +28,6 @@ dart_pkg("sky_services") {
     "//sky/services/activity:interfaces",
     "//sky/services/media:interfaces",
     "//sky/services/testing:interfaces",
+    "//sky/services/vsync:interfaces",
   ]
 }

--- a/sky/services/vsync/BUILD.gn
+++ b/sky/services/vsync/BUILD.gn
@@ -1,0 +1,39 @@
+# Copyright 2015 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//mojo/public/tools/bindings/mojom.gni")
+
+group("vsync") {
+  testonly = true
+
+  deps = [
+    ":interfaces",
+  ]
+
+  if (is_android) {
+    deps += [ ":vsync_lib" ]
+  }
+}
+
+mojom("interfaces") {
+  sources = [
+    "vsync.mojom",
+  ]
+}
+
+if (is_android) {
+  import("//build/config/android/config.gni")
+  import("//build/config/android/rules.gni")
+
+  android_library("vsync_lib") {
+    java_files = [ "src/org/domokit/vsync/VsyncProviderImpl.java" ]
+
+    deps = [
+      "//base:base_java",
+      "//mojo/public/java:bindings",
+      "//mojo/public/java:system",
+      ":interfaces_java",
+    ]
+  }
+}

--- a/sky/services/vsync/src/org/domokit/vsync/VsyncProviderImpl.java
+++ b/sky/services/vsync/src/org/domokit/vsync/VsyncProviderImpl.java
@@ -1,0 +1,36 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.domokit.vsync;
+
+import android.view.Choreographer;
+
+import org.chromium.mojo.system.MojoException;
+import org.chromium.mojom.vsync.VsyncProvider;
+
+/**
+ * Android implementation of VsyncProvider.
+ */
+public class VsyncProviderImpl implements VsyncProvider {
+    private static final String TAG = "VsyncProviderImpl";
+
+    public VsyncProviderImpl() {
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public void onConnectionError(MojoException e) {}
+
+    @Override
+    public void awaitVsync(final AwaitVsyncResponse callback) {
+        Choreographer.getInstance().postFrameCallback(new Choreographer.FrameCallback() {
+            @Override
+            public void doFrame(long frameTimeNanos) {
+                callback.call(frameTimeNanos);
+            }
+        });
+    }
+}

--- a/sky/services/vsync/vsync.mojom
+++ b/sky/services/vsync/vsync.mojom
@@ -1,0 +1,9 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+module vsync;
+
+interface VsyncProvider {
+  AwaitVsync() => (int64 time_stamp);
+};

--- a/sky/shell/BUILD.gn
+++ b/sky/shell/BUILD.gn
@@ -20,6 +20,7 @@ common_deps = [
   "//sky/engine/tonic",
   "//sky/engine/wtf",
   "//sky/services/engine:interfaces",
+  "//sky/services/vsync:interfaces",
   "//sky/shell/dart",
   "//ui/gfx/geometry",
   "//ui/gl",
@@ -134,6 +135,8 @@ if (is_android) {
       "//sky/services/media:interfaces_java",
       "//sky/services/media:media_lib",
       "//sky/services/oknet",
+      "//sky/services/vsync:interfaces_java",
+      "//sky/services/vsync:vsync_lib",
     ]
   }
 

--- a/sky/shell/android/org/domokit/sky/shell/SkyApplication.java
+++ b/sky/shell/android/org/domokit/sky/shell/SkyApplication.java
@@ -21,9 +21,11 @@ import org.chromium.mojom.keyboard.KeyboardService;
 import org.chromium.mojom.media.MediaService;
 import org.chromium.mojom.mojo.NetworkService;
 import org.chromium.mojom.sensors.SensorService;
+import org.chromium.mojom.vsync.VsyncProvider;
 import org.domokit.activity.ActivityImpl;
 import org.domokit.media.MediaServiceImpl;
 import org.domokit.oknet.NetworkServiceImpl;
+import org.domokit.vsync.VsyncProviderImpl;
 
 /**
  * Sky implementation of {@link android.app.Application}, managing application-level global
@@ -95,6 +97,13 @@ public class SkyApplication extends BaseChromiumApplication {
             @Override
             public void connectToService(Context context, Core core, MessagePipeHandle pipe) {
                 SensorService.MANAGER.bind(new SensorServiceImpl(context), pipe);
+            }
+        });
+
+        registry.register(VsyncProvider.MANAGER.getName(), new ServiceFactory() {
+            @Override
+            public void connectToService(Context context, Core core, MessagePipeHandle pipe) {
+                VsyncProvider.MANAGER.bind(new VsyncProviderImpl(), pipe);
             }
         });
     }

--- a/sky/shell/ui/animator.h
+++ b/sky/shell/ui/animator.h
@@ -6,6 +6,7 @@
 #define SKY_SHELL_UI_ANIMATOR_H_
 
 #include "base/memory/weak_ptr.h"
+#include "sky/services/vsync/vsync.mojom.h"
 #include "sky/shell/ui/engine.h"
 
 namespace sky {
@@ -21,12 +22,17 @@ class Animator {
   void Start();
   void Stop();
 
+  void set_vsync_provider(vsync::VsyncProviderPtr vsync_provider) {
+    vsync_provider_ = vsync_provider.Pass();
+  }
+
  private:
-  void BeginFrame();
+  void BeginFrame(int64_t time_stamp);
   void OnFrameComplete();
 
   Engine::Config config_;
   Engine* engine_;
+  vsync::VsyncProviderPtr vsync_provider_;
   int outstanding_requests_;
   bool did_defer_frame_request_;
   bool engine_requested_frame_;

--- a/sky/shell/ui/engine.cc
+++ b/sky/shell/ui/engine.cc
@@ -65,6 +65,13 @@ Engine::Engine(const Config& config)
   mojo::ServiceProviderPtr service_provider =
       CreateServiceProvider(config.service_provider_context);
   mojo::ConnectToService(service_provider.get(), &network_service_);
+
+#if defined(OS_ANDROID)
+  // TODO(abarth): Implement VsyncProvider on other platforms.
+  vsync::VsyncProviderPtr vsync_provider;
+  mojo::ConnectToService(service_provider.get(), &vsync_provider);
+  animator_->set_vsync_provider(vsync_provider.Pass());
+#endif
 }
 
 Engine::~Engine() {


### PR DESCRIPTION
Instead of using back pressure from swap buffers to drive the engine, this
patch using the vsync signal from the Android framework. We still respect
back pressure from swap buffers if we get too far ahead.