### PR TITLE
Fix visual bugs in Stocks

### DIFF
--- a/sky/packages/sky/lib/widgets/drawer.dart
+++ b/sky/packages/sky/lib/widgets/drawer.dart
@@ -68,8 +68,11 @@ class Drawer extends StatefulComponent {
     // while dragging.
     _performance.attachedForce = kDefaultSpringForce;
 
-    if (navigator != null)
-      navigator.pushState(this, (_) => _performance.reverse());
+    if (navigator != null) {
+      scheduleMicrotask(() {
+        navigator.pushState(this, (_) => _performance.reverse());
+      });
+    }
   }
 
   void syncFields(Drawer source) {
@@ -85,7 +88,8 @@ class Drawer extends StatefulComponent {
       child: new ColorTransition(
         performance: _performance,
         direction: showing ? Direction.forward : Direction.reverse,
-        color: new AnimatedColorValue(colors.transparent, end: const Color(0x7F000000))
+        color: new AnimatedColorValue(colors.transparent, end: const Color(0x7F000000)),
+        child: new Container()
       ),
       onGestureTap: handleMaskTap
     );

--- a/sky/packages/sky/lib/widgets/tabs.dart
+++ b/sky/packages/sky/lib/widgets/tabs.dart
@@ -34,7 +34,6 @@ const double _kMinTabWidth = 72.0;
 const double _kMaxTabWidth = 264.0;
 const double _kRelativeMaxTabWidth = 56.0;
 const EdgeDims _kTabLabelPadding = const EdgeDims.symmetric(horizontal: 12.0);
-const TextStyle _kTabTextStyle = const TextStyle(textAlign: TextAlign.center);
 const int _kTabIconSize = 24;
 const double _kTabBarScrollDrag = 0.025;
 const Duration _kTabBarScroll = const Duration(milliseconds: 200);
@@ -322,7 +321,7 @@ class Tab extends Component {
 
   Widget _buildLabelText() {
     assert(label.text != null);
-    return new Text(label.text, style: _kTabTextStyle);
+    return new Text(label.text);
   }
 
   Widget _buildLabelIcon() {


### PR DESCRIPTION
- Center the labels on the tabs
 - Make the drawer's mask visible