### PR TITLE
Fix spurious skyanalyzer failures

### DIFF
--- a/sky/tools/skyanalyzer
+++ b/sky/tools/skyanalyzer
@@ -26,7 +26,7 @@ _IGNORED_PATTERNS = [
   re.compile(r'^([0-9]+|No) (error|warning|issue)s? found.'),
 
   # Ignore analyzer status output.
-  re.compile(r'^[0-9]+ errors, [0-9]+ warnings and [0-9]+ hints found.'),
+  re.compile(r'^[0-9]+ errors(, [0-9]+ warnings)? and [0-9]+ hints found.'),
 
   # Ignored because they don't affect Sky code
   re.compile(r'\[hint\] When compiled to JS, this test might return true when the left hand side is an int'),
@@ -35,8 +35,8 @@ _IGNORED_PATTERNS = [
   re.compile(r'^\[error\] Native functions can only be declared in'),
 
   # TODO: Fix all the warnings in the mojo packages
-  re.compile(r'.*/dart-pkg/mojom/'),
-  re.compile(r'.*/dart-pkg/mojo/'),
+  re.compile(r'.*dart-pub-cache.*/mojom-'),
+  re.compile(r'.*dart-pub-cache.*/mojo-'),
   re.compile(r'.*/mojo/public/dart/'),
 
   # TODO: Remove this once Sky no longer generates this warning.


### PR DESCRIPTION
We need to update our regexps because we moved the mojom and mojo packages.