### PR TITLE
Fix common asserts in animation API.

### DIFF
--- a/sky/packages/sky/lib/animation/animated_simulation.dart
+++ b/sky/packages/sky/lib/animation/animated_simulation.dart
@@ -51,7 +51,8 @@ class Ticker {
 
     _onTick(timeStamp);
 
-    if (isTicking)
+    // The onTick callback may have scheduled another tick already.
+    if (isTicking && _animationId == null)
       _scheduleTick();
   }
 

--- a/sky/packages/sky/lib/animation/timeline.dart
+++ b/sky/packages/sky/lib/animation/timeline.dart
@@ -14,7 +14,7 @@ class TweenSimulation extends Simulation {
   final double end;
 
   TweenSimulation(Duration duration, this.begin, this.end) :
-      _durationInSeconds = duration.inMilliseconds / 1000.0 {
+      _durationInSeconds = duration.inMicroseconds / Duration.MICROSECONDS_PER_SECOND {
     assert(_durationInSeconds > 0.0);
     assert(begin != null && begin >= 0.0 && begin <= 1.0);
     assert(end != null && end >= 0.0 && end <= 1.0);

--- a/sky/packages/sky/lib/widgets/drawer.dart
+++ b/sky/packages/sky/lib/widgets/drawer.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:sky' as sky;
 
 import 'package:sky/animation/animated_value.dart';
@@ -69,9 +68,7 @@ class Drawer extends StatefulComponent {
     _performance.attachedForce = kDefaultSpringForce;
 
     if (navigator != null) {
-      scheduleMicrotask(() {
-        navigator.pushState(this, (_) => _performance.reverse());
-      });
+      navigator.pushState(this, (_) => _performance.reverse());
     }
   }
 
@@ -120,14 +117,12 @@ class Drawer extends StatefulComponent {
   }
 
   void _onDismissed() {
-    scheduleMicrotask(() {
-      if (navigator != null &&
-          navigator.currentRoute is RouteState &&
-          (navigator.currentRoute as RouteState).owner == this) // TODO(ianh): remove cast once analyzer is cleverer
-        navigator.pop();
-      if (onDismissed != null)
-        onDismissed();
-    });
+    if (navigator != null &&
+        navigator.currentRoute is RouteState &&
+        (navigator.currentRoute as RouteState).owner == this) // TODO(ianh): remove cast once analyzer is cleverer
+      navigator.pop();
+    if (onDismissed != null)
+      onDismissed();
   }
 
   bool get _isMostlyClosed => _performance.progress < 0.5;

--- a/sky/packages/sky/lib/widgets/popup_menu.dart
+++ b/sky/packages/sky/lib/widgets/popup_menu.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:sky' as sky;
 
 import 'package:sky/animation/animated_value.dart';
@@ -72,11 +71,7 @@ class PopupMenu extends StatefulComponent {
   }
 
   void _open() {
-    if (navigator != null) {
-      scheduleMicrotask(() {
-        navigator.pushState(this, (_) => _close());
-      });
-    }
+    navigator.pushState(this, (_) => _close());
   }
 
   void _close() {

--- a/sky/packages/sky/lib/widgets/snack_bar.dart
+++ b/sky/packages/sky/lib/widgets/snack_bar.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 
 import 'package:sky/animation/animated_value.dart';
 import 'package:sky/animation/animation_performance.dart';
@@ -61,7 +60,7 @@ class SnackBar extends Component {
 
   void _onDismissed() {
     if (onDismissed != null)
-      scheduleMicrotask(() { onDismissed(); });
+      onDismissed();
   }
 
   Widget build() {


### PR DESCRIPTION
1. We would assert if you tried to start an animation from within an
animation status callback. This is a common pattern, so I fixed this
assert (in Ticker._tick).
2. We would assert for animations with duration under a millisecond.
Fixed.

Also removed the workarounds assocated with #1.