### PR TITLE
Add IgnorePointer, Scrollable listener support

### DIFF
--- a/examples/widgets/overlay_geometry.dart
+++ b/examples/widgets/overlay_geometry.dart
@@ -1,0 +1,189 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:sky' as sky;
+
+import 'package:sky/base/lerp.dart';
+import 'package:sky/painting/box_painter.dart';
+import 'package:sky/painting/text_style.dart';
+import 'package:sky/rendering/box.dart';
+import 'package:sky/theme/colors.dart';
+import 'package:sky/widgets/basic.dart';
+import 'package:sky/widgets/block_viewport.dart';
+import 'package:sky/widgets/card.dart';
+import 'package:sky/widgets/icon.dart';
+import 'package:sky/widgets/scrollable.dart';
+import 'package:sky/widgets/scaffold.dart';
+import 'package:sky/widgets/theme.dart';
+import 'package:sky/widgets/tool_bar.dart';
+import 'package:sky/widgets/framework.dart';
+import 'package:sky/widgets/task_description.dart';
+
+class CardModel {
+  CardModel(this.value, this.height, this.color);
+  int value;
+  double height;
+  Color color;
+  String get label => "Card $value";
+  Key get key => new Key.fromObjectIdentity(this);
+}
+
+enum MarkerType { topLeft, bottomRight, touch }
+
+class Marker extends Component {
+  Marker({
+    this.type: MarkerType.touch,
+    this.position,
+    this.size: 40.0,
+    Key key }) : super(key: key);
+
+  final Point position;
+  final double size;
+  final MarkerType type;
+
+  void paintMarker(sky.Canvas canvas, _) {
+    Paint paint = new Paint()..color = const Color(0x8000FF00);
+    paint.setStyle(sky.PaintingStyle.fill);
+    double r = size / 2.0;
+    canvas.drawCircle(new Point(r, r), r, paint);
+
+    paint.color = const Color(0xFFFFFFFF);
+    paint.setStyle(sky.PaintingStyle.stroke);
+    paint.strokeWidth = 1.0;
+    if (type == MarkerType.topLeft) {
+      canvas.drawLine(new Point(r, r), new Point(r + r - 1.0, r), paint);
+      canvas.drawLine(new Point(r, r), new Point(r, r + r - 1.0), paint);
+    }
+    if (type == MarkerType.bottomRight) {
+      canvas.drawLine(new Point(r, r), new Point(1.0, r), paint);
+      canvas.drawLine(new Point(r, r), new Point(r, 1.0), paint);
+    }
+  }
+
+  Widget build() {
+    return new Positioned(
+      left: position.x - size / 2.0,
+      top: position.y - size / 2.0,
+      child: new IgnorePointer(
+        child: new Container(
+          width: size,
+          height: size,
+          child: new CustomPaint(callback: paintMarker)
+        )
+      )
+    );
+  }
+}
+
+class OverlayGeometryApp extends App {
+
+  static const TextStyle cardLabelStyle =
+    const TextStyle(color: white, fontSize: 18.0, fontWeight: bold);
+
+  List<CardModel> cardModels;
+  BlockViewportLayoutState layoutState = new BlockViewportLayoutState();
+  Map<MarkerType, Point> markers = new Map<MarkerType, Point>();
+  double markersScrollOffset;
+  ScrollListener scrollListener;
+
+  void initState() {
+    List<double> cardHeights = <double>[
+      48.0, 63.0, 82.0, 146.0, 60.0, 55.0, 84.0, 96.0, 50.0,
+      48.0, 63.0, 82.0, 146.0, 60.0, 55.0, 84.0, 96.0, 50.0,
+      48.0, 63.0, 82.0, 146.0, 60.0, 55.0, 84.0, 96.0, 50.0
+    ];
+    cardModels = new List.generate(cardHeights.length, (i) {
+      Color color = lerpColor(Red[300], Blue[900], i / cardHeights.length);
+      return new CardModel(i, cardHeights[i], color);
+    });
+    super.initState();
+  }
+
+  void handleScroll(Scrollable scrollable) {
+    setState(() {
+      double dy = markersScrollOffset - scrollable.scrollOffset;
+      markersScrollOffset = scrollable.scrollOffset;
+      for (MarkerType type in markers.keys) {
+        Point oldPosition = markers[type];
+        markers[type] = new Point(oldPosition.x, oldPosition.y + dy);
+      }
+    });
+  }
+
+  EventDisposition handlePointerDown(Widget target, sky.PointerEvent event) {
+    setState(() {
+      markers[MarkerType.touch] = new Point(event.x, event.y);
+      markers[MarkerType.topLeft] = target.localToGlobal(new Point(0.0, 0.0));
+      Size size = (target.root as RenderBox).size;
+      markers[MarkerType.bottomRight] = target.localToGlobal(new Point(size.width, size.height));
+
+      Scrollable scrollable = findScrollableAncestor(target: target);
+      markersScrollOffset = scrollable.scrollOffset;
+      if (scrollListener == null) {
+        scrollListener = () { handleScroll(scrollable); };
+        scrollable.addListener(scrollListener);
+      }
+    });
+
+    return EventDisposition.processed;
+  }
+
+  Widget builder(int index) {
+    if (index >= cardModels.length)
+      return null;
+    CardModel cardModel = cardModels[index];
+    Widget card = new Card(
+      color: cardModel.color,
+      child: new Container(
+        height: cardModel.height,
+        padding: const EdgeDims.all(8.0),
+        child: new Center(child: new Text(cardModel.label, style: cardLabelStyle))
+      )
+    );
+    return new Listener(
+      key: cardModel.key,
+      onPointerDown: (e) { return handlePointerDown(card, e); },
+      child: card
+    );
+  }
+
+  Widget build() {
+    Scrollable scrollable = new VariableHeightScrollable(
+      builder: builder,
+      token: cardModels.length,
+      layoutState: layoutState
+    );
+
+    Widget cardCollection = new Container(
+      padding: const EdgeDims.symmetric(vertical: 12.0, horizontal: 8.0),
+      decoration: new BoxDecoration(backgroundColor: Theme.of(this).primarySwatch[50]),
+      child: scrollable
+    );
+
+    List<Widget> layers = <Widget>[
+      new Scaffold(
+        toolbar: new ToolBar(center: new Text('Tap a Card')),
+        body: cardCollection
+      )
+    ];
+    for (MarkerType type in markers.keys)
+      layers.add(new Marker(type: type, position: markers[type]));
+
+    return new IconTheme(
+      data: const IconThemeData(color: IconThemeColor.white),
+      child: new Theme(
+        data: new ThemeData(
+          brightness: ThemeBrightness.light,
+          primarySwatch: Blue,
+          accentColor: RedAccent[200]
+        ),
+        child: new TaskDescription(label: 'Cards', child: new Stack(layers))
+      )
+    );
+  }
+}
+
+void main() {
+  runApp(new OverlayGeometryApp());
+}

