### PR TITLE
Add a compositing update phase

### DIFF
--- a/sky/packages/sky/lib/rendering/sky_binding.dart
+++ b/sky/packages/sky/lib/rendering/sky_binding.dart
@@ -71,6 +71,7 @@ class SkyBinding {
   }
   void beginFrame(double timeStamp) {
     RenderObject.flushLayout();
+    _renderView.updateCompositing();
     RenderObject.flushPaint();
     _renderView.paintFrame();
     _renderView.compositeFrame();


### PR DESCRIPTION
We need to compute whether a RenderObject has a composited descendant so that
we can decide whether to use canvas.saveLayer or to create a new composited
layer while walking down the tree during painting.

The compositing update walks the tree from the root only to places where the
tree's structure has been mutated. In the common case during an animation loop,
we won't need to visit any render object beyond the root.