### PR TITLE
Switch the default whitespace mode to pre-line

### DIFF
--- a/sky/engine/core/rendering/style/RenderStyle.h
+++ b/sky/engine/core/rendering/style/RenderStyle.h
@@ -969,7 +969,7 @@ public:
     static EPosition initialPosition() { return StaticPosition; }
     static EUnicodeBidi initialUnicodeBidi() { return UBNormal; }
     static EVisibility initialVisibility() { return VISIBLE; }
-    static EWhiteSpace initialWhiteSpace() { return PRE_WRAP; }
+    static EWhiteSpace initialWhiteSpace() { return PRE_LINE; }
     static short initialHorizontalBorderSpacing() { return 0; }
     static short initialVerticalBorderSpacing() { return 0; }
     static Color initialColor() { return Color::white; }


### PR DESCRIPTION
This mode will preserve new lines, allow breaks, but collapse whitespace. That
means whitespace at the start of lines will be collapsed.