--- a/sky/packages/sky/lib/rendering/box.dart
+++ b/sky/packages/sky/lib/rendering/box.dart
@@ -1732,6 +1732,13 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   Rect get paintBounds => Point.origin & size;
 }
 
+class RenderIgnorePointer extends RenderProxyBox {
+  RenderIgnorePointer({ RenderBox child }) : super(child);
+  bool hitTest(HitTestResult result, { Point position }) {
+    return false;
+  }
+}
+
 // HELPER METHODS FOR RENDERBOX CONTAINERS
 abstract class RenderBoxContainerDefaultsMixin<ChildType extends RenderBox, ParentDataType extends ContainerParentDataMixin<ChildType>> implements ContainerRenderObjectMixin<ChildType, ParentDataType> {
 

--- a/sky/packages/sky/lib/widgets/basic.dart
+++ b/sky/packages/sky/lib/widgets/basic.dart
@@ -638,3 +638,13 @@ class WidgetToRenderBoxAdapter extends LeafRenderObjectWrapper {
     super.remove();
   }
 }
+
+
+// EVENT HANDLING
+
+class IgnorePointer extends OneChildRenderObjectWrapper {
+  IgnorePointer({ Key key, Widget child })
+    : super(key: key, child: child);
+  RenderIgnorePointer createNode() => new RenderIgnorePointer();
+  RenderIgnorePointer get root => super.root;
+}

