### PR TITLE
Sporadic crash from invalid touch event

### DIFF
--- a/sky/packages/sky/lib/rendering/sky_binding.dart
+++ b/sky/packages/sky/lib/rendering/sky_binding.dart
@@ -102,27 +102,23 @@ class SkyBinding {
     return state;
   }
 
+  PointerState _getOrCreateStateForPointer(event, position) {
+    PointerState state = _stateForPointer[event.pointer];
+    if (state == null)
+      state = _createStateForPointer(event, position);
+    return state;
+  }
+
   void _handlePointerEvent(sky.PointerEvent event) {
     Point position = new Point(event.x, event.y);
 
-    PointerState state;
-    switch(event.type) {
-      case 'pointerdown':
-        state = _createStateForPointer(event, position);
-        break;
-      case 'pointerup':
-      case 'pointercancel':
-        state = _stateForPointer[event.pointer];
-        if (_hammingWeight(event.buttons) <= 1)
-          _stateForPointer.remove(event.pointer);
-        break;
-      case 'pointermove':
-        state = _stateForPointer[event.pointer];
-        // In the case of mouse hover we won't already have a cached down.
-        if (state == null)
-          state = _createStateForPointer(event, position);
-        break;
+    PointerState state = _getOrCreateStateForPointer(event, position);
+
+    if (event.type == 'pointerup' || event.type == 'pointercancel') {
+      if (_hammingWeight(event.buttons) <= 1)
+        _stateForPointer.remove(event.pointer);
     }
+
     event.dx = position.x - state.lastPosition.x;
     event.dy = position.y - state.lastPosition.y;
     state.lastPosition = position;


### PR DESCRIPTION
When embedded by the view_manager, sometimes we receive pointerup or
pointercancel events without having received a cooresponding pointerdown event.
The underlying issue is that the view_manager doesn't capture on pointerdown
and instead performs a new hit test for every pointer event. We should fix that
in view_manager, but, in the meantime, this patch makes us not crash in this
scenario.

Fixes #339