### PR TITLE
Remove the flicker from MimicOverlay

### DIFF
--- a/sky/packages/sky/lib/widgets/mimic_overlay.dart
+++ b/sky/packages/sky/lib/widgets/mimic_overlay.dart
@@ -70,8 +70,9 @@ class MimicOverlay extends AnimatedComponent {
     setState(() {
       // TODO(abarth): We need to convert global bounds into local coordinates.
       _mimicBounds.begin = globalToLocal(globalBounds.topLeft) & globalBounds.size;
-      _expandPerformance.forward();
+      _mimicBounds.value = _mimicBounds.begin;
     });
+    _expandPerformance.forward();
   }
 
   Widget build() {


### PR DESCRIPTION
There were two problems:

1) When starting the mimic, we put up a bad frame because although we set the
   `begin` value of the animation, we were building using the current `value`,
   which hadn't been updated.

2) When stoping the mimic, we'd dirty a component during didUnmount, which
   wouldn't get cleaned until the next frame. Now we're sure to clean all the
   components before leaving flushBuild.