--- a/sky/tests/examples/overlay_geometry-expected.txt
+++ b/sky/tests/examples/overlay_geometry-expected.txt
@@ -1,0 +1,183 @@
+TestRenderView enabled
+
+PAINT FOR FRAME #1 ----------------------------------------------
+1 | TestPaintingCanvas() constructor: 800.0 x 600.0
+------------------------------------------------------------------------
+
+PAINT FOR FRAME #2 ----------------------------------------------
+2 | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 | paintChild RenderStack at Point(0.0, 0.0)
+2 |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  | paintChild RenderScaffold at Point(0.0, 0.0)
+2 |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  | paintChild RenderDecoratedBox at Point(0.0, 56.0)
+2 |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  | drawRect(Rect.fromLTRB(0.0, 56.0, 800.0, 600.0), Paint(color:Color(0xffe3f2fd)))
+2 |  |  |  | paintChild RenderPadding at Point(0.0, 56.0)
+2 |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  | paintChild RenderSizeObserver at Point(8.0, 68.0)
+2 |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  | paintChild RenderBlockViewport at Point(8.0, 68.0)
+2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  | save
+2 |  |  |  |  |  |  | clipRect(Rect.fromLTRB(8.0, 68.0, 792.0, 588.0))
+2 |  |  |  |  |  |  | paintChild RenderPadding at Point(8.0, 68.0)
+2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(12.0, 72.0)
+2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffe57373), drawLooper:true))
+2 |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(12.0, 72.0)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(12.0, 72.0, 788.0, 120.0), Paint(color:Color(0xff000000)))
+2 |  |  |  |  |  |  |  |  |  | clipRRect()
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(12.0, 72.0)
+2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(12.0, 72.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(20.0, 80.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(367.0, 83.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(367.0, 83.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-367.0, -83.5)
+2 |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  | paintChild RenderPadding at Point(8.0, 124.0)
+2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(12.0, 128.0)
+2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffdd7174), drawLooper:true))
+2 |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(12.0, 128.0)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(12.0, 128.0, 788.0, 191.0), Paint(color:Color(0xff000000)))
+2 |  |  |  |  |  |  |  |  |  | clipRRect()
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(12.0, 128.0)
+2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(12.0, 128.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(20.0, 136.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(367.0, 147.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(367.0, 147.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-367.0, -147.0)
+2 |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  | paintChild RenderPadding at Point(8.0, 195.0)
+2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(12.0, 199.0)
+2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffd56f76), drawLooper:true))
+2 |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(12.0, 199.0)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(12.0, 199.0, 788.0, 281.0), Paint(color:Color(0xff000000)))
+2 |  |  |  |  |  |  |  |  |  | clipRRect()
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(12.0, 199.0)
+2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(12.0, 199.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(20.0, 207.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(367.0, 227.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(367.0, 227.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-367.0, -227.5)
+2 |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  | paintChild RenderPadding at Point(8.0, 285.0)
+2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(12.0, 289.0)
+2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffcd6e78), drawLooper:true))
+2 |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(12.0, 289.0)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(12.0, 289.0, 788.0, 435.0), Paint(color:Color(0xff000000)))
+2 |  |  |  |  |  |  |  |  |  | clipRRect()
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(12.0, 289.0)
+2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(12.0, 289.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(20.0, 297.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(367.0, 349.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(367.0, 349.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-367.0, -349.5)
+2 |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  | paintChild RenderPadding at Point(8.0, 439.0)
+2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(12.0, 443.0)
+2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffc56c79), drawLooper:true))
+2 |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(12.0, 443.0)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(12.0, 443.0, 788.0, 503.0), Paint(color:Color(0xff000000)))
+2 |  |  |  |  |  |  |  |  |  | clipRRect()
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(12.0, 443.0)
+2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(12.0, 443.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(20.0, 451.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(367.0, 460.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(367.0, 460.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-367.0, -460.5)
+2 |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  | paintChild RenderPadding at Point(8.0, 507.0)
+2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(12.0, 511.0)
+2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffbd6a7b), drawLooper:true))
+2 |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(12.0, 511.0)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(12.0, 511.0, 788.0, 566.0), Paint(color:Color(0xff000000)))
+2 |  |  |  |  |  |  |  |  |  | clipRRect()
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(12.0, 511.0)
+2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(12.0, 511.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(20.0, 519.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(367.0, 526.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(367.0, 526.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-367.0, -526.0)
+2 |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  | paintChild RenderPadding at Point(8.0, 570.0)
+2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  | paintChild RenderDecoratedBox at Point(12.0, 574.0)
+2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xffb5697d), drawLooper:true))
+2 |  |  |  |  |  |  |  |  | paintChild RenderClipRRect at Point(12.0, 574.0)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  | saveLayer(Rect.fromLTRB(12.0, 574.0, 788.0, 658.0), Paint(color:Color(0xff000000)))
+2 |  |  |  |  |  |  |  |  |  | clipRRect()
+2 |  |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(12.0, 574.0)
+2 |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  | paintChild RenderPadding at Point(12.0, 574.0)
+2 |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(20.0, 582.0)
+2 |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(367.0, 603.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(367.0, 603.5)
+2 |  |  |  |  |  |  |  |  |  |  |  |  |  | translate(-367.0, -603.5)
+2 |  |  |  |  |  |  |  |  |  | restore
+2 |  |  |  |  |  |  | restore
+2 |  |  | paintChild RenderDecoratedBox at Point(0.0, 0.0)
+2 |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  | drawRect(Rect.fromLTRB(0.0, 0.0, 800.0, 56.0), Paint(color:Color(0xff2196f3), drawLooper:true))
+2 |  |  |  | paintChild RenderPadding at Point(0.0, 0.0)
+2 |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  | paintChild RenderFlex at Point(8.0, 0.0)
+2 |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  | paintChild RenderConstrainedBox at Point(8.0, 0.0)
+2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  | paintChild RenderFlex at Point(8.0, 0.0)
+2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  | paintChild RenderPadding at Point(8.0, 14.0)
+2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | paintChild RenderParagraph at Point(32.0, 14.0)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  |  | translate(32.0, 14.0)
+2 |  |  |  |  |  |  |  |  |  | translate(-32.0, -14.0)
+------------------------------------------------------------------------
+PAINTED 2 FRAMES

--- a/sky/tests/examples/overlay_geometry.dart
+++ b/sky/tests/examples/overlay_geometry.dart
@@ -1,0 +1,18 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:sky/widgets/framework.dart';
+
+import '../../../examples/widgets/overlay_geometry.dart';
+import '../resources/display_list.dart';
+
+main() async {
+  TestRenderView testRenderView = new TestRenderView();
+  OverlayGeometryApp app = new OverlayGeometryApp();
+  runApp(app, renderViewOverride: testRenderView);
+  await testRenderView.checkFrame();
+  testRenderView.endTest();
+}


### PR DESCRIPTION
The IgnorePointer class enables one to cut a widget subtree off from pointer events. This is useful when a child should not shield pointer events from overlapping children below it.

Added a ScrollListener listener to Scrollable. The ScrollListener runs each time the Scrollable's scrollOffset changes. This can be used to keep overlay widgets in sync with a Scrollable below them.

Removed the Scrollable ScrollClient API. It was no longer used and was clumsy to use as a ScrollListener.

Added global function findScrollableAncestor() to scrollable.dart.

Added examples/widgets/overlay_geometry.dart. The app's Scaffold is contained by a Stack. The Stack is used to display green overlay "Markers" at the corners of the most recently selected list item and where the corresponding tap occurred. The app uses Widget.localToGlobal() to compute the overlay positions of the markers. The ScrollListener is used to keep the markers' positions up to date.
