### PR TITLE
Generalize _cleanRelayoutSubtreeRootChildren into visitChildren

### DIFF
--- a/sky/packages/sky/lib/widgets/scaffold.dart
+++ b/sky/packages/sky/lib/widgets/scaffold.dart
@@ -70,6 +70,14 @@ class RenderScaffold extends RenderBox {
     }
   }
 
+  void visitChildren(RenderObjectVisitor visitor) {
+    for (ScaffoldSlots slot in ScaffoldSlots.values) {
+      RenderBox box = _slots[slot];
+      if (box != null)
+        visitor(box);
+    }
+  }
+
   ScaffoldSlots remove(RenderBox child) {
     assert(child != null);
     for (ScaffoldSlots slot in ScaffoldSlots.values) {


### PR DESCRIPTION
This generalization will let us implement other alogorithims that need to walk
the RenderObject tree.