### PR TITLE
RenderStack should handle top, right, bottom, left all being zero

### DIFF
--- a/sky/packages/sky/lib/rendering/stack.dart
+++ b/sky/packages/sky/lib/rendering/stack.dart
@@ -155,14 +155,14 @@ class RenderStack extends RenderBox with ContainerRenderObjectMixin<RenderBox, S
         BoxConstraints childConstraints = innerConstraints;
 
         if (childData.left != null && childData.right != null)
-          childConstraints = childConstraints.applyWidth(childData.right - childData.left);
+          childConstraints = childConstraints.applyWidth(size.width - childData.right - childData.left);
         else if (childData.left != null)
           childConstraints = childConstraints.applyMaxWidth(size.width - childData.left);
         else if (childData.right != null)
           childConstraints = childConstraints.applyMaxWidth(size.width - childData.right);
 
         if (childData.top != null && childData.bottom != null)
-          childConstraints = childConstraints.applyHeight(childData.bottom - childData.top);
+          childConstraints = childConstraints.applyHeight(size.height - childData.bottom - childData.top);
         else if (childData.top != null)
           childConstraints = childConstraints.applyMaxHeight(size.height - childData.top);
         else if (childData.bottom != null)

--- a/sky/tests/layout/tight_block-expected.txt
+++ b/sky/tests/layout/tight_block-expected.txt
@@ -1,0 +1,18 @@
+TestRenderView enabled
+
+PAINT FOR FRAME #1 ----------------------------------------------
+1 | TestPaintingCanvas() constructor: 800.0 x 600.0
+1 | paintChild RenderPositionedBox at Point(0.0, 0.0)
+1 |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+1 |  | paintChild RenderStack at Point(350.0, 250.0)
+1 |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+1 |  |  | paintChild RenderDecoratedBox at Point(350.0, 250.0)
+1 |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+1 |  |  |  | drawRect(Rect.fromLTRB(350.0, 250.0, 450.0, 350.0), Paint(color:Color(0xffff0000)))
+1 |  |  |  | paintChild RenderConstrainedBox at Point(350.0, 250.0)
+1 |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+1 |  |  | paintChild RenderDecoratedBox at Point(350.0, 250.0)
+1 |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+1 |  |  |  | drawRect(Rect.fromLTRB(350.0, 250.0, 450.0, 350.0), Paint(color:Color(0xffff0000)))
+------------------------------------------------------------------------
+PAINTED 1 FRAMES

--- a/sky/tests/layout/tight_block.dart
+++ b/sky/tests/layout/tight_block.dart
@@ -1,0 +1,34 @@
+import 'dart:math' as math;
+import 'dart:sky' as sky;
+
+import 'package:sky/rendering/box.dart';
+import 'package:sky/rendering/stack.dart';
+import 'package:sky/rendering/object.dart';
+
+import '../resources/display_list.dart';
+
+void main() {
+  RenderBox size = new RenderConstrainedBox(
+    additionalConstraints: new BoxConstraints.tight(const Size(100.0, 100.0)));
+
+  RenderBox red = new RenderDecoratedBox(
+    decoration: new BoxDecoration(
+      backgroundColor: const sky.Color(0xFFFF0000)
+    ),
+    child: size);
+
+  RenderBox green = new RenderDecoratedBox(
+    decoration: new BoxDecoration(
+      backgroundColor: const sky.Color(0xFFFF0000)
+    ));
+
+  RenderBox stack = new RenderStack(children: [red, green]);
+  (green.parentData as StackParentData)
+    ..left = 0.0
+    ..right = 0.0
+    ..bottom = 0.0
+    ..top = 0.0;
+
+  RenderBox center = new RenderPositionedBox(child: stack);
+  new TestRenderView(center).endTest();
+}


### PR DESCRIPTION
Previously, we didn't set the width of the child correctly when top and bottom
(or left and right) were both specified.

Fixes #275