### PR TITLE
Rename Widget.root to Widget.renderObject

### DIFF
--- a/examples/game/lib/sprite_widget.dart
+++ b/examples/game/lib/sprite_widget.dart
@@ -24,14 +24,14 @@ class SpriteWidget extends OneChildRenderObjectWrapper {
   ///     var mySpriteWidget = new SpriteWidget(mySpriteTree, SpriteBoxTransformMode.fixedHeight);
   SpriteWidget(this.rootNode, [this.transformMode = SpriteBoxTransformMode.letterbox]);
 
-  SpriteBox get root => super.root;
+  SpriteBox get renderObject => super.renderObject;
 
   SpriteBox createNode() => new SpriteBox(rootNode, transformMode);
 
   void syncRenderObject(SpriteWidget old) {
     super.syncRenderObject(old);
 
-    root.rootNode = rootNode;
-    root.transformMode = transformMode;
+    renderObject.rootNode = rootNode;
+    renderObject.transformMode = transformMode;
   }
 }

--- a/examples/widgets/overlay_geometry.dart
+++ b/examples/widgets/overlay_geometry.dart
@@ -115,7 +115,7 @@ class OverlayGeometryApp extends App {
     setState(() {
       markers[MarkerType.touch] = new Point(event.x, event.y);
       markers[MarkerType.topLeft] = target.localToGlobal(new Point(0.0, 0.0));
-      Size size = (target.root as RenderBox).size;
+      Size size = (target.renderObject as RenderBox).size;
       markers[MarkerType.bottomRight] = target.localToGlobal(new Point(size.width, size.height));
 
       Scrollable scrollable = findScrollableAncestor(target: target);

--- a/sky/packages/sky/lib/widgets/basic.dart
+++ b/sky/packages/sky/lib/widgets/basic.dart
@@ -37,11 +37,11 @@ class Opacity extends OneChildRenderObjectWrapper {
   final double opacity;
 
   RenderOpacity createNode() => new RenderOpacity(opacity: opacity);
-  RenderOpacity get root => super.root;
+  RenderOpacity get renderObject => super.renderObject;
 
   void syncRenderObject(Opacity old) {
     super.syncRenderObject(old);
-    root.opacity = opacity;
+    renderObject.opacity = opacity;
   }
 }
 
@@ -53,12 +53,12 @@ class ColorFilter extends OneChildRenderObjectWrapper {
   final sky.TransferMode transferMode;
 
   RenderColorFilter createNode() => new RenderColorFilter(color: color, transferMode: transferMode);
-  RenderColorFilter get root => super.root;
+  RenderColorFilter get renderObject => super.renderObject;
 
   void syncRenderObject(ColorFilter old) {
     super.syncRenderObject(old);
-    root.color = color;
-    root.transferMode = transferMode;
+    renderObject.color = color;
+    renderObject.transferMode = transferMode;
   }
 }
 
@@ -69,11 +69,11 @@ class DecoratedBox extends OneChildRenderObjectWrapper {
   final BoxDecoration decoration;
 
   RenderDecoratedBox createNode() => new RenderDecoratedBox(decoration: decoration);
-  RenderDecoratedBox get root => super.root;
+  RenderDecoratedBox get renderObject => super.renderObject;
 
   void syncRenderObject(DecoratedBox old) {
     super.syncRenderObject(old);
-    root.decoration = decoration;
+    renderObject.decoration = decoration;
   }
 }
 
@@ -85,17 +85,17 @@ class CustomPaint extends OneChildRenderObjectWrapper {
   final dynamic token; // set this to be repainted automatically when the token changes
 
   RenderCustomPaint createNode() => new RenderCustomPaint(callback: callback);
-  RenderCustomPaint get root => super.root;
+  RenderCustomPaint get renderObject => super.renderObject;
 
   void syncRenderObject(CustomPaint old) {
     super.syncRenderObject(old);
     if (old != null && old.token != token)
-      root.markNeedsPaint();
-    root.callback = callback;
+      renderObject.markNeedsPaint();
+    renderObject.callback = callback;
   }
 
   void remove() {
-    root.callback = null;
+    renderObject.callback = null;
     super.remove();
   }
 }
@@ -105,7 +105,7 @@ class ClipRect extends OneChildRenderObjectWrapper {
     : super(key: key, child: child);
 
   RenderClipRect createNode() => new RenderClipRect();
-  RenderClipRect get root => super.root;
+  RenderClipRect get renderObject => super.renderObject;
 
   // Nothing to sync, so we don't implement syncRenderObject()
 }
@@ -118,12 +118,12 @@ class ClipRRect extends OneChildRenderObjectWrapper {
   final double yRadius;
 
   RenderClipRRect createNode() => new RenderClipRRect(xRadius: xRadius, yRadius: yRadius);
-  RenderClipRRect get root => super.root;
+  RenderClipRRect get renderObject => super.renderObject;
 
   void syncRenderObject(ClipRRect old) {
     super.syncRenderObject(old);
-    root.xRadius = xRadius;
-    root.yRadius = yRadius;
+    renderObject.xRadius = xRadius;
+    renderObject.yRadius = yRadius;
   }
 }
 
@@ -132,7 +132,7 @@ class ClipOval extends OneChildRenderObjectWrapper {
     : super(key: key, child: child);
 
   RenderClipOval createNode() => new RenderClipOval();
-  RenderClipOval get root => super.root;
+  RenderClipOval get renderObject => super.renderObject;
 
   // Nothing to sync, so we don't implement syncRenderObject()
 }
@@ -147,11 +147,11 @@ class Transform extends OneChildRenderObjectWrapper {
   final Matrix4 transform;
 
   RenderTransform createNode() => new RenderTransform(transform: transform);
-  RenderTransform get root => super.root;
+  RenderTransform get renderObject => super.renderObject;
 
   void syncRenderObject(Transform old) {
     super.syncRenderObject(old);
-    root.transform = transform;
+    renderObject.transform = transform;
   }
 }
 
@@ -162,11 +162,11 @@ class Padding extends OneChildRenderObjectWrapper {
   final EdgeDims padding;
 
   RenderPadding createNode() => new RenderPadding(padding: padding);
-  RenderPadding get root => super.root;
+  RenderPadding get renderObject => super.renderObject;
 
   void syncRenderObject(Padding old) {
     super.syncRenderObject(old);
-    root.padding = padding;
+    renderObject.padding = padding;
   }
 }
 
@@ -175,7 +175,7 @@ class Center extends OneChildRenderObjectWrapper {
     : super(key: key, child: child);
 
   RenderPositionedBox createNode() => new RenderPositionedBox();
-  RenderPositionedBox get root => super.root;
+  RenderPositionedBox get renderObject => super.renderObject;
 
   // Nothing to sync, so we don't implement syncRenderObject()
 }
@@ -188,7 +188,7 @@ class SizedBox extends OneChildRenderObjectWrapper {
   final double height;
 
   RenderConstrainedBox createNode() => new RenderConstrainedBox(additionalConstraints: _additionalConstraints());
-  RenderConstrainedBox get root => super.root;
+  RenderConstrainedBox get renderObject => super.renderObject;
 
   BoxConstraints _additionalConstraints() {
     BoxConstraints result = const BoxConstraints();
@@ -201,7 +201,7 @@ class SizedBox extends OneChildRenderObjectWrapper {
 
   void syncRenderObject(SizedBox old) {
     super.syncRenderObject(old);
-    root.additionalConstraints = _additionalConstraints();
+    renderObject.additionalConstraints = _additionalConstraints();
   }
 }
 
@@ -212,11 +212,11 @@ class ConstrainedBox extends OneChildRenderObjectWrapper {
   final BoxConstraints constraints;
 
   RenderConstrainedBox createNode() => new RenderConstrainedBox(additionalConstraints: constraints);
-  RenderConstrainedBox get root => super.root;
+  RenderConstrainedBox get renderObject => super.renderObject;
 
   void syncRenderObject(ConstrainedBox old) {
     super.syncRenderObject(old);
-    root.additionalConstraints = constraints;
+    renderObject.additionalConstraints = constraints;
   }
 }
 
@@ -227,11 +227,11 @@ class AspectRatio extends OneChildRenderObjectWrapper {
   final double aspectRatio;
 
   RenderAspectRatio createNode() => new RenderAspectRatio(aspectRatio: aspectRatio);
-  RenderAspectRatio get root => super.root;
+  RenderAspectRatio get renderObject => super.renderObject;
 
   void syncRenderObject(AspectRatio old) {
     super.syncRenderObject(old);
-    root.aspectRatio = aspectRatio;
+    renderObject.aspectRatio = aspectRatio;
   }
 }
 
@@ -243,12 +243,12 @@ class ShrinkWrapWidth extends OneChildRenderObjectWrapper {
   final double stepHeight;
 
   RenderShrinkWrapWidth createNode() => new RenderShrinkWrapWidth();
-  RenderShrinkWrapWidth get root => super.root;
+  RenderShrinkWrapWidth get renderObject => super.renderObject;
 
   void syncRenderObject(ShrinkWrapWidth old) {
     super.syncRenderObject(old);
-    root.stepWidth = stepWidth;
-    root.stepHeight = stepHeight;
+    renderObject.stepWidth = stepWidth;
+    renderObject.stepHeight = stepHeight;
   }
 }
 
@@ -260,12 +260,12 @@ class Baseline extends OneChildRenderObjectWrapper {
   final TextBaseline baselineType;
 
   RenderBaseline createNode() => new RenderBaseline(baseline: baseline, baselineType: baselineType);
-  RenderBaseline get root => super.root;
+  RenderBaseline get renderObject => super.renderObject;
 
   void syncRenderObject(Baseline old) {
     super.syncRenderObject(old);
-    root.baseline = baseline;
-    root.baselineType = baselineType;
+    renderObject.baseline = baseline;
+    renderObject.baselineType = baselineType;
   }
 }
 
@@ -281,12 +281,12 @@ class Viewport extends OneChildRenderObjectWrapper {
   final ScrollDirection scrollDirection;
 
   RenderViewport createNode() => new RenderViewport(scrollOffset: scrollOffset, scrollDirection: scrollDirection);
-  RenderViewport get root => super.root;
+  RenderViewport get renderObject => super.renderObject;
 
   void syncRenderObject(Viewport old) {
     super.syncRenderObject(old);
-    root.scrollOffset = scrollOffset;
-    root.scrollDirection = scrollDirection;
+    renderObject.scrollOffset = scrollOffset;
+    renderObject.scrollDirection = scrollDirection;
   }
 }
 
@@ -297,15 +297,15 @@ class SizeObserver extends OneChildRenderObjectWrapper {
   final SizeChangedCallback callback;
 
   RenderSizeObserver createNode() => new RenderSizeObserver(callback: callback);
-  RenderSizeObserver get root => super.root;
+  RenderSizeObserver get renderObject => super.renderObject;
 
   void syncRenderObject(SizeObserver old) {
     super.syncRenderObject(old);
-    root.callback = callback;
+    renderObject.callback = callback;
   }
 
   void remove() {
-    root.callback = null;
+    renderObject.callback = null;
     super.remove();
   }
 }
@@ -381,11 +381,11 @@ class Block extends MultiChildRenderObjectWrapper {
   final BlockDirection direction;
 
   RenderBlock createNode() => new RenderBlock(direction: direction);
-  RenderBlock get root => super.root;
+  RenderBlock get renderObject => super.renderObject;
 
   void syncRenderObject(Widget old) {
     super.syncRenderObject(old);
-    root.direction = direction;
+    renderObject.direction = direction;
   }
 }
 
@@ -394,7 +394,7 @@ class Stack extends MultiChildRenderObjectWrapper {
     : super(key: key, children: children);
 
   RenderStack createNode() => new RenderStack();
-  RenderStack get root => super.root;
+  RenderStack get renderObject => super.renderObject;
 }
 
 class Positioned extends ParentDataNode {
@@ -429,14 +429,14 @@ class Flex extends MultiChildRenderObjectWrapper {
   final TextBaseline textBaseline;
 
   RenderFlex createNode() => new RenderFlex(direction: direction);
-  RenderFlex get root => super.root;
+  RenderFlex get renderObject => super.renderObject;
 
   void syncRenderObject(Widget old) {
     super.syncRenderObject(old);
-    root.direction = direction;
-    root.justifyContent = justifyContent;
-    root.alignItems = alignItems;
-    root.textBaseline = textBaseline;
+    renderObject.direction = direction;
+    renderObject.justifyContent = justifyContent;
+    renderObject.alignItems = alignItems;
+    renderObject.textBaseline = textBaseline;
   }
 
 }
@@ -452,11 +452,11 @@ class Paragraph extends LeafRenderObjectWrapper {
   final TextSpan text;
 
   RenderParagraph createNode() => new RenderParagraph(text);
-  RenderParagraph get root => super.root;
+  RenderParagraph get renderObject => super.renderObject;
 
   void syncRenderObject(Widget old) {
     super.syncRenderObject(old);
-    root.text = text;
+    renderObject.text = text;
   }
 }
 
@@ -520,14 +520,14 @@ class Image extends LeafRenderObjectWrapper {
   final sky.ColorFilter colorFilter;
 
   RenderImage createNode() => new RenderImage(image: image, width: width, height: height, colorFilter: colorFilter);
-  RenderImage get root => super.root;
+  RenderImage get renderObject => super.renderObject;
 
   void syncRenderObject(Widget old) {
     super.syncRenderObject(old);
-    root.image = image;
-    root.width = width;
-    root.height = height;
-    root.colorFilter = colorFilter;
+    renderObject.image = image;
+    renderObject.width = width;
+    renderObject.height = height;
+    renderObject.colorFilter = colorFilter;
   }
 }
 
@@ -626,20 +626,20 @@ class WidgetToRenderBoxAdapter extends LeafRenderObjectWrapper {
   final RenderBox renderBox;
 
   RenderBox createNode() => this.renderBox;
-  RenderBox get root => super.root;
+  RenderBox get renderObject => super.renderObject;
 
   void syncRenderObject(Widget old) {
     super.syncRenderObject(old);
     if (old != null) {
       assert(old is WidgetToRenderBoxAdapter);
-      assert(root == old.root);
+      assert(renderObject == old.renderObject);
     }
   }
 
   void remove() {
     RenderObjectWrapper ancestor = findAncestorRenderObjectWrapper();
     assert(ancestor is RenderObjectWrapper);
-    assert(ancestor.root == root.parent);
+    assert(ancestor.renderObject == renderObject.parent);
     ancestor.detachChildRoot(this);
     super.remove();
   }
@@ -652,5 +652,5 @@ class IgnorePointer extends OneChildRenderObjectWrapper {
   IgnorePointer({ Key key, Widget child })
     : super(key: key, child: child);
   RenderIgnorePointer createNode() => new RenderIgnorePointer();
-  RenderIgnorePointer get root => super.root;
+  RenderIgnorePointer get renderObject => super.renderObject;
 }

--- a/sky/packages/sky/lib/widgets/block_viewport.dart
+++ b/sky/packages/sky/lib/widgets/block_viewport.dart
@@ -88,7 +88,7 @@ class BlockViewport extends RenderObjectWrapper {
   Object token;
   BlockViewportLayoutState layoutState;
 
-  RenderBlockViewport get root => super.root;
+  RenderBlockViewport get renderObject => super.renderObject;
   RenderBlockViewport createNode() => new RenderBlockViewport();
 
   void walkChildren(WidgetTreeWalker walker) {
@@ -101,20 +101,20 @@ class BlockViewport extends RenderObjectWrapper {
   void insertChildRoot(RenderObjectWrapper child, dynamic slot) {
     if (slot == _omit)
       return;
-    final root = this.root; // TODO(ianh): Remove this once the analyzer is cleverer
+    final renderObject = this.renderObject; // TODO(ianh): Remove this once the analyzer is cleverer
     assert(slot == null || slot is RenderObject);
-    assert(root is ContainerRenderObjectMixin);
-    root.add(child.root, before: slot);
-    assert(root == this.root); // TODO(ianh): Remove this once the analyzer is cleverer
+    assert(renderObject is ContainerRenderObjectMixin);
+    renderObject.add(child.renderObject, before: slot);
+    assert(renderObject == this.renderObject); // TODO(ianh): Remove this once the analyzer is cleverer
   }
 
   void detachChildRoot(RenderObjectWrapper child) {
-    final root = this.root; // TODO(ianh): Remove this once the analyzer is cleverer
-    assert(root is ContainerRenderObjectMixin);
-    if (child.root.parent != root)
+    final renderObject = this.renderObject; // TODO(ianh): Remove this once the analyzer is cleverer
+    assert(renderObject is ContainerRenderObjectMixin);
+    if (child.renderObject.parent != renderObject)
       return; // probably had slot == _omit when inserted
-    root.remove(child.root);
-    assert(root == this.root); // TODO(ianh): Remove this once the analyzer is cleverer
+    renderObject.remove(child.renderObject);
+    assert(renderObject == this.renderObject); // TODO(ianh): Remove this once the analyzer is cleverer
   }
 
   void remove() {
@@ -126,12 +126,12 @@ class BlockViewport extends RenderObjectWrapper {
   }
 
   void didMount() {
-    root.callback = layout;
+    renderObject.callback = layout;
     super.didMount();
   }
 
   void didUnmount() {
-    root.callback = null;
+    renderObject.callback = null;
     super.didUnmount();
   }
 
@@ -173,12 +173,12 @@ class BlockViewport extends RenderObjectWrapper {
   void syncRenderObject(BlockViewport old) {
     super.syncRenderObject(old);
     if (layoutState._dirty || !layoutState.isValid) {
-      root.markNeedsLayout();
+      renderObject.markNeedsLayout();
     } else {
       if (layoutState._visibleChildCount > 0) {
         assert(layoutState.firstVisibleChildIndex >= 0);
         assert(builder != null);
-        assert(root != null);
+        assert(renderObject != null);
         final int startIndex = layoutState._firstVisibleChildIndex;
         int lastIndex = startIndex + layoutState._visibleChildCount - 1;
         for (int index = startIndex; index <= lastIndex; index += 1) {
@@ -188,8 +188,8 @@ class BlockViewport extends RenderObjectWrapper {
           _Key key = new _Key.fromWidget(widget);
           Widget oldWidget = layoutState._childrenByKey[key];
           assert(oldWidget != null);
-          assert(oldWidget.root.parent == root);
-          widget = syncChild(widget, oldWidget, root.childAfter(oldWidget.root));
+          assert(oldWidget.renderObject.parent == renderObject);
+          widget = syncChild(widget, oldWidget, renderObject.childAfter(oldWidget.renderObject));
           assert(widget != null);
           layoutState._childrenByKey[key] = widget;
         }
@@ -214,7 +214,7 @@ class BlockViewport extends RenderObjectWrapper {
     newWidget = syncChild(newWidget, oldWidget, _omit);
     assert(newWidget != null);
     // Update the offsets based on the newWidget's height.
-    RenderBox widgetRoot = newWidget.root;
+    RenderBox widgetRoot = newWidget.renderObject;
     assert(widgetRoot is RenderBox);
     double newHeight = widgetRoot.getMaxIntrinsicHeight(innerConstraints);
     double oldHeight = offsets[index + 1] - offsets[index];
@@ -237,7 +237,7 @@ class BlockViewport extends RenderObjectWrapper {
     if (index >= offsets.length - 1) {
       assert(index == offsets.length - 1);
       final double widgetStartOffset = offsets[index];
-      RenderBox widgetRoot = widget.root;
+      RenderBox widgetRoot = widget.renderObject;
       assert(widgetRoot is RenderBox);
       final double widgetEndOffset = widgetStartOffset + widgetRoot.getMaxIntrinsicHeight(innerConstraints);
       offsets.add(widgetEndOffset);
@@ -266,7 +266,7 @@ class BlockViewport extends RenderObjectWrapper {
 
     final List<double> offsets = layoutState._childOffsets;
     final Map<_Key, Widget> childrenByKey = layoutState._childrenByKey;
-    final double height = root.size.height;
+    final double height = renderObject.size.height;
     final double endOffset = startOffset + height;
     BoxConstraints innerConstraints = new BoxConstraints.tightFor(width: constraints.constrainWidth());
 
@@ -362,7 +362,7 @@ class BlockViewport extends RenderObjectWrapper {
     int index = startIndex;
     if (haveChildren) {
       // Build all the widgets we need.
-      root.startOffset = offsets[index] - startOffset;
+      renderObject.startOffset = offsets[index] - startOffset;
       while (offsets[index] < endOffset) {
         if (!builtChildren.containsKey(index)) {
           Widget widget = _getWidget(index, innerConstraints);
@@ -392,14 +392,14 @@ class BlockViewport extends RenderObjectWrapper {
       while (index > startIndex) {
         index -= 1;
         Widget widget = builtChildren[index];
-        if (widget.root.parent == root) {
-          root.move(widget.root, before: nextSibling);
+        if (widget.renderObject.parent == renderObject) {
+          renderObject.move(widget.renderObject, before: nextSibling);
         } else {
-          assert(widget.root.parent == null);
-          root.add(widget.root, before: nextSibling);
+          assert(widget.renderObject.parent == null);
+          renderObject.add(widget.renderObject, before: nextSibling);
         }
         widget.updateSlot(nextSibling);
-        nextSibling = widget.root;
+        nextSibling = widget.renderObject;
       }
     }
 

--- a/sky/packages/sky/lib/widgets/checkbox.dart
+++ b/sky/packages/sky/lib/widgets/checkbox.dart
@@ -64,16 +64,16 @@ class _CheckboxWrapper extends LeafRenderObjectWrapper {
   final Color uncheckedColor;
   final Color accentColor;
 
-  _RenderCheckbox get root => super.root;
+  _RenderCheckbox get renderObject => super.renderObject;
   _RenderCheckbox createNode() => new _RenderCheckbox(
       value: value, uncheckedColor: uncheckedColor, onChanged: onChanged);
 
   void syncRenderObject(_CheckboxWrapper old) {
     super.syncRenderObject(old);
-    root.value = value;
-    root.onChanged = onChanged;
-    root.uncheckedColor = uncheckedColor;
-    root.accentColor = accentColor;
+    renderObject.value = value;
+    renderObject.onChanged = onChanged;
+    renderObject.uncheckedColor = uncheckedColor;
+    renderObject.accentColor = accentColor;
   }
 }
 

--- a/sky/packages/sky/lib/widgets/framework.dart
+++ b/sky/packages/sky/lib/widgets/framework.dart
@@ -248,10 +248,10 @@ abstract class Widget {
       (key as GlobalKey)._unregister(this); // TODO(ianh): remove cast when analyzer is cleverer
   }
 
-  RenderObject _root;
+  RenderObject _renderObject;
 
   /// The underlying [RenderObject] associated with this [Widget].
-  RenderObject get root => _root;
+  RenderObject get renderObject => _renderObject;
 
   // Subclasses which implements Nodes that become stateful may return true
   // if the node has become stateful and should be retained.
@@ -273,7 +273,7 @@ abstract class Widget {
   }
 
   void remove() {
-    _root = null;
+    _renderObject = null;
     setParent(null);
   }
 
@@ -318,7 +318,7 @@ abstract class Widget {
           assert(!newNode.mounted);
           oldNode.setParent(this);
           oldNode._sync(newNode, slot);
-          assert(oldNode.root is RenderObject);
+          assert(oldNode.renderObject is RenderObject);
           return oldNode;
         } else {
           oldNode.setParent(null);
@@ -335,7 +335,7 @@ abstract class Widget {
     assert(!newNode.mounted);
     newNode.setParent(this);
     newNode._sync(oldNode, slot);
-    assert(newNode.root is RenderObject);
+    assert(newNode.renderObject is RenderObject);
     return newNode;
   }
 
@@ -374,15 +374,15 @@ abstract class Widget {
   // globalToLocal().
   Point globalToLocal(Point point) {
     assert(mounted);
-    assert(root is RenderBox);
-    return (root as RenderBox).globalToLocal(point);
+    assert(renderObject is RenderBox);
+    return (renderObject as RenderBox).globalToLocal(point);
   }
 
   // See globalToLocal().
   Point localToGlobal(Point point) {
     assert(mounted);
-    assert(root is RenderBox);
-    return (root as RenderBox).localToGlobal(point);
+    assert(renderObject is RenderBox);
+    return (renderObject as RenderBox).localToGlobal(point);
   }
 }
 
@@ -410,9 +410,9 @@ abstract class TagNode extends Widget {
     Widget oldChild = old == null ? null : (old as TagNode).child;
     child = syncChild(child, oldChild, slot);
     assert(child.parent == this);
-    assert(child.root != null);
-    _root = child.root;
-    assert(_root == root); // in case a subclass reintroduces it
+    assert(child.renderObject != null);
+    _renderObject = child.renderObject;
+    assert(_renderObject == renderObject); // in case a subclass reintroduces it
   }
 
   void updateSlot(dynamic newSlot) {
@@ -596,7 +596,7 @@ abstract class Component extends Widget {
 
   void remove() {
     assert(_built != null);
-    assert(root != null);
+    assert(renderObject != null);
     removeChild(_built);
     _built = null;
     super.remove();
@@ -604,7 +604,7 @@ abstract class Component extends Widget {
 
   void detachRoot() {
     assert(_built != null);
-    assert(root != null);
+    assert(renderObject != null);
     _built.detachRoot();
   }
 
@@ -664,15 +664,15 @@ abstract class Component extends Widget {
     _isBuilding = false;
 
     _dirty = false;
-    _root = _built.root;
-    assert(_root == root); // in case a subclass reintroduces it
-    assert(root != null);
+    _renderObject = _built.renderObject;
+    assert(_renderObject == renderObject); // in case a subclass reintroduces it
+    assert(renderObject != null);
   }
 
   void _buildIfDirty() {
     if (!_dirty || !_mounted)
       return;
-    assert(root != null);
+    assert(renderObject != null);
     _sync(null, _slot);
   }
 
@@ -870,8 +870,8 @@ abstract class RenderObjectWrapper extends Widget {
     Widget target = RenderObjectWrapper._getMounted(renderObject);
     if (target == null)
       return;
-    RenderObject targetRoot = target.root;
-    while (target != null && target.root == targetRoot) {
+    RenderObject targetRoot = target.renderObject;
+    while (target != null && target.renderObject == targetRoot) {
       yield target;
       target = target.parent;
     }
@@ -882,7 +882,7 @@ abstract class RenderObjectWrapper extends Widget {
   void detachChildRoot(RenderObjectWrapper child);
 
   void retainStatefulRenderObjectWrapper(RenderObjectWrapper newNode) {
-    newNode._root = _root;
+    newNode._renderObject = _renderObject;
     newNode._ancestor = _ancestor;
   }
 
@@ -892,21 +892,21 @@ abstract class RenderObjectWrapper extends Widget {
     //               doesn't need.
     assert(parent != null || this is RenderViewWrapper);
     if (old == null) {
-      _root = createNode();
-      assert(_root != null);
+      _renderObject = createNode();
+      assert(_renderObject != null);
       _ancestor = findAncestorRenderObjectWrapper();
       if (_ancestor is RenderObjectWrapper)
         _ancestor.insertChildRoot(this, slot);
     } else {
       assert(old is RenderObjectWrapper);
-      _root = old.root;
+      _renderObject = old.renderObject;
       _ancestor = old._ancestor;
-      assert(_root != null);
+      assert(_renderObject != null);
     }
-    assert(_root == root); // in case a subclass reintroduces it
-    assert(root != null);
+    assert(_renderObject == renderObject); // in case a subclass reintroduces it
+    assert(renderObject != null);
     assert(mounted);
-    _nodeMap[root] = this;
+    _nodeMap[renderObject] = this;
     syncRenderObject(old);
   }
 
@@ -930,22 +930,22 @@ abstract class RenderObjectWrapper extends Widget {
       ancestor = ancestor.parent;
     }
     if (parentData != null) {
-      assert(root.parentData != null);
-      root.parentData.merge(parentData); // this will throw if the types aren't appropriate
-      if (ancestor != null && ancestor.root != null)
-        ancestor.root.markNeedsLayout();
+      assert(renderObject.parentData != null);
+      renderObject.parentData.merge(parentData); // this will throw if the types aren't appropriate
+      if (ancestor != null && ancestor.renderObject != null)
+        ancestor.renderObject.markNeedsLayout();
     }
   }
 
   void remove() {
-    assert(root != null);
-    _nodeMap.remove(root);
+    assert(renderObject != null);
+    _nodeMap.remove(renderObject);
     super.remove();
   }
 
   void detachRoot() {
     assert(_ancestor != null);
-    assert(root != null);
+    assert(renderObject != null);
     _ancestor.detachChildRoot(this);
   }
 
@@ -988,19 +988,19 @@ abstract class OneChildRenderObjectWrapper extends RenderObjectWrapper {
   }
 
   void insertChildRoot(RenderObjectWrapper child, dynamic slot) {
-    final root = this.root; // TODO(ianh): Remove this once the analyzer is cleverer
-    assert(root is RenderObjectWithChildMixin);
+    final renderObject = this.renderObject; // TODO(ianh): Remove this once the analyzer is cleverer
+    assert(renderObject is RenderObjectWithChildMixin);
     assert(slot == null);
-    root.child = child.root;
-    assert(root == this.root); // TODO(ianh): Remove this once the analyzer is cleverer
+    renderObject.child = child.renderObject;
+    assert(renderObject == this.renderObject); // TODO(ianh): Remove this once the analyzer is cleverer
   }
 
   void detachChildRoot(RenderObjectWrapper child) {
-    final root = this.root; // TODO(ianh): Remove this once the analyzer is cleverer
-    assert(root is RenderObjectWithChildMixin);
-    assert(root.child == child.root);
-    root.child = null;
-    assert(root == this.root); // TODO(ianh): Remove this once the analyzer is cleverer
+    final renderObject = this.renderObject; // TODO(ianh): Remove this once the analyzer is cleverer
+    assert(renderObject is RenderObjectWithChildMixin);
+    assert(renderObject.child == child.renderObject);
+    renderObject.child = null;
+    assert(renderObject == this.renderObject); // TODO(ianh): Remove this once the analyzer is cleverer
   }
 
   void remove() {
@@ -1029,19 +1029,19 @@ abstract class MultiChildRenderObjectWrapper extends RenderObjectWrapper {
   }
 
   void insertChildRoot(RenderObjectWrapper child, dynamic slot) {
-    final root = this.root; // TODO(ianh): Remove this once the analyzer is cleverer
+    final renderObject = this.renderObject; // TODO(ianh): Remove this once the analyzer is cleverer
     assert(slot == null || slot is RenderObject);
-    assert(root is ContainerRenderObjectMixin);
-    root.add(child.root, before: slot);
-    assert(root == this.root); // TODO(ianh): Remove this once the analyzer is cleverer
+    assert(renderObject is ContainerRenderObjectMixin);
+    renderObject.add(child.renderObject, before: slot);
+    assert(renderObject == this.renderObject); // TODO(ianh): Remove this once the analyzer is cleverer
   }
 
   void detachChildRoot(RenderObjectWrapper child) {
-    final root = this.root; // TODO(ianh): Remove this once the analyzer is cleverer
-    assert(root is ContainerRenderObjectMixin);
-    assert(child.root.parent == root);
-    root.remove(child.root);
-    assert(root == this.root); // TODO(ianh): Remove this once the analyzer is cleverer
+    final renderObject = this.renderObject; // TODO(ianh): Remove this once the analyzer is cleverer
+    assert(renderObject is ContainerRenderObjectMixin);
+    assert(child.renderObject.parent == renderObject);
+    renderObject.remove(child.renderObject);
+    assert(renderObject == this.renderObject); // TODO(ianh): Remove this once the analyzer is cleverer
   }
 
   void remove() {
@@ -1070,8 +1070,8 @@ abstract class MultiChildRenderObjectWrapper extends RenderObjectWrapper {
   void syncRenderObject(MultiChildRenderObjectWrapper old) {
     super.syncRenderObject(old);
 
-    final root = this.root; // TODO(ianh): Remove this once the analyzer is cleverer
-    if (root is! ContainerRenderObjectMixin)
+    final renderObject = this.renderObject; // TODO(ianh): Remove this once the analyzer is cleverer
+    if (renderObject is! ContainerRenderObjectMixin)
       return;
 
     var startIndex = 0;
@@ -1090,7 +1090,7 @@ abstract class MultiChildRenderObjectWrapper extends RenderObjectWrapper {
       assert(children[atIndex] != null);
       assert(children[atIndex].parent == this);
       if (atIndex > 0)
-        children[atIndex-1].updateSlot(children[atIndex].root);
+        children[atIndex-1].updateSlot(children[atIndex].renderObject);
     }
 
     // Scan backwards from end of list while nodes can be directly synced
@@ -1106,7 +1106,7 @@ abstract class MultiChildRenderObjectWrapper extends RenderObjectWrapper {
       endIndex--;
       oldEndIndex--;
       sync(endIndex);
-      nextSibling = children[endIndex].root;
+      nextSibling = children[endIndex].renderObject;
     }
 
     HashMap<Key, Widget> oldNodeIdMap = null;
@@ -1147,28 +1147,28 @@ abstract class MultiChildRenderObjectWrapper extends RenderObjectWrapper {
         return false;
 
       oldNodeIdMap[currentNode.key] = null; // mark it reordered
-      assert(root is ContainerRenderObjectMixin);
-      assert(old.root is ContainerRenderObjectMixin);
-      assert(oldNode.root != null);
+      assert(renderObject is ContainerRenderObjectMixin);
+      assert(old.renderObject is ContainerRenderObjectMixin);
+      assert(oldNode.renderObject != null);
 
-      if (old.root == root) {
-        root.move(oldNode.root, before: nextSibling);
+      if (old.renderObject == renderObject) {
+        renderObject.move(oldNode.renderObject, before: nextSibling);
       } else {
-        (old.root as ContainerRenderObjectMixin).remove(oldNode.root); // TODO(ianh): Remove cast once the analyzer is cleverer
-        root.add(oldNode.root, before: nextSibling);
+        (old.renderObject as ContainerRenderObjectMixin).remove(oldNode.renderObject); // TODO(ianh): Remove cast once the analyzer is cleverer
+        renderObject.add(oldNode.renderObject, before: nextSibling);
       }
 
       return true;
     }
 
     // Scan forwards, this time we may re-order;
-    nextSibling = root.firstChild;
+    nextSibling = renderObject.firstChild;
     while (startIndex < endIndex && oldStartIndex < oldEndIndex) {
       currentNode = children[startIndex];
       oldNode = oldChildren[oldStartIndex];
 
       if (currentNode.runtimeType == oldNode.runtimeType && currentNode.key == oldNode.key) {
-        nextSibling = root.childAfter(nextSibling);
+        nextSibling = renderObject.childAfter(nextSibling);
         sync(startIndex);
         startIndex++;
         advanceOldStartIndex();
@@ -1198,7 +1198,7 @@ abstract class MultiChildRenderObjectWrapper extends RenderObjectWrapper {
       advanceOldStartIndex();
     }
 
-    assert(root == this.root); // TODO(ianh): Remove this once the analyzer is cleverer
+    assert(renderObject == this.renderObject); // TODO(ianh): Remove this once the analyzer is cleverer
   }
 
 }
@@ -1293,7 +1293,7 @@ abstract class AbstractWidgetRoot extends StatefulComponent {
 
 class RenderViewWrapper extends OneChildRenderObjectWrapper {
   RenderViewWrapper({ Key key, Widget child }) : super(key: key, child: child);
-  RenderView get root => super.root;
+  RenderView get renderObject => super.renderObject;
   RenderView createNode() => SkyBinding.instance.renderView;
 }
 
@@ -1337,14 +1337,14 @@ class RenderBoxToWidgetAdapter extends AbstractWidgetRoot {
   void set container(RenderObjectWithChildMixin<RenderBox> value) {
     if (_container != value) {
       assert(value.child == null);
-      if (root != null) {
-        assert(_container.child == root);
+      if (renderObject != null) {
+        assert(_container.child == renderObject);
         _container.child = null;
       }
       _container = value;
-      if (root != null) {
-        _container.child = root;
-        assert(_container.child == root);
+      if (renderObject != null) {
+        _container.child = renderObject;
+        assert(_container.child == renderObject);
       }
     }
   }
@@ -1353,12 +1353,12 @@ class RenderBoxToWidgetAdapter extends AbstractWidgetRoot {
 
   void _buildIfDirty() {
     super._buildIfDirty();
-    if (root.parent == null) {
+    if (renderObject.parent == null) {
       // we haven't attached it yet
       assert(_container.child == null);
-      _container.child = root;
+      _container.child = renderObject;
     }
-    assert(root.parent == _container);
+    assert(renderObject.parent == _container);
   }
 
   Widget build() => builder();

--- a/sky/packages/sky/lib/widgets/ink_well.dart
+++ b/sky/packages/sky/lib/widgets/ink_well.dart
@@ -131,6 +131,6 @@ class InkWell extends OneChildRenderObjectWrapper {
   InkWell({ Key key, Widget child })
     : super(key: key, child: child);
 
-  RenderInkWell get root => super.root;
+  RenderInkWell get renderObject => super.renderObject;
   RenderInkWell createNode() => new RenderInkWell();
 }

--- a/sky/packages/sky/lib/widgets/scaffold.dart
+++ b/sky/packages/sky/lib/widgets/scaffold.dart
@@ -196,7 +196,7 @@ class Scaffold extends RenderObjectWrapper {
 
   Map<ScaffoldSlots, Widget> _slots = new Map<ScaffoldSlots, Widget>();
 
-  RenderScaffold get root => super.root;
+  RenderScaffold get renderObject => super.renderObject;
   RenderScaffold createNode() => new RenderScaffold();
 
   void walkChildren(WidgetTreeWalker walker) {
@@ -208,15 +208,15 @@ class Scaffold extends RenderObjectWrapper {
   }
 
   void insertChildRoot(RenderObjectWrapper child, ScaffoldSlots slot) {
-    root[slot] = child != null ? child.root : null;
+    renderObject[slot] = child != null ? child.renderObject : null;
   }
 
   void detachChildRoot(RenderObjectWrapper child) {
-    final root = this.root; // TODO(ianh): Remove this once the analyzer is cleverer
-    assert(root is RenderScaffold);
-    assert(root == child.root.parent);
-    root.remove(child.root);
-    assert(root == this.root); // TODO(ianh): Remove this once the analyzer is cleverer
+    final renderObject = this.renderObject; // TODO(ianh): Remove this once the analyzer is cleverer
+    assert(renderObject is RenderScaffold);
+    assert(renderObject == child.renderObject.parent);
+    renderObject.remove(child.renderObject);
+    assert(renderObject == this.renderObject); // TODO(ianh): Remove this once the analyzer is cleverer
   }
 
   void remove() {

--- a/sky/packages/sky/lib/widgets/scrollable.dart
+++ b/sky/packages/sky/lib/widgets/scrollable.dart
@@ -233,20 +233,20 @@ Scrollable findScrollableAncestor({ Widget target }) {
 
 bool ensureWidgetIsVisible(Widget target, { ValueAnimation<double> animation }) {
   assert(target.mounted);
-  assert(target.root is RenderBox);
+  assert(target.renderObject is RenderBox);
 
   Scrollable scrollable = findScrollableAncestor(target: target);
   if (scrollable == null)
     return false;
 
-  Size targetSize = (target.root as RenderBox).size;
+  Size targetSize = (target.renderObject as RenderBox).size;
   Point targetCenter = target.localToGlobal(
     scrollable.scrollDirection == ScrollDirection.vertical
       ? new Point(0.0, targetSize.height / 2.0)
       : new Point(targetSize.width / 2.0, 0.0)
   );
 
-  Size scrollableSize = (scrollable.root as RenderBox).size;
+  Size scrollableSize = (scrollable.renderObject as RenderBox).size;
   Point scrollableCenter = scrollable.localToGlobal(
     scrollable.scrollDirection == ScrollDirection.vertical
       ? new Point(0.0, scrollableSize.height / 2.0)

--- a/sky/packages/sky/lib/widgets/switch.dart
+++ b/sky/packages/sky/lib/widgets/switch.dart
@@ -55,15 +55,15 @@ class _SwitchWrapper extends LeafRenderObjectWrapper {
   final ValueChanged onChanged;
   final Color thumbColor;
 
-  _RenderSwitch get root => super.root;
+  _RenderSwitch get renderObject => super.renderObject;
   _RenderSwitch createNode() => new _RenderSwitch(
       value: value, thumbColor: thumbColor, onChanged: onChanged);
 
   void syncRenderObject(_SwitchWrapper old) {
     super.syncRenderObject(old);
-    root.value = value;
-    root.onChanged = onChanged;
-    root.thumbColor = thumbColor;
+    renderObject.value = value;
+    renderObject.onChanged = onChanged;
+    renderObject.thumbColor = thumbColor;
   }
 }
 

--- a/sky/packages/sky/lib/widgets/tabs.dart
+++ b/sky/packages/sky/lib/widgets/tabs.dart
@@ -287,18 +287,18 @@ class TabBarWrapper extends MultiChildRenderObjectWrapper {
   final bool isScrollable;
   final LayoutChanged onLayoutChanged;
 
-  RenderTabBar get root => super.root;
+  RenderTabBar get renderObject => super.renderObject;
   RenderTabBar createNode() => new RenderTabBar(onLayoutChanged);
 
   void syncRenderObject(Widget old) {
     super.syncRenderObject(old);
-    root.selectedIndex = selectedIndex;
-    root.backgroundColor = backgroundColor;
-    root.indicatorColor = indicatorColor;
-    root.indicatorRect = indicatorRect;
-    root.textAndIcons = textAndIcons;
-    root.isScrollable = isScrollable;
-    root.onLayoutChanged = onLayoutChanged;
+    renderObject.selectedIndex = selectedIndex;
+    renderObject.backgroundColor = backgroundColor;
+    renderObject.indicatorColor = indicatorColor;
+    renderObject.indicatorRect = indicatorRect;
+    renderObject.textAndIcons = textAndIcons;
+    renderObject.isScrollable = isScrollable;
+    renderObject.onLayoutChanged = onLayoutChanged;
   }
 }
 


### PR DESCRIPTION
The name `root` is confusing because this value isn't the root of anything.
It's just the associated `RenderObject` instance.