### PR TITLE
Fix crash when hitting "enter" key on keyboard during entry

### DIFF
--- a/examples/fitness/lib/feed.dart
+++ b/examples/fitness/lib/feed.dart
@@ -254,7 +254,13 @@ class AddItemDialog extends StatefulComponent {
     this.navigator = source.navigator;
   }
 
-  String _addItemRoute;
+  // TODO(jackson): Internationalize
+  static final Map<String, String> _labels = {
+    '/measurements/new': 'Measure',
+    '/meals/new': 'Eat',
+  };
+
+  String _addItemRoute = _labels.keys.first;
 
   void _handleAddItemRouteChanged(String routeName) {
     setState(() {
@@ -263,15 +269,10 @@ class AddItemDialog extends StatefulComponent {
   }
 
   Widget build() {
-    // TODO(jackson): Internationalize
-    Map<String, String> labels = {
-      '/meals/new': 'Eat',
-      '/measurements/new': 'Measure',
-    };
     List<Widget> menuItems = [];
-    for(String routeName in labels.keys) {
+    for(String routeName in _labels.keys) {
       menuItems.add(new DialogMenuItem([
-        new Flexible(child: new Text(labels[routeName])),
+        new Flexible(child: new Text(_labels[routeName])),
         new Radio(value: routeName, groupValue: _addItemRoute, onChanged: _handleAddItemRouteChanged),
       ], onPressed: () => _handleAddItemRouteChanged(routeName)));
     }

--- a/examples/fitness/lib/measurement.dart
+++ b/examples/fitness/lib/measurement.dart
@@ -72,7 +72,8 @@ class MeasurementFragment extends StatefulComponent {
     double parsedWeight;
     try {
       parsedWeight = double.parse(_weight);
-    } on FormatException {
+    } on FormatException catch(e) {
+      print("Exception $e");
       setState(() {
         _errorMessage = "Save failed";
       });
@@ -130,6 +131,7 @@ class MeasurementFragment extends StatefulComponent {
   Widget buildSnackBar() {
     if (_errorMessage == null)
       return null;
+    // TODO(jackson): This doesn't show up, unclear why.
     return new SnackBar(content: new Text(_errorMessage));
   }
 

--- a/examples/fitness/pubspec.yaml
+++ b/examples/fitness/pubspec.yaml
@@ -2,8 +2,8 @@ name: fitness
 dependencies:
   sky: any
   sky_tools: any
-dependency_overrides:
   path: "^1.3.6"
+dependency_overrides:
   material_design_icons:
     path: ../../sky/packages/material_design_icons
   sky:

--- a/sky/packages/sky/lib/widgets/snack_bar.dart
+++ b/sky/packages/sky/lib/widgets/snack_bar.dart
@@ -72,7 +72,9 @@ class SnackBar extends Component {
           )
         )
       )
-    ]..addAll(actions);
+    ];
+    if (actions != null)
+      children.addAll(actions);
 
     return new SlideTransition(
       duration: _kSlideInDuration,


### PR DESCRIPTION
Now it wont crash on save, but it still doesn't display
the error message in a snackbar and this also doesn't
wire up the enter/go key to actually do anything.

We'll need to implement performEditorAction on our
InputConnection implementation to catch this key and
pass it along to dart.

Our Input control needs to get more powerful to handle things
like this, including filtering of input.

The code was crashing by triggering a bug in the SnackBar
which didn't assert for actions, but crashed when they
were not null.

Partial fix for https://github.com/domokit/sky_engine/issues/543

@abarth