### PR TITLE
Scaffold: animate the FloatingActionButton with the SnackBar.

### DIFF
--- a/examples/fitness/lib/feed.dart
+++ b/examples/fitness/lib/feed.dart
@@ -80,6 +80,7 @@ class FeedFragment extends StatefulComponent {
     onItemDeleted = source.onItemDeleted;
   }
 
+  AnimationStatus _snackBarStatus = AnimationStatus.dismissed;
   bool _isShowingSnackBar = false;
 
   EventDisposition _handleFitnessModeChange(FitnessMode value) {
@@ -168,6 +169,7 @@ class FeedFragment extends StatefulComponent {
     setState(() {
       _undoItem = item;
       _isShowingSnackBar = true;
+      _snackBarStatus = AnimationStatus.forward;
     });
   }
 
@@ -205,13 +207,16 @@ class FeedFragment extends StatefulComponent {
     });
   }
 
+  Anchor _snackBarAnchor = new Anchor();
   Widget buildSnackBar() {
-    if (!_isShowingSnackBar)
+    if (_snackBarStatus == AnimationStatus.dismissed)
       return null;
     return new SnackBar(
       showing: _isShowingSnackBar,
+      anchor: _snackBarAnchor,
       content: new Text("Item deleted."),
-      actions: [new SnackBarAction(label: "UNDO", onPressed: _handleUndo)]
+      actions: [new SnackBarAction(label: "UNDO", onPressed: _handleUndo)],
+      onDismissed: () { setState(() { _snackBarStatus = AnimationStatus.dismissed; }); }
     );
   }
 
@@ -225,10 +230,11 @@ class FeedFragment extends StatefulComponent {
   Widget buildFloatingActionButton() {
     switch (_fitnessMode) {
       case FitnessMode.feed:
-        return new FloatingActionButton(
-          child: new Icon(type: 'content/add', size: 24),
-          onPressed: _handleActionButtonPressed
-        );
+        return _snackBarAnchor.build(
+          new FloatingActionButton(
+            child: new Icon(type: 'content/add', size: 24),
+            onPressed: _handleActionButtonPressed
+          ));
       case FitnessMode.chart:
         return null;
     }

--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -247,11 +247,13 @@ class StockHome extends StatefulComponent {
     });
   }
 
+  Anchor _snackBarAnchor = new Anchor();
   Widget buildSnackBar() {
     if (_snackBarStatus == AnimationStatus.dismissed)
       return null;
     return new SnackBar(
       showing: _isSnackBarShowing,
+      anchor: _snackBarAnchor,
       content: new Text("Stock purchased!"),
       actions: [new SnackBarAction(label: "UNDO", onPressed: _handleUndo)],
       onDismissed: () { setState(() { _snackBarStatus = AnimationStatus.dismissed; }); }
@@ -266,11 +268,12 @@ class StockHome extends StatefulComponent {
   }
 
   Widget buildFloatingActionButton() {
-    return new FloatingActionButton(
-      child: new Icon(type: 'content/add', size: 24),
-      backgroundColor: colors.RedAccent[200],
-      onPressed: _handleStockPurchased
-    );
+    return _snackBarAnchor.build(
+      new FloatingActionButton(
+        child: new Icon(type: 'content/add', size: 24),
+        backgroundColor: colors.RedAccent[200],
+        onPressed: _handleStockPurchased
+      ));
   }
 
   void addMenuToOverlays(List<Widget> overlays) {

--- a/sky/packages/sky/lib/widgets/animated_component.dart
+++ b/sky/packages/sky/lib/widgets/animated_component.dart
@@ -20,11 +20,20 @@ abstract class AnimatedComponent extends StatefulComponent {
     });
   }
 
+  bool isWatching(performance) => _watchedPerformances.contains(performance);
+
   void watch(AnimationPerformance performance) {
-    assert(!_watchedPerformances.contains(performance));
+    assert(!isWatching(performance));
     _watchedPerformances.add(performance);
     if (mounted)
       performance.addListener(_performanceChanged);
+  }
+
+  void unwatch(AnimationPerformance performance) {
+    assert(isWatching(performance));
+    _watchedPerformances.remove(performance);
+    if (mounted)
+      performance.removeListener(_performanceChanged);
   }
 
   void didMount() {

--- a/sky/packages/sky/lib/widgets/navigator.dart
+++ b/sky/packages/sky/lib/widgets/navigator.dart
@@ -85,7 +85,7 @@ class Transition extends TransitionBase {
     super.syncFields(source);
   }
 
-  Widget build() {
+  Widget buildWithChild(Widget child) {
     // TODO(jackson): Hit testing should ignore transform
     // TODO(jackson): Block input unless content is interactive
     return new SlideTransition(

--- a/sky/packages/sky/lib/widgets/snack_bar.dart
+++ b/sky/packages/sky/lib/widgets/snack_bar.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:sky/animation/animated_value.dart';
 import 'package:sky/animation/animation_performance.dart';
+import 'package:sky/animation/curves.dart';
 import 'package:sky/painting/text_style.dart';
 import 'package:sky/theme/typography.dart' as typography;
 import 'package:sky/widgets/basic.dart';
@@ -43,6 +44,7 @@ class SnackBar extends Component {
 
   SnackBar({
     Key key,
+    this.anchor,
     this.content,
     this.actions,
     this.showing,
@@ -51,6 +53,7 @@ class SnackBar extends Component {
     assert(content != null);
   }
 
+  Anchor anchor;
   Widget content;
   List<SnackBarAction> actions;
   bool showing;
@@ -79,9 +82,11 @@ class SnackBar extends Component {
     return new SlideTransition(
       duration: _kSlideInDuration,
       direction: showing ? Direction.forward : Direction.reverse,
-      position: new AnimatedValue<Point>(const Point(0.0, 50.0),
-                                         end: Point.origin),
+      position: new AnimatedValue<Point>(Point.origin,
+                                         end: const Point(0.0, -52.0),
+                                         curve: easeIn, reverseCurve: easeOut),
       onDismissed: _onDismissed,
+      anchor: anchor,
       child: new Material(
         level: 2,
         color: const Color(0xFF323232),


### PR DESCRIPTION
This introduces the concept of an Anchor, which you can use to link
transitions together. I've used this in the Fitness and Stocks apps to
link the FAB and SnackBar to animate together by sharing the
SlideTransition.

I also fixed the Scaffold hit testing code to apply sub-widget
transforms, so it works with Transformed nodes.