### PR TITLE
Don't grey out Sky code in Atom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ Thumbs.db
 /mojo/dart/mojom/bin/packages
 /mojo/dart/mojom/packages
 /mojo/dart/mojom/test/packages
+/sky/packages/**/packages

--- a/sky/packages/sky/.gitignore
+++ b/sky/packages/sky/.gitignore
@@ -2,5 +2,4 @@
 .pub/
 AUTHORS
 LICENSE
-packages
 pubspec.lock


### PR DESCRIPTION
For some reason having |packages| in this .gitignore file is causing Atom to
grey out all the files in the Sky package. Moving the entry up to the root of
the git repo fixes the issue.