### PR TITLE
Fix Mac build

### DIFF
--- a/sky/services/keyboard/ios/keyboard_service_impl.h
+++ b/sky/services/keyboard/ios/keyboard_service_impl.h
@@ -24,11 +24,11 @@ class KeyboardServiceImpl : public ::keyboard::KeyboardService {
  public:
   explicit KeyboardServiceImpl(
       mojo::InterfaceRequest<::keyboard::KeyboardService> request);
-  virtual ~KeyboardServiceImpl() override;
-  virtual void Show(::keyboard::KeyboardClientPtr client,
-                    ::keyboard::KeyboardType type) override;
-  virtual void ShowByRequest() override;
-  virtual void Hide() override;
+  ~KeyboardServiceImpl() override;
+  void Show(::keyboard::KeyboardClientPtr client,
+            ::keyboard::KeyboardType type) override;
+  void ShowByRequest() override;
+  void Hide() override;
 
  private:
   mojo::StrongBinding<::keyboard::KeyboardService> binding_;
@@ -49,4 +49,4 @@ class KeyboardServiceFactory
 }  // namespace services
 }  // namespace sky
 
-#endif /* defined(SKY_SERVICES_KEYBOARD_IOS_KEYBOARD_SERVICE_IMPL_H__) *
+#endif /* defined(SKY_SERVICES_KEYBOARD_IOS_KEYBOARD_SERVICE_IMPL_H__) */

--- a/sky/shell/BUILD.gn
+++ b/sky/shell/BUILD.gn
@@ -12,6 +12,7 @@ common_deps = [
   "//mojo/public/cpp/application",
   "//mojo/public/interfaces/application",
   "//mojo/services/asset_bundle/public/interfaces",
+  "//mojo/services/keyboard/public/interfaces",
   "//mojo/services/navigation/public/interfaces",
   "//mojo/services/network/public/interfaces",
   "//services/asset_bundle:lib",

--- a/sky/shell/mac/platform_service_provider_mac.cc
+++ b/sky/shell/mac/platform_service_provider_mac.cc
@@ -10,8 +10,12 @@
 #include "mojo/public/interfaces/application/service_provider.mojom.h"
 #include "sky/engine/wtf/Assertions.h"
 #include "sky/services/ns_net/network_service_impl.h"
-#include "sky/services/keyboard/ios/keyboard_service_impl.h"
 #include "sky/shell/service_provider.h"
+
+#if TARGET_OS_IPHONE
+#include "sky/services/keyboard/ios/keyboard_service_impl.h"
+#endif
+
 #if !TARGET_OS_IPHONE
 #include "sky/shell/testing/test_runner.h"
 #endif
@@ -30,10 +34,12 @@ class PlatformServiceProvider : public mojo::ServiceProvider {
       network_.Create(nullptr, mojo::MakeRequest<mojo::NetworkService>(
                                    client_handle.Pass()));
     }
+#if TARGET_OS_IPHONE
     if (service_name == ::keyboard::KeyboardService::Name_) {
       keyboard_.Create(nullptr, mojo::MakeRequest<::keyboard::KeyboardService>(
                                     client_handle.Pass()));
     }
+#endif
 #if !TARGET_OS_IPHONE
     if (service_name == TestHarness::Name_) {
       TestRunner::Shared().Create(
@@ -45,7 +51,9 @@ class PlatformServiceProvider : public mojo::ServiceProvider {
  private:
   mojo::StrongBinding<mojo::ServiceProvider> binding_;
   mojo::NetworkServiceFactory network_;
+#if TARGET_OS_IPHONE
   sky::services::keyboard::KeyboardServiceFactory keyboard_;
+#endif
 };
 
 static void CreatePlatformServiceProvider(


### PR DESCRIPTION
Looks like the Keyboard service is only for iOS. We shouldn't try to build it
on Mac.