### PR TITLE
Remove pub spam during the build

### DIFF
--- a/sky/build/sky_init.py
+++ b/sky/build/sky_init.py
@@ -13,13 +13,16 @@ SRC_ROOT = os.path.dirname(os.path.dirname(SKY_BUILD_DIR))
 WORKBENCH = os.path.join(SRC_ROOT, 'sky', 'packages', 'workbench')
 DART_SDK = os.path.join(SRC_ROOT, 'third_party', 'dart-sdk', 'dart-sdk', 'bin')
 PUB = os.path.join(DART_SDK, 'pub')
+PUB_CACHE = os.path.join(SRC_ROOT, "dart-pub-cache")
 
 def main():
     parser = argparse.ArgumentParser(description='Packaging tool for Sky apps')
     parser.add_argument('--touch', type=str)
     args = parser.parse_args()
 
-    subprocess.check_call([PUB, 'run', 'sky:init'], cwd=WORKBENCH)
+    env = os.environ.copy()
+    env["PUB_CACHE"] = PUB_CACHE
+    subprocess.check_call([PUB, 'run', 'sky:init'], cwd=WORKBENCH, env=env)
 
     if args.touch:
         with open(os.path.abspath(args.touch), 'w') as f:

--- a/sky/tools/skypy/skyserver.py
+++ b/sky/tools/skypy/skyserver.py
@@ -13,6 +13,7 @@ SRC_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(SKYPY_PATH)))
 WORKBENCH_ROOT = os.path.join(SRC_ROOT, 'sky', 'packages', 'workbench')
 DART_SDK = os.path.join(SRC_ROOT, 'third_party', 'dart-sdk', 'dart-sdk', 'bin')
 PUB = os.path.join(DART_SDK, 'pub')
+PUB_CACHE = os.path.join(SRC_ROOT, "dart-pub-cache")
 
 class SkyServer(object):
     def __init__(self, port, root, package_root):
@@ -33,9 +34,11 @@ class SkyServer(object):
                 self.port)
             return
 
-        subprocess.check_call([PUB, 'run', 'sky:init'], cwd=WORKBENCH_ROOT)
+        env = os.environ.copy()
+        env["PUB_CACHE"] = PUB_CACHE
+        subprocess.check_call([PUB, 'run', 'sky:init'], cwd=WORKBENCH_ROOT, env=env)
         args = [PUB, 'run', 'sky_tools:sky_server', str(self.port)]
-        self.server = subprocess.Popen(args, cwd=WORKBENCH_ROOT)
+        self.server = subprocess.Popen(args, cwd=WORKBENCH_ROOT, env=env)
         return self.server.pid
 
     def stop(self):


### PR DESCRIPTION
When using `pub run`, we need to set the PUB_CACHE environment variable to
//dart-pub-cache in order to use the Dart packages we downloaded during
`gclient sync`.