### PR TITLE
Simplify SkPicture

### DIFF
--- a/examples/raw/baseline.dart
+++ b/examples/raw/baseline.dart
@@ -47,7 +47,9 @@ void drawText(sky.Canvas canvas, String lh) {
 void main() {
   // prepare the rendering
   sky.PictureRecorder recorder = new sky.PictureRecorder();
-  sky.Canvas canvas = new sky.Canvas(recorder, new sky.Rect.fromLTWH(0.0, 0.0, sky.view.width, sky.view.height));
+  final double devicePixelRatio = sky.view.devicePixelRatio;
+  sky.Canvas canvas = new sky.Canvas(recorder, new sky.Rect.fromLTWH(0.0, 0.0, sky.view.width * devicePixelRatio, sky.view.height * devicePixelRatio));
+  canvas.scale(devicePixelRatio, devicePixelRatio);
 
   // background
   sky.Paint paint = new sky.Paint();

--- a/examples/raw/hello_world.dart
+++ b/examples/raw/hello_world.dart
@@ -8,7 +8,9 @@ Picture draw(int a, int r, int g, int b) {
   Size size = new Size(view.width, view.height);
 
   PictureRecorder recorder = new PictureRecorder();
-  Canvas canvas = new Canvas(recorder, Point.origin & size);
+  final double devicePixelRatio = sky.view.devicePixelRatio;
+  Canvas canvas = new Canvas(recorder, Point.origin & (size * devicePixelRatio));
+  canvas.scale(devicePixelRatio, devicePixelRatio);
   double radius = size.shortestSide * 0.45;
 
   Paint paint = new Paint()..color = new Color.fromARGB(a, r, g, b);

--- a/examples/raw/mutating-dom.dart
+++ b/examples/raw/mutating-dom.dart
@@ -202,7 +202,9 @@ void doFrame(double timeStamp) {
   // draw the result
   report("recording...");
   sky.PictureRecorder recorder = new sky.PictureRecorder();
-  sky.Canvas canvas = new sky.Canvas(recorder, new sky.Rect.fromLTWH(0.0, 0.0, sky.view.width, sky.view.height));
+  final double devicePixelRatio = sky.view.devicePixelRatio;
+  sky.Canvas canvas = new sky.Canvas(recorder, new sky.Rect.fromLTWH(0.0, 0.0, sky.view.width * devicePixelRatio, sky.view.height * devicePixelRatio));
+  canvas.scale(devicePixelRatio, devicePixelRatio);
   layoutRoot.maxWidth = sky.view.width;
   layoutRoot.layout();
   layoutRoot.paint(canvas);

--- a/examples/raw/painting.dart
+++ b/examples/raw/painting.dart
@@ -9,7 +9,9 @@ import 'dart:typed_data';
 void beginFrame(double timeStamp) {
   sky.Size size = new sky.Size(sky.view.width, sky.view.height);
   sky.PictureRecorder recorder = new sky.PictureRecorder();
-  sky.Canvas canvas = new sky.Canvas(recorder, sky.Point.origin & size);
+  final double devicePixelRatio = sky.view.devicePixelRatio;
+  sky.Canvas canvas = new sky.Canvas(recorder, sky.Point.origin & (size * devicePixelRatio));
+  canvas.scale(devicePixelRatio, devicePixelRatio);
 
   sky.Paint paint = new sky.Paint();
   sky.Point mid = size.center(sky.Point.origin);

--- a/examples/raw/painting_node.dart
+++ b/examples/raw/painting_node.dart
@@ -6,11 +6,12 @@ import 'dart:sky';
 
 PaintingNode paintingNode = null;
 Picture draw(int a, int r, int g, int b) {
-  Rect bounds = new Rect.fromLTRB(0.0, 0.0, view.width, view.height);
+  final double devicePixelRatio = view.devicePixelRatio;
   Size size = new Size(view.width, view.height);
 
   PictureRecorder recorder = new PictureRecorder();
-  Canvas canvas = new Canvas(recorder, bounds);
+  Canvas canvas = new Canvas(recorder, new Rect.fromLTRB(0.0, 0.0, view.width * devicePixelRatio, view.height * devicePixelRatio));
+  canvas.scale(devicePixelRatio, devicePixelRatio);
   double radius = size.shortestSide * 0.45;
 
   Paint paint = new Paint()..color = new Color.fromARGB(a, r, g, b);
@@ -20,7 +21,7 @@ Picture draw(int a, int r, int g, int b) {
     paintingNode = new PaintingNode();
     Paint innerPaint = new Paint()..color = new Color.fromARGB(a, 255 - r, 255 - g, 255 - b);
     PictureRecorder innerRecorder = new PictureRecorder();
-    Canvas innerCanvas = new Canvas(innerRecorder, bounds);
+    Canvas innerCanvas = new Canvas(innerRecorder, Point.origin & bounds);
     innerCanvas.drawCircle(size.center(Point.origin), radius * 0.5, innerPaint);
 
     paintingNode.setBackingDrawable(innerRecorder.endRecordingAsDrawable());

--- a/examples/raw/shadow.dart
+++ b/examples/raw/shadow.dart
@@ -7,7 +7,9 @@ import 'dart:sky';
 void beginFrame(double timeStamp) {
   double size = 100.0;
   PictureRecorder recorder = new PictureRecorder();
-  Canvas canvas = new Canvas(recorder, new Rect.fromLTWH(0.0, 0.0, view.width, view.height));
+  final double devicePixelRatio = view.devicePixelRatio;
+  Canvas canvas = new Canvas(recorder, new Rect.fromLTWH(0.0, 0.0, view.width * devicePixelRatio, view.height * devicePixelRatio));
+  canvas.scale(devicePixelRatio, devicePixelRatio);
   canvas.translate(size + 10.0, size + 10.0);
 
   Paint paint = new Paint();

--- a/examples/raw/spinning_arabic.dart
+++ b/examples/raw/spinning_arabic.dart
@@ -13,7 +13,9 @@ void beginFrame(double timeStamp) {
     timeBase = timeStamp;
   double delta = timeStamp - timeBase;
   PictureRecorder recorder = new PictureRecorder();
-  Canvas canvas = new Canvas(recorder, new Rect.fromLTWH(0.0, 0.0, view.width, view.height));
+  final double devicePixelRatio = view.devicePixelRatio;
+  Canvas canvas = new Canvas(recorder, new Rect.fromLTWH(0.0, 0.0, view.width * devicePixelRatio, view.height * devicePixelRatio));
+  canvas.scale(devicePixelRatio, devicePixelRatio);
   canvas.translate(view.width / 2.0, view.height / 2.0);
   canvas.rotate(math.PI * delta / 1800);
   canvas.drawRect(new Rect.fromLTRB(-100.0, -100.0, 100.0, 100.0),

--- a/examples/raw/spinning_image.dart
+++ b/examples/raw/spinning_image.dart
@@ -18,7 +18,9 @@ void beginFrame(double timeStamp) {
     timeBase = timeStamp;
   double delta = timeStamp - timeBase;
   PictureRecorder recorder = new PictureRecorder();
-  Canvas canvas = new Canvas(recorder, Point.origin & new Size(view.width, view.height));
+  final double devicePixelRatio = view.devicePixelRatio;
+  Canvas canvas = new Canvas(recorder, Point.origin & new Size(view.width * devicePixelRatio, view.height * devicePixelRatio));
+  cavnas.scale(devicePixelRatio, devicePixelRatio);
   canvas.translate(view.width / 2.0, view.height / 2.0);
   canvas.rotate(math.PI * delta / 1800);
   canvas.scale(0.2, 0.2);

--- a/examples/raw/spinning_square.dart
+++ b/examples/raw/spinning_square.dart
@@ -13,7 +13,9 @@ void beginFrame(double timeStamp) {
     timeBase = timeStamp;
   double delta = timeStamp - timeBase;
   PictureRecorder recorder = new PictureRecorder();
-  Canvas canvas = new Canvas(recorder, new Rect.fromLTWH(0.0, 0.0, view.width, view.height));
+  final double devicePixelRatio = view.devicePixelRatio;
+  Canvas canvas = new Canvas(recorder, new Rect.fromLTWH(0.0, 0.0, view.width * devicePixelRatio, view.height * devicePixelRatio));
+  canvas.scale(devicePixelRatio, devicePixelRatio);
   canvas.translate(view.width / 2.0, view.height / 2.0);
   canvas.rotate(math.PI * delta / 1800);
   canvas.drawRect(new Rect.fromLTRB(-100.0, -100.0, 100.0, 100.0),

--- a/sky/engine/core/painting/Canvas.cpp
+++ b/sky/engine/core/painting/Canvas.cpp
@@ -157,6 +157,13 @@ void Canvas::clipPath(const CanvasPath* path)
     m_canvas->clipPath(path->path(), SkRegion::kIntersect_Op, true);
 }
 
+void Canvas::drawColor(SkColor color, SkXfermode::Mode transferMode)
+{
+    if (!m_canvas)
+        return;
+    m_canvas->drawColor(color, transferMode);
+}
+
 void Canvas::drawLine(const Point& p1, const Point& p2, const Paint* paint)
 {
     if (!m_canvas)

--- a/sky/engine/core/painting/Canvas.h
+++ b/sky/engine/core/painting/Canvas.h
@@ -77,6 +77,7 @@ public:
     void clipRRect(const RRect* rrect);
     void clipPath(const CanvasPath* path);
 
+    void drawColor(SkColor color, SkXfermode::Mode transferMode);
     void drawLine(const Point& p1, const Point& p2, const Paint* paint);
     void drawPaint(const Paint* paint);
     void drawRect(const Rect& rect, const Paint* paint);

--- a/sky/engine/core/painting/Canvas.idl
+++ b/sky/engine/core/painting/Canvas.idl
@@ -25,6 +25,7 @@
   void clipRRect(RRect rrect);
   void clipPath(Path path);
 
+  void drawColor(Color color, TransferMode transferMode);
   void drawLine(Point p1, Point p2, Paint paint);
   void drawPaint(Paint paint);
   void drawRect(Rect rect, Paint paint);

--- a/sky/packages/sky/lib/rendering/box.dart
+++ b/sky/packages/sky/lib/rendering/box.dart
@@ -1716,9 +1716,13 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   void paintFrame() {
     sky.tracing.begin('RenderView.paintFrame');
     try {
+      double devicePixelRatio = sky.view.devicePixelRatio;
       sky.PictureRecorder recorder = new sky.PictureRecorder();
-      PaintingCanvas canvas = new PaintingCanvas(recorder, paintBounds);
-      canvas.drawPaintingNode(paintingNode, Point.origin);
+      Rect cullRect = Point.origin & (size * devicePixelRatio);
+      PaintingCanvas canvas = new PaintingCanvas(recorder, cullRect);
+      canvas.drawColor(const Color(0xFF000000), sky.TransferMode.src);
+      canvas.scale(devicePixelRatio, devicePixelRatio);
+      canvas.paintChild(child, Point.origin);
       sky.view.picture = recorder.endRecording();
     } finally {
       sky.tracing.end('RenderView.paintFrame');

--- a/sky/shell/ui/engine.cc
+++ b/sky/shell/ui/engine.cc
@@ -106,21 +106,16 @@ void Engine::BeginFrame(base::TimeTicks frame_time) {
 PassRefPtr<SkPicture> Engine::Paint() {
   TRACE_EVENT0("sky", "Engine::Paint");
 
-  SkRTreeFactory factory;
-  SkPictureRecorder recorder;
-  SkCanvas* canvas = recorder.beginRecording(
-      physical_size_.width(), physical_size_.height(), &factory,
-      SkPictureRecorder::kComputeSaveLayerInfo_RecordFlag);
-
   if (sky_view_) {
     RefPtr<SkPicture> picture = sky_view_->Paint();
-    canvas->clear(SK_ColorBLACK);
-    canvas->scale(display_metrics_.device_pixel_ratio,
-                  display_metrics_.device_pixel_ratio);
     if (picture)
-      canvas->drawPicture(picture.get());
+      return picture.release();
   }
 
+  SkPictureRecorder recorder;
+  SkCanvas* canvas = recorder.beginRecording(
+      physical_size_.width(), physical_size_.height());
+  canvas->clear(SK_ColorBLACK);
   return adoptRef(recorder.endRecordingAsPicture());
 }
 


### PR DESCRIPTION
This patch simplifies the SkPicture we generate for Skia. Instead of drawing
everything into a nested SkPicture, we now draw everything into the top-level
picture, which requires us to apply the device scale factor in Dart.