### PR TITLE
Use ImageResource instead of Future<sky.Image>

### DIFF
--- a/examples/game/lib/image_map.dart
+++ b/examples/game/lib/image_map.dart
@@ -15,7 +15,7 @@ class ImageMap {
   }
 
   Future<Image> _loadImage(String url) async {
-    Image image = await _bundle.loadImage(url);
+    Image image = await _bundle.loadImage(url).first;
     _images[url] = image;
     return image;
   }

--- a/sky/packages/sky/lib/base/image_resource.dart
+++ b/sky/packages/sky/lib/base/image_resource.dart
@@ -1,0 +1,42 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:sky' as sky;
+
+typedef void ImageListener(sky.Image image);
+
+class ImageResource {
+  ImageResource(this._futureImage) {
+    _futureImage.then((sky.Image image) {
+      _image = image;
+      _resolved = true;
+      _notifyListeners();
+    });
+  }
+
+  bool _resolved = false;
+  Future<sky.Image> _futureImage;
+  sky.Image _image;
+  final List<ImageListener> _listeners = new List<ImageListener>();
+
+  Future<sky.Image> get first => _futureImage;
+
+  void addListener(ImageListener listener) {
+    _listeners.add(listener);
+    if (_resolved)
+      listener(_image);
+  }
+
+  void removeListener(ImageListener listener) {
+    _listeners.remove(listener);
+  }
+
+  void _notifyListeners() {
+    assert(_resolved);
+    List<ImageListener> localListeners = new List<ImageListener>.from(_listeners);
+    for (ImageListener listener in localListeners)
+      listener(_image);
+  }
+}

--- a/sky/packages/sky/lib/mojo/net/image_cache.dart
+++ b/sky/packages/sky/lib/mojo/net/image_cache.dart
@@ -7,12 +7,12 @@ import 'dart:collection';
 import 'dart:sky' as sky;
 
 import 'package:mojo/mojo/url_response.mojom.dart';
+import 'package:sky/base/image_resource.dart';
 import 'package:sky/mojo/net/fetch.dart';
 
-final HashMap<String, Future<sky.Image>> _cache =
-    new HashMap<String, Future<sky.Image>>();
+final HashMap<String, ImageResource> _cache = new Map<String, ImageResource>();
 
-Future<sky.Image> load(String url) {
+ImageResource load(String url) {
   return _cache.putIfAbsent(url, () {
     Completer<sky.Image> completer = new Completer<sky.Image>();
     fetchUrl(url).then((UrlResponse response) {
@@ -23,6 +23,6 @@ Future<sky.Image> load(String url) {
         new sky.ImageDecoder(response.body.handle.h, completer.complete);
       }
     });
-    return completer.future;
+    return new ImageResource(completer.future);
   });
 }

--- a/sky/packages/sky/lib/rendering/box.dart
+++ b/sky/packages/sky/lib/rendering/box.dart
@@ -1475,18 +1475,43 @@ class RenderDecoratedBox extends RenderProxyBox {
     RenderBox child
   }) : _painter = new BoxPainter(decoration), super(child);
 
-  BoxPainter _painter;
+  final BoxPainter _painter;
+
   BoxDecoration get decoration => _painter.decoration;
   void set decoration (BoxDecoration value) {
     assert(value != null);
-    if (_painter.decoration.backgroundImage != null)
-      _painter.decoration.backgroundImage.removeChangeListener(markNeedsPaint);
-    if (value.backgroundImage != null)
-      value.backgroundImage.addChangeListener(markNeedsPaint);
     if (value == _painter.decoration)
       return;
+    _removeBackgroundImageListenerIfNeeded();
     _painter.decoration = value;
+    _addBackgroundImageListenerIfNeeded();
     markNeedsPaint();
+  }
+
+  bool get _needsBackgroundImageListener {
+    return attached &&
+        _painter.decoration != null &&
+        _painter.decoration.backgroundImage != null;
+  }
+
+  void _addBackgroundImageListenerIfNeeded() {
+    if (_needsBackgroundImageListener)
+      _painter.decoration.backgroundImage.addChangeListener(markNeedsPaint);
+  }
+
+  void _removeBackgroundImageListenerIfNeeded() {
+    if (_needsBackgroundImageListener)
+      _painter.decoration.backgroundImage.removeChangeListener(markNeedsPaint);
+  }
+
+  void attach() {
+    super.attach();
+    _addBackgroundImageListenerIfNeeded();
+  }
+
+  void detach() {
+    _removeBackgroundImageListenerIfNeeded();
+    super.detach();
   }
 
   void paint(PaintingCanvas canvas, Offset offset) {


### PR DESCRIPTION
Using ImageResource solves two problems:

1) Listeners can be notified synchronously when the sky.Image is already
   available. This change removes flash of 0x0 layout when moving an
   already-cached image around in the render tree.

2) In the future, when we support animated images, we can notify listeners
   multiple times whenever a new image is available.