### PR TITLE
Improve scrollable tabs performance

### DIFF
--- a/sky/packages/sky/lib/widgets/basic.dart
+++ b/sky/packages/sky/lib/widgets/basic.dart
@@ -538,6 +538,7 @@ class FutureImage extends StatefulComponent {
     image = source.image;
     width = source.width;
     height = source.height;
+    colorFilter = source.colorFilter;
     if (needToResolveImage)
       _resolveImage();
   }


### PR DESCRIPTION
By removing the Opacity node used to highlight the selected tab's text/icon, TabBar scrolling performance is no longer dominated by the GPU.
