### PR TITLE
Make it easier to run SkyShell from the command line on Mac

### DIFF
--- a/sky/shell/BUILD.gn
+++ b/sky/shell/BUILD.gn
@@ -27,6 +27,13 @@ common_deps = [
   "//ui/gl",
 ]
 
+testing_sources = [
+  "testing/test_runner.cc",
+  "testing/test_runner.h",
+  "testing/testing.cc",
+  "testing/testing.h",
+]
+
 source_set("common") {
   sources = [
     "gpu/ganesh_context.cc",
@@ -225,12 +232,10 @@ if (is_android) {
     output_name = "sky_shell"
 
     sources = [
-      "linux/main.cc",
+      "linux/main_linux.cc",
       "linux/platform_service_provider_linux.cc",
       "linux/platform_view_linux.cc",
-      "testing/test_runner.cc",
-      "testing/test_runner.h",
-    ]
+    ] + testing_sources
 
     deps = common_deps + [
              ":common",
@@ -254,9 +259,7 @@ if (is_android) {
       "mac/sky_application.mm",
       "mac/sky_window.h",
       "mac/sky_window.mm",
-      "testing/test_runner.cc",
-      "testing/test_runner.h",
-    ]
+    ] + testing_sources
 
     deps = common_deps + [
              ":common",

--- a/sky/shell/linux/main_linux.cc
+++ b/sky/shell/linux/main_linux.cc
@@ -1,0 +1,36 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/at_exit.h"
+#include "base/basictypes.h"
+#include "base/bind.h"
+#include "base/command_line.h"
+#include "base/logging.h"
+#include "base/message_loop/message_loop.h"
+#include "sky/shell/service_provider.h"
+#include "sky/shell/shell.h"
+#include "sky/shell/switches.h"
+#include "sky/shell/testing/testing.h"
+
+int main(int argc, const char* argv[]) {
+  base::AtExitManager exit_manager;
+  base::CommandLine::Init(argc, argv);
+
+  base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
+
+  if (command_line.HasSwitch(sky::shell::switches::kHelp)) {
+    sky::shell::switches::PrintUsage("sky_shell");
+    return 0;
+  }
+
+  base::MessageLoop message_loop;
+
+  sky::shell::Shell::Init(make_scoped_ptr(
+      new sky::shell::ServiceProviderContext(message_loop.task_runner())));
+
+  message_loop.PostTask(FROM_HERE, base::Bind(&sky::shell::InitForTesting));
+  message_loop.Run();
+
+  return 0;
+}

--- a/sky/shell/mac/sky_window.mm
+++ b/sky/shell/mac/sky_window.mm
@@ -8,10 +8,10 @@
 #include "mojo/public/cpp/bindings/interface_request.h"
 #include "sky/services/engine/input_event.mojom.h"
 #include "sky/shell/mac/platform_view_mac.h"
-#include "sky/shell/shell.h"
 #include "sky/shell/shell_view.h"
+#include "sky/shell/shell.h"
+#include "sky/shell/switches.h"
 #include "sky/shell/ui_delegate.h"
-
 
 @interface SkyWindow ()<NSWindowDelegate>
 
@@ -87,9 +87,14 @@ static inline sky::EventType EventTypeFromNSEventPhase(NSEventPhase phase) {
   base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
   base::CommandLine::StringVector args = command_line.GetArgs();
   if (args.size() > 0) {
-    LOG(INFO) << "Loading " << args[0];
     mojo::String string(args[0]);
     _sky_engine->RunFromNetwork(string);
+    return;
+  }
+
+  if (command_line.HasSwitch(sky::shell::switches::kSnapshot)) {
+    auto snapshot = command_line.GetSwitchValueASCII(sky::shell::switches::kSnapshot);
+    _sky_engine->RunFromSnapshot(snapshot);
     return;
   }
 

--- a/sky/shell/testing/testing.cc
+++ b/sky/shell/testing/testing.cc
@@ -2,28 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <iostream>
+#include "sky/shell/testing/testing.h"
 
-#include "base/at_exit.h"
-#include "base/basictypes.h"
-#include "base/bind.h"
-#include "base/command_line.h"
-#include "base/i18n/icu_util.h"
-#include "base/logging.h"
-#include "base/message_loop/message_loop.h"
 #include "sky/engine/public/web/WebRuntimeFeatures.h"
-#include "sky/shell/platform_view.h"
-#include "sky/shell/service_provider.h"
-#include "sky/shell/shell.h"
-#include "sky/shell/shell_view.h"
+#include "base/command_line.h"
 #include "sky/shell/switches.h"
 #include "sky/shell/testing/test_runner.h"
 
 namespace sky {
 namespace shell {
-namespace {
 
-void Init() {
+void InitForTesting() {
   base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
   blink::WebRuntimeFeatures::enableObservatory(
       !command_line.HasSwitch(switches::kNonInteractive));
@@ -51,30 +40,5 @@ void Init() {
   runner.Start(single_test.Pass());
 }
 
-}  // namespace
 }  // namespace shell
 }  // namespace sky
-
-int main(int argc, const char* argv[]) {
-  base::AtExitManager exit_manager;
-  base::CommandLine::Init(argc, argv);
-
-  base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
-
-  if (command_line.HasSwitch(sky::shell::switches::kHelp) ||
-      (!command_line.HasSwitch(sky::shell::switches::kPackageRoot) &&
-       !command_line.HasSwitch(sky::shell::switches::kSnapshot))) {
-    sky::shell::switches::PrintUsage("sky_shell");
-    return 0;
-  }
-
-  base::MessageLoop message_loop;
-
-  sky::shell::Shell::Init(make_scoped_ptr(
-      new sky::shell::ServiceProviderContext(message_loop.task_runner())));
-
-  message_loop.PostTask(FROM_HERE, base::Bind(&sky::shell::Init));
-  message_loop.Run();
-
-  return 0;
-}

--- a/sky/shell/testing/testing.h
+++ b/sky/shell/testing/testing.h
@@ -1,0 +1,16 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SKY_SHELL_TESTING_TESTING_H_
+#define SKY_SHELL_TESTING_TESTING_H_
+
+namespace sky {
+namespace shell {
+
+void InitForTesting();
+
+}  // namespace shell
+}  // namespace sky
+
+#endif  // SKY_SHELL_TESTING_TESTING_H_


### PR DESCRIPTION
Now you can use --snapshot to load snapshots from the command line and have
them appear visually on Mac. Also, remove code duplication with Linux by
factoring common testing code into //sky/shell/testing.