### PR TITLE
sky_snapshot should work with absolute paths

### DIFF
--- a/sky/tools/sky_snapshot/loader.cc
+++ b/sky/tools/sky_snapshot/loader.cc
@@ -25,8 +25,10 @@ std::string Fetch(const std::string& url) {
 base::FilePath SimplifyPath(const base::FilePath& path) {
   std::vector<base::FilePath::StringType> components;
   path.GetComponents(&components);
-  base::FilePath result;
-  for (const auto& component : components) {
+  auto it = components.begin();
+  base::FilePath result(*it++);
+  for (; it != components.end(); it++) {
+    auto& component = *it;
     if (component == base::FilePath::kCurrentDirectory)
       continue;
     if (component == base::FilePath::kParentDirectory)


### PR DESCRIPTION
Instead of appending the first path component, we should use it to initialize
`result`. That makes this code work with absolute paths.