### PR TITLE
Add a minimum sdk version for sky_engine

### DIFF
--- a/sky/packages/sky_engine/pubspec.yaml
+++ b/sky/packages/sky_engine/pubspec.yaml
@@ -3,3 +3,6 @@ version: 0.0.9
 author: Chromium Authors <sky-dev@googlegroups.com>
 description: Dart SDK extensions for dart:sky
 homepage: https://github.com/domokit/sky_engine
+# sky_engine requires sdk_ext support in the analyzer which was added in 1.11.x
+environment:
+  sdk: '>=1.11.0 <2.0.0'


### PR DESCRIPTION
We could update all our other versions as well if we wanted
but this the only package in sky which uses sdk_ext

@abarth