### PR TITLE
Stop using workbench/packages for sky_snapshot

### DIFF
--- a/sky/build/skyx.gni
+++ b/sky/build/skyx.gni
@@ -32,8 +32,7 @@ template("skyx") {
     args = [
       rebase_path("$sky_snapshot_dir/sky_snapshot", src_dir),
       rebase_path(main_dart, src_dir),
-      "--package-root",
-      rebase_path("//sky/packages/workbench/packages", src_dir),
+      "--package-root", rebase_path("packages"),
       "--snapshot",
       rebase_path(snapshot, src_dir),
       "-C",

--- a/sky/packages/workbench/pubspec.yaml
+++ b/sky/packages/workbench/pubspec.yaml
@@ -6,8 +6,6 @@ homepage: https://github.com/domokit/sky_engine/tree/master/sky/packages/workben
 dependencies:
   sky: any
   sky_tools: any
-  # This is a hack until sky_snapshot no longer uses workbench's packages directory.
-  playfair: any
 dependency_overrides:
   material_design_icons:
     path: ../material_design_icons


### PR DESCRIPTION
Instead we use the packages directory which is at the same
level as the BUILD.gn file.  That's a bit of a broken assumption
but it happens to work for all our skyx uses for now.

@abarth