### PR TITLE
Import mojom.dart files from package:mojom

### DIFF
--- a/sky/packages/sky/lib/mojo/embedder.dart
+++ b/sky/packages/sky/lib/mojo/embedder.dart
@@ -7,9 +7,9 @@ import "dart:sky.internals" as internals;
 import "package:mojo/application.dart";
 import "package:mojo/bindings.dart" as bindings;
 import "package:mojo/core.dart" as core;
-import "package:mojo/mojom/mojo/service_provider.mojom.dart";
-import "package:mojo/mojom/mojo/shell.mojom.dart";
+import "package:mojom/mojo/service_provider.mojom.dart";
 import "package:mojom/mojo/service_registry.mojom.dart";
+import "package:mojom/mojo/shell.mojom.dart";
 
 final _EmbedderImpl embedder = new _EmbedderImpl();
 

--- a/sky/packages/sky/lib/mojo/shell.dart
+++ b/sky/packages/sky/lib/mojo/shell.dart
@@ -6,7 +6,7 @@ import 'dart:sky.internals' as internals;
 
 import 'package:mojo/application.dart';
 import 'package:mojo/core.dart' as core;
-import 'package:mojo/mojom/mojo/service_provider.mojom.dart';
+import 'package:mojom/mojo/service_provider.mojom.dart';
 import 'package:sky/mojo/embedder.dart';
 
 ApplicationConnection _initConnection() {


### PR DESCRIPTION
I incorrectly thought we were now supposed to import these mojoms from the
packages that publish them. However, we're still supposed to import them from
the virtual mojom package.