### PR TITLE
Use localToGlobal and globalToLocal in MimicOverlay

### DIFF
--- a/sky/packages/sky/lib/widgets/mimic.dart
+++ b/sky/packages/sky/lib/widgets/mimic.dart
@@ -120,8 +120,7 @@ class Mimicable extends StatefulComponent {
     if (_didStartMimic)
       return;
     assert(_mimic != null);
-    // TODO(abarth): We'll need to convert Point.origin to global coordinates.
-    Point globalPosition = Point.origin;
+    Point globalPosition = localToGlobal(Point.origin);
     _mimic._startMimic(key, globalPosition & _size);
     _didStartMimic = true;
   }

--- a/sky/packages/sky/lib/widgets/mimic_overlay.dart
+++ b/sky/packages/sky/lib/widgets/mimic_overlay.dart
@@ -69,7 +69,7 @@ class MimicOverlay extends AnimatedComponent {
   void _handleMimicCallback(Rect globalBounds) {
     setState(() {
       // TODO(abarth): We need to convert global bounds into local coordinates.
-      _mimicBounds.begin = globalBounds;
+      _mimicBounds.begin = globalToLocal(globalBounds.topLeft) & globalBounds.size;
       _expandPerformance.forward();
     });
   }


### PR DESCRIPTION
Also, make RenderStack support negative positions with clipping so that we can
expand objects that are partially offscreen.