### PR TITLE
Lower sky package requirements

### DIFF
--- a/sky/packages/sky/pubspec.yaml
+++ b/sky/packages/sky/pubspec.yaml
@@ -9,8 +9,8 @@ dependencies:
   mojo_services: 0.0.21
   mojo: 0.0.21
   newton: ^0.1.2
-  sky_engine: ^0.0.3
-  sky_services: ^0.0.4
+  sky_engine: ^0.0.2
+  sky_services: ^0.0.3
   sky_tools: ^0.0.4
   vector_math: ^1.4.3
 environment:


### PR DESCRIPTION
I misread the release process. gclient sync won't succeed without this.