### PR TITLE
Clear the frame to black before drawing

### DIFF
--- a/services/sky/compositor/rasterizer_bitmap.cc
+++ b/services/sky/compositor/rasterizer_bitmap.cc
@@ -31,8 +31,7 @@ scoped_ptr<mojo::GLTexture> RasterizerBitmap::Rasterize(SkPicture* picture) {
 
   SkBitmapDevice device(bitmap_);
   SkCanvas canvas(&device);
-  // Draw red so we can see when we fail to paint.
-  canvas.drawColor(SK_ColorRED);
+  canvas.clear(SK_ColorBLACK);
   canvas.drawPicture(picture);
   canvas.flush();
 

--- a/services/sky/compositor/rasterizer_ganesh.cc
+++ b/services/sky/compositor/rasterizer_ganesh.cc
@@ -29,6 +29,7 @@ scoped_ptr<mojo::GLTexture> RasterizerGanesh::Rasterize(SkPicture* picture) {
                               host_->resource_manager()->CreateTexture(size));
 
   SkCanvas* canvas = surface.canvas();
+  canvas->clear(SK_ColorBLACK);
   canvas->drawPicture(picture);
   canvas->flush();
 

--- a/sky/shell/gpu/rasterizer.cc
+++ b/sky/shell/gpu/rasterizer.cc
@@ -66,6 +66,7 @@ void Rasterizer::Draw(PassRefPtr<SkPicture> picture) {
 void Rasterizer::DrawPicture(SkPicture* picture) {
   TRACE_EVENT0("sky", "Rasterizer::DrawPicture");
   SkCanvas* canvas = ganesh_surface_->canvas();
+  canvas->clear(SK_ColorBLACK);
   canvas->drawPicture(picture);
   canvas->flush();
 }


### PR DESCRIPTION
We used to do this in the SkPicture, but it's simpler to do it in the
rasterizer now that we're using multiple SkPictures in Dart.