### PR TITLE
Don't claim to be a text editor

### DIFF
--- a/sky/shell/android/org/domokit/sky/shell/PlatformViewAndroid.java
+++ b/sky/shell/android/org/domokit/sky/shell/PlatformViewAndroid.java
@@ -124,11 +124,6 @@ public class PlatformViewAndroid extends SurfaceView
     }
 
     @Override
-    public boolean onCheckIsTextEditor() {
-        return true;
-    }
-
-    @Override
     public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
         return mKeyboardState.createInputConnection(outAttrs);
     }


### PR DESCRIPTION
http://developer.android.com/reference/android/view/View.html#onCheckIsTextEditor()
says that we should return true if the "primary purpose" of
the view is text editing.  The keyboard still seems to work
fine if we return false here (default implementation) so
I'm removing this for now.

Fixes https://github.com/domokit/sky_engine/issues/116

@abarth