### PR TITLE
Unbreak text

### DIFF
--- a/sky/packages/sky/lib/rendering/paragraph.dart
+++ b/sky/packages/sky/lib/rendering/paragraph.dart
@@ -102,8 +102,9 @@ double _applyFloatingPointHack(double layoutValue) {
 
 class RenderParagraph extends RenderBox {
 
-  RenderParagraph(this._inline) {
+  RenderParagraph(RenderInline inline) {
     _layoutRoot.rootElement = _document.createElement('p');
+    this.inline = inline;
   }
 
   final sky.Document _document = new sky.Document();


### PR DESCRIPTION
Previously, no text was appearing because we weren't actually converting the
Dart objects into DOM.