### PR TITLE
Port clipping to the new layer world.

### DIFF
--- a/sky/engine/core/painting/Canvas.cpp
+++ b/sky/engine/core/painting/Canvas.cpp
@@ -47,6 +47,13 @@ void Canvas::restore()
     m_canvas->restore();
 }
 
+int Canvas::getSaveCount()
+{
+    if (!m_canvas)
+        return 0;
+    return m_canvas->getSaveCount();
+}
+
 void Canvas::translate(float dx, float dy)
 {
     if (!m_canvas)

--- a/sky/engine/core/painting/Canvas.h
+++ b/sky/engine/core/painting/Canvas.h
@@ -63,6 +63,7 @@ public:
     void save();
     void saveLayer(const Rect& bounds, const Paint& paint);
     void restore();
+    int getSaveCount();
 
     void translate(float dx, float dy);
     void scale(float sx, float sy);

--- a/sky/engine/core/painting/Canvas.idl
+++ b/sky/engine/core/painting/Canvas.idl
@@ -11,6 +11,7 @@
   // TODO(jackson): Paint should be optional, but making it optional causes crash
   void saveLayer(Rect bounds, /* optional */ Paint paint);
   void restore();
+  int getSaveCount(); // returns 1 for a clean canvas; each call to save() or saveLayer() increments it, and each call to restore() decrements it.
 
   void translate(float dx, float dy);
   void scale(float sx, float sy);

--- a/sky/packages/sky/lib/rendering/box.dart
+++ b/sky/packages/sky/lib/rendering/box.dart
@@ -805,7 +805,7 @@ class RenderOpacity extends RenderProxyBox {
   Paint _cachedPaint;
   Paint get _paint {
     if (_cachedPaint == null) {
-      _cachedPaint =  new Paint()
+      _cachedPaint = new Paint()
         ..color = new Color.fromARGB(_alpha, 0, 0, 0)
         ..setTransferMode(sky.TransferMode.srcOver)
         ..isAntiAlias = false;
@@ -825,7 +825,7 @@ class RenderOpacity extends RenderProxyBox {
         return;
       }
 
-      context.canvas.saveLayer(null, _paint);
+      context.canvas.saveLayer(null, _paint); // TODO(abarth): layerize
       context.paintChild(child, offset.toPoint());
       context.canvas.restore();
     }
@@ -871,7 +871,7 @@ class RenderColorFilter extends RenderProxyBox {
 
   void paint(PaintingContext context, Offset offset) {
     if (child != null) {
-      context.canvas.saveLayer(offset & size, _paint);
+      context.canvas.saveLayer(offset & size, _paint); // TODO(abarth): layerize
       context.paintChild(child, offset.toPoint());
       context.canvas.restore();
     }
@@ -882,12 +882,8 @@ class RenderClipRect extends RenderProxyBox {
   RenderClipRect({ RenderBox child }) : super(child);
 
   void paint(PaintingContext context, Offset offset) {
-    if (child != null) {
-      context.canvas.save();
-      context.canvas.clipRect(offset & size);
-      context.paintChild(child, offset.toPoint());
-      context.canvas.restore();
-    }
+    if (child != null)
+      context.paintChildWithClip(child, offset.toPoint(), Offset.zero & size);
   }
 }
 
@@ -923,7 +919,7 @@ class RenderClipRRect extends RenderProxyBox {
   void paint(PaintingContext context, Offset offset) {
     if (child != null) {
       Rect rect = offset & size;
-      context.canvas.saveLayer(rect, _paint);
+      context.canvas.saveLayer(rect, _paint); // TODO(abarth): layerize
       sky.RRect rrect = new sky.RRect()..setRectXY(rect, xRadius, yRadius);
       context.canvas.clipRRect(rrect);
       context.paintChild(child, offset.toPoint());
@@ -951,7 +947,7 @@ class RenderClipOval extends RenderProxyBox {
   void paint(PaintingContext context, Offset offset) {
     if (child != null) {
       Rect rect = offset & size;
-      context.canvas.saveLayer(rect, _paint);
+      context.canvas.saveLayer(rect, _paint); // TODO(abarth): layerize
       context.canvas.clipPath(_getPath(rect));
       context.paintChild(child, offset.toPoint());
       context.canvas.restore();

--- a/sky/packages/sky/lib/rendering/layer.dart
+++ b/sky/packages/sky/lib/rendering/layer.dart
@@ -163,14 +163,14 @@ class TransformLayer extends ContainerLayer {
 }
 
 class ClipLayer extends ContainerLayer {
-  ClipLayer({ Offset offset: Offset.zero, this.size }) : super(offset: offset);
+  ClipLayer({ Offset offset: Offset.zero, this.clipRect }) : super(offset: offset);
 
-  Size size;
+  Rect clipRect;
 
   void paint(sky.Canvas canvas) {
     canvas.save();
     canvas.translate(offset.dx, offset.dy);
-    canvas.clipRect(Point.origin & size);
+    canvas.clipRect(clipRect);
     super.paint(canvas);
     canvas.restore();
   }

--- a/sky/tests/resources/display_list.dart
+++ b/sky/tests/resources/display_list.dart
@@ -26,17 +26,24 @@ class TestPaintingCanvas extends PaintingCanvas {
     logger("${indent} ${s}");
   }
 
+  int _saveCount = 1;
+
   void save() {
     log("save");
+    _saveCount += 1;
   }
 
   void saveLayer(Rect bounds, Paint paint) {
     log("saveLayer($bounds, $paint)");
+    _saveCount += 1;
   }
 
   void restore() {
     log("restore");
+    _saveCount -= 1;
   }
+
+  int getSaveCount() => _saveCount;
 
   void translate(double dx, double dy) {
     log("translate($dx, $dy)");


### PR DESCRIPTION
- Add Canvas.getSaveCount()
- Make RenderClipRect call context.paintChildWithClip instead of doing the clipping itself
- Make ClipLayer take a Rect instead of a Size
- Make PaintingContext.canvas read-only
- Add PaintingContext.paintChildWithClip()
- Minor rearrangings of code and style tweaks