### PR TITLE
Revert "Roll Dart forward"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -20,7 +20,7 @@
 vars = {
   'chromium_git': 'https://chromium.googlesource.com',
   'skia_revision': '29ccdf86ab0a1649fd775c9431891bacb1391e99',
-  'dart_revision': 'da92573117ecc4a3715cf044a6fdf393ebdad8d9',
+  'dart_revision': '2d6e6db8437eaaa364f3d5b599afb6804e93f65f',
   'dart_observatory_packages_revision': 'cdc4b3d4c15b9c0c8e7702dff127b440afbb7485',
 
   'buildtools_revision': '5215ee866bc3e8eb4a7f124212845abf4029e60b',


### PR DESCRIPTION
Reverts domokit/sky_engine#563

This seems to break the android build:
```In file included from ../../dart/runtime/vm/flags.h:8:0,
                 from ../../dart/runtime/vm/thread_interrupter_android.cc:10:
../../dart/runtime/vm/thread_interrupter_android.cc: In static member function 'static void dart::ThreadInterrupter::InterruptThread(dart::InterruptableThreadState*)':
../../dart/runtime/vm/thread_interrupter_android.cc:54:10: error: 'result' was not declared in this scope
   ASSERT(result == 0);
          ^
../../dart/runtime/platform/assert.h:275:50: note: in definition of macro 'ASSERT'
 #define ASSERT(condition) do {} while (false && (condition))
                                                  ^
../../dart/runtime/vm/thread_interrupter_android.cc:53:7: error: unused variable 'resut' [-Werror=unused-variable]
   int resut = syscall(__NR_tgkill, getpid(), state->id, SIGPROF);
       ^
In file included from ../../dart/runtime/vm/flags.h:9:0,
                 from ../../dart/runtime/vm/thread_interrupter_android.cc:10:
../../dart/runtime/vm/globals.h: At global scope:
../../dart/runtime/vm/globals.h:30:14: error: 'dart::kPosInfinity' defined but not used [-Werror=unused-variable]
 const double kPosInfinity = bit_cast<double>(DART_UINT64_C(0x7ff0000000000000));
              ^
../../dart/runtime/vm/globals.h:31:14: error: 'dart::kNegInfinity' defined but not used [-Werror=unused-variable]
 const double kNegInfinity = bit_cast<double>(DART_UINT64_C(0xfff0000000000000));
              ^
cc1plus: all warnings being treated as errors
[4/477] LINK clang_x64/gen_snapshot
ninja: build stopped: subcommand failed.
```