### PR TITLE
glFlush after inserting sync point

### DIFF
--- a/services/sky/compositor/resource_manager.cc
+++ b/services/sky/compositor/resource_manager.cc
@@ -50,6 +50,7 @@ mojo::TransferableResourcePtr ResourceManager::CreateTransferableResource(
   glGenMailboxCHROMIUM(mailbox);
   glProduceTextureCHROMIUM(GL_TEXTURE_2D, mailbox);
   GLuint sync_point = glInsertSyncPointCHROMIUM();
+  glFlush();
 
   mojo::TransferableResourcePtr resource = mojo::TransferableResource::New();
   resource->id = next_resource_id_++;


### PR DESCRIPTION
Insert a glFlush() after glInsertSyncPointCHROMIUM() to induce a driver-level
flush after writing to the texture. This may be required for the changes to
be visible in the compositor's context. We're still investigating, but this
seems to help quite a bit in the meantime.

Mitigates (or possibly fixes?) issue #36