### PR TITLE
Make SkyShell.app work

### DIFF
--- a/sky/shell/mac/Info.plist
+++ b/sky/shell/mac/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
-	<string>Sky</string>
+	<string>SkyShell</string>
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
It was looking for the wrong executable name.