### PR TITLE
Stacked does not repaint when its position changes

### DIFF
--- a/sky/packages/sky/lib/widgets/widget.dart
+++ b/sky/packages/sky/lib/widgets/widget.dart
@@ -887,8 +887,8 @@ abstract class RenderObjectWrapper extends Widget {
     if (parentData != null) {
       assert(root.parentData != null);
       root.parentData.merge(parentData); // this will throw if the types aren't appropriate
-      if (parent.root != null)
-        parent.root.markNeedsLayout();
+      if (ancestor != null && ancestor.root != null)
+        ancestor.root.markNeedsLayout();
     }
   }
 

--- a/sky/tests/resources/display_list.dart
+++ b/sky/tests/resources/display_list.dart
@@ -178,9 +178,11 @@ class TestApp extends App {
 class WidgetTester {
   TestRenderView renderView = new TestRenderView();
 
-  Future test(Function builder) {
+  Future test(Function builder, { int frameCount: 1 }) async {
     runApp(new TestApp(builder: builder), renderViewOverride: renderView);
-    return renderView.checkFrame();
+    while (--frameCount != 0)
+      await renderView.checkFrame();
+    return await renderView.checkFrame();
   }
 
   void endTest() {

--- a/sky/tests/widgets/stack_relayout_from_parent_data-expected.txt
+++ b/sky/tests/widgets/stack_relayout_from_parent_data-expected.txt
@@ -1,0 +1,30 @@
+TestRenderView enabled
+
+PAINT FOR FRAME #1 ----------------------------------------------
+1 | TestPaintingCanvas() constructor: 800.0 x 600.0
+------------------------------------------------------------------------
+
+PAINT FOR FRAME #2 ----------------------------------------------
+2 | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 | paintChild RenderSizeObserver at Point(0.0, 0.0)
+2 |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  | paintChild RenderStack at Point(0.0, 0.0)
+2 |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  | paintChild RenderParagraph at Point(50.0, 50.0)
+2 |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  | translate(50.0, 50.0)
+2 |  |  |  | translate(-50.0, -50.0)
+------------------------------------------------------------------------
+
+PAINT FOR FRAME #3 ----------------------------------------------
+3 | TestPaintingCanvas() constructor: 800.0 x 600.0
+3 | paintChild RenderSizeObserver at Point(0.0, 0.0)
+3 |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+3 |  | paintChild RenderStack at Point(0.0, 0.0)
+3 |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+3 |  |  | paintChild RenderParagraph at Point(400.0, 300.0)
+3 |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+3 |  |  |  | translate(400.0, 300.0)
+3 |  |  |  | translate(-400.0, -300.0)
+------------------------------------------------------------------------
+PAINTED 3 FRAMES

--- a/sky/tests/widgets/stack_relayout_from_parent_data.dart
+++ b/sky/tests/widgets/stack_relayout_from_parent_data.dart
@@ -1,0 +1,49 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:sky/widgets/basic.dart';
+
+import '../resources/display_list.dart';
+
+class ChildComponent extends Component {
+  ChildComponent(this.size);
+
+  final Size size;
+
+  Widget build() {
+    String text = "This text should be roughly centered";
+    return new Positioned(child: new Text(text),
+        top: size.height / 2.0, left: size.width / 2.0);
+  }
+}
+
+class ParentComponent extends StatefulComponent {
+  Size _size = new Size(100.0, 100.0);
+
+  void syncFields(ParentComponent source) {
+  }
+
+  Widget build() {
+    return new SizeObserver(
+      child : new Stack([new ChildComponent(_size)]),
+      callback : sizeCallback
+    );
+  }
+
+  void sizeCallback(Size size) {
+    setState(() {
+      _size = size;
+    });
+  }
+}
+
+main() async {
+  WidgetTester tester = new WidgetTester();
+
+  await tester.test(() {
+    return new ParentComponent();
+  }, frameCount: 2);
+
+  tester.endTest();
+}


### PR DESCRIPTION
We were marking the parent *Widget's* render object as needing layout, but
we actually need to walk up the component tree until we find the parent
*RenderObjectWrapper* so we can mark actually mark the parent render object as
needing layout.

Fixes #408