### PR TITLE
Don't corrupt drawing when rotating

### DIFF
--- a/sky/shell/gpu/rasterizer.cc
+++ b/sky/shell/gpu/rasterizer.cc
@@ -53,6 +53,9 @@ void Rasterizer::Draw(PassRefPtr<SkPicture> picture) {
   if (size.IsEmpty())
     return;
 
+  if (surface_->GetSize() != size)
+    surface_->Resize(size);
+
   EnsureGLContext();
   CHECK(context_->MakeCurrent(surface_.get()));
   EnsureGaneshSurface(surface_->GetBackingFrameBufferObject(), size);


### PR DESCRIPTION
Previously there was a race condition when updating the size of the GLSurface.
Now we explicitly update the size of the surface to match what we expect.