### PR TITLE
Allow iOS apps to restart by copying the app.skyx to the Documents directory on the device.

### DIFF
--- a/sky/shell/BUILD.gn
+++ b/sky/shell/BUILD.gn
@@ -174,6 +174,7 @@ if (is_android) {
 
   source_set("ios_scaffolding") {
     sources = [
+      "ios/document_watcher.m",
       "ios/main_ios.mm",
       "ios/sky_app_delegate.h",
       "ios/sky_app_delegate.mm",

--- a/sky/shell/ios/document_watcher.h
+++ b/sky/shell/ios/document_watcher.h
@@ -1,0 +1,13 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef NDEBUG
+#import <Foundation/Foundation.h>
+
+@interface DocumentWatcher : NSThread
+- (instancetype)initWithDocumentPath:(NSString*)path callbackBlock:(void (^)(void))callbackBlock;
+- (void)cancel;
+@end
+
+#endif // !NDEBUG

--- a/sky/shell/ios/document_watcher.m
+++ b/sky/shell/ios/document_watcher.m
@@ -1,0 +1,100 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#ifndef NDEBUG
+#import "document_watcher.h"
+
+@interface DocumentWatcher ()
+
+@property(nonatomic, readonly) NSDate* lastModifiedDate;
+@property (copy) void (^callbackBlock)(void);
+
+@end
+
+@implementation DocumentWatcher {
+  NSString* _documentPath;
+  NSTimer* _timer;
+  CFRunLoopRef _loop;
+}
+
+@synthesize lastModifiedDate = _lastModifiedDate;
+
+- (instancetype)initWithDocumentPath:(NSString*)path callbackBlock:(void (^)(void))callbackBlock {
+  self = [super init];
+
+  if (self) {
+    _documentPath = path;
+    self.callbackBlock = callbackBlock;
+
+    [self start];
+  }
+
+  return self;
+}
+
+- (void)main {
+  [self onCheck:nil];
+  _timer = [[NSTimer scheduledTimerWithTimeInterval:1.0
+                                             target:self
+                                           selector:@selector(onCheck:)
+                                           userInfo:nil
+                                            repeats:YES] retain];
+  while (!self.isCancelled) {
+    _loop = CFRunLoopGetCurrent();
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode,
+                       [[NSDate distantFuture] timeIntervalSinceNow], YES);
+  }
+}
+
+- (void)_setLastModifiedDate:(NSDate*)lastModifiedDate path:(NSString*)path {
+  if ([_lastModifiedDate isEqualToDate:lastModifiedDate]) {
+    return;
+  }
+
+  [_lastModifiedDate release];
+  _lastModifiedDate = [lastModifiedDate retain];
+
+  if (_lastModifiedDate == nil && lastModifiedDate == nil) {
+    return;
+  }
+
+  dispatch_async(dispatch_get_main_queue(), self.callbackBlock);
+}
+
+- (void)onCheck:(id)sender {
+  if (![[NSFileManager defaultManager] fileExistsAtPath:_documentPath]) {
+    return;
+  }
+
+  NSError* error = nil;
+  NSDictionary* attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:_documentPath
+                                                                              error:&error];
+  if (error != nil) {
+    NSLog(@"[DocumentWatcher onCheck]: error reading attributes for path %@: %@", _documentPath, error);
+    return;
+  }
+
+  [self _setLastModifiedDate:attributes.fileModificationDate path:_documentPath];
+}
+
+- (void)cancel {
+  [_timer invalidate];
+  [_timer release];
+  _timer = nil;
+
+  if (_loop) {
+    CFRunLoopWakeUp(_loop);
+    _loop = NULL;
+  }
+
+  [super cancel];
+}
+
+- (void)dealloc {
+  [_documentPath release];
+  [_lastModifiedDate release];
+  [super dealloc];
+}
+
+@end
+#endif // !NDEBUG


### PR DESCRIPTION
This work is to support a workflow where developers testing on an iOS
device will automatically see their app updates as they change their Sky
code. Currently this works by using the ios-deploy tool:
$ ios-deploy --bundle_id 'org.domokit.sky.game' --upload out/ios_Debug/game_app.app/app.skyx --to Documents/app.skyx
Upcoming commits will incorporate this into skytool.