### PR TITLE
Fix CreatePlatformServiceProvider to allow calling more than once.

### DIFF
--- a/sky/shell/testing/test_runner.h
+++ b/sky/shell/testing/test_runner.h
@@ -34,11 +34,11 @@ class TestRunner : public mojo::InterfaceFactory<TestHarness>,
 
   void Start(scoped_ptr<SingleTest> single_test);
 
- private:
   // mojo::InterfaceFactory<TestHarness> implementation:
   void Create(mojo::ApplicationConnection* app,
               mojo::InterfaceRequest<TestHarness> request) override;
 
+ private:
   // TestHarness implementation:
   void OnTestComplete(const mojo::String& test_result,
                       const mojo::Array<uint8_t> pixels) override;


### PR DESCRIPTION
The previous implementation would (silently) delete any previous
ServiceProviderImpl which would close all open mojo pipes.
This would manfiest in the mojo:network_service never
responding to Dart's request for loads.

This mostly fixes issue #256, however there still appears to be
a separate display-only race, which may be related to issue #52.

R=abarth@google.com