### PR TITLE
Analyzer updates

### DIFF
--- a/sky/tools/shelldb
+++ b/sky/tools/shelldb
@@ -392,39 +392,6 @@ class StopSky(object):
         pids.clear()
 
 
-class Analyze(object):
-    def add_subparser(self, subparsers):
-        analyze_parser = subparsers.add_parser('analyze',
-            help=('run the dart analyzer with sky url mappings'))
-        analyze_parser.add_argument('app_path', type=str)
-        analyze_parser.add_argument('--congratulate', action="store_true")
-        analyze_parser.set_defaults(func=self.run)
-
-    def run(self, args, pids):
-        build_dir = pids.get('build_dir')
-        if not build_dir:
-            logging.fatal("pids file missing build_dir. Try 'start' first.")
-            return 2
-        analyzer_path = os.path.join(SRC_ROOT, 'sky/tools/skyanalyzer')
-        analyzer_args = [
-            analyzer_path,
-            args.app_path
-        ]
-        if args.congratulate:
-          analyzer_args.append('--congratulate')
-        try:
-          output = subprocess.check_output(analyzer_args, stderr=subprocess.STDOUT)
-          result = 0
-        except subprocess.CalledProcessError as e:
-          output = e.output
-          result = e.returncode
-        lines = output.split('\n')
-        lines.pop()
-        for line in lines:
-          print >> sys.stderr, line
-        return result
-
-
 class StartTracing(object):
     def add_subparser(self, subparsers):
         start_tracing_parser = subparsers.add_parser('start_tracing',
@@ -480,7 +447,6 @@ class SkyShellRunner(object):
             SetBuildDir(),
             StartSky(),
             StopSky(),
-            Analyze(),
             GDBAttach(),
             StartTracing(),
             StopTracing(),

--- a/sky/tools/skyanalyzer
+++ b/sky/tools/skyanalyzer
@@ -31,9 +31,6 @@ _IGNORED_PATTERNS = [
   # Ignored because they don't affect Sky code
   re.compile(r'\[hint\] When compiled to JS, this test might return true when the left hand side is an int'),
 
-  # TODO: Remove once sdk-extensions are in place
-  re.compile(r'^\[error\] Native functions can only be declared in'),
-
   # TODO: Fix all the warnings in the mojo packages
   re.compile(r'.*dart-pub-cache.*\.mojom\.dart'),
   re.compile(r'.*dart-pub-cache.*/mojo-'),
@@ -42,10 +39,6 @@ _IGNORED_PATTERNS = [
   # TODO: Remove this once Sky no longer generates this warning.
   # dartbug.com/22836
   re.compile(r'.*cannot both be unnamed'),
-
-  # TODO: Remove this once Sky no longer generates this warning.
-  # dartbug.com/23606
-  re.compile(r'^\[warning] Missing concrete implementation of \'RenderObject.toString\''),
 ]
 
 def main():
@@ -56,7 +49,7 @@ def main():
 
     try:
       subprocess.check_output([
-          DARTANALYZER, "--package-warnings", args.app_path,
+          DARTANALYZER, "--package-warnings", os.path.abspath(args.app_path),
           "--package-root", os.path.join(WORKBENCH, "packages"),
           "--fatal-warnings"
       ], stderr=subprocess.STDOUT, cwd=WORKBENCH)


### PR DESCRIPTION
- Remove shelldb analyze, since we want to remove shelldb.
- Make skyanalyzer pass the absolute path to dartanalyzer. I'm not
  sure why this is sometimes needed, but without it, I sometimes get
  file not found errors.
- Remove some of the patterns we were ignoring, since either the
  errors have been fixed or the analyzer has been fixed.

There's still hundreds of warnings in the mojo and sky packages (the
ones in the sky packages are all bogus, I believe).