### PR TITLE
Fix RenderViewport's hit testing

### DIFF
--- a/sky/packages/sky/lib/rendering/box.dart
+++ b/sky/packages/sky/lib/rendering/box.dart
@@ -1240,11 +1240,11 @@ class RenderViewport extends RenderBox with RenderObjectWithChildMixin<RenderBox
     if (child != null) {
       assert(child.parentData is BoxParentData);
       Rect childBounds = child.parentData.position & child.size;
-      if (childBounds.contains(position + -scrollOffset))
-        child.hitTest(result, position: position + scrollOffset);
+      Point transformedPosition = position + scrollOffset;
+      if (childBounds.contains(transformedPosition))
+        child.hitTest(result, position: transformedPosition);
     }
   }
-
 }
 
 class RenderImage extends RenderBox {

--- a/sky/tests/layout/viewport_hit_test-expected.txt
+++ b/sky/tests/layout/viewport_hit_test-expected.txt
@@ -1,0 +1,21 @@
+unittest-suite-wait-for-done
+TestRenderView enabled
+
+PAINT FOR FRAME #1 ----------------------------------------------
+1 | TestPaintingCanvas() constructor: 800.0 x 600.0
+1 | paintChild RenderViewport at Point(0.0, 0.0)
+1 |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+1 |  | save
+1 |  | clipRect(Rect.fromLTRB(0.0, 0.0, 800.0, 600.0))
+1 |  | paintChild RenderDecoratedBox at Point(0.0, 10.0)
+1 |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+1 |  |  | drawRect(Rect.fromLTRB(0.0, 10.0, 800.0, 110.0), Paint(color:Color(0xffff0000)))
+1 |  |  | paintChild RenderConstrainedBox at Point(0.0, 10.0)
+1 |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+1 |  | restore
+------------------------------------------------------------------------
+PASS: Should be able to hit with negative scroll offset
+
+All 1 tests passed.
+unittest-suite-success
+DONE

--- a/sky/tests/layout/viewport_hit_test.dart
+++ b/sky/tests/layout/viewport_hit_test.dart
@@ -1,0 +1,34 @@
+import 'package:sky/rendering/box.dart';
+import 'package:sky/rendering/object.dart';
+
+import '../resources/display_list.dart';
+import '../resources/third_party/unittest/unittest.dart';
+import '../resources/unit.dart';
+
+void main() {
+  initUnit();
+
+  test('Should be able to hit with negative scroll offset', () {
+    RenderBox size = new RenderConstrainedBox(
+      additionalConstraints: new BoxConstraints.tight(const Size(100.0, 100.0)));
+  
+    RenderBox red = new RenderDecoratedBox(
+      decoration: new BoxDecoration(
+        backgroundColor: const Color(0xFFFF0000)
+      ),
+      child: size);
+  
+    RenderViewport viewport = new RenderViewport(child: red, scrollOffset: new Offset(0.0, -10.0));
+    TestRenderView renderView = new TestRenderView(viewport);
+  
+    HitTestResult result;
+
+    result = new HitTestResult();  
+    renderView.hitTest(result, position: new Point(15.0, 0.0));
+    expect(result.path.first.target, equals(viewport));
+
+    result = new HitTestResult();  
+    renderView.hitTest(result, position: new Point(15.0, 15.0));
+    expect(result.path.first.target, equals(size));
+  });
+}


### PR DESCRIPTION
We were subtracting the scrollOffset when we were supposed to add it.