### PR TITLE
Borders on Containers shouldn't overlap the content

### DIFF
--- a/sky/packages/sky/lib/painting/box_painter.dart
+++ b/sky/packages/sky/lib/painting/box_painter.dart
@@ -10,6 +10,61 @@ import 'package:sky/base/image_resource.dart';
 import 'package:sky/base/lerp.dart';
 import 'package:sky/painting/shadows.dart';
 
+class EdgeDims {
+  // used for e.g. padding
+  const EdgeDims(this.top, this.right, this.bottom, this.left);
+  const EdgeDims.all(double value)
+      : top = value, right = value, bottom = value, left = value;
+  const EdgeDims.only({ this.top: 0.0,
+                        this.right: 0.0,
+                        this.bottom: 0.0,
+                        this.left: 0.0 });
+  const EdgeDims.symmetric({ double vertical: 0.0,
+                             double horizontal: 0.0 })
+    : top = vertical, left = horizontal, bottom = vertical, right = horizontal;
+
+  final double top;
+  final double right;
+  final double bottom;
+  final double left;
+
+  bool operator ==(other) {
+    if (identical(this, other))
+      return true;
+    return other is EdgeDims
+        && top == other.top
+        && right == other.right
+        && bottom == other.bottom
+        && left == other.left;
+  }
+
+  EdgeDims operator+(EdgeDims other) {
+    return new EdgeDims(top + other.top,
+                        right + other.right,
+                        bottom + other.bottom,
+                        left + other.left);
+  }
+
+  EdgeDims operator-(EdgeDims other) {
+    return new EdgeDims(top - other.top,
+                        right - other.right,
+                        bottom - other.bottom,
+                        left - other.left);
+  }
+
+  static const EdgeDims zero = const EdgeDims(0.0, 0.0, 0.0, 0.0);
+
+  int get hashCode {
+    int value = 373;
+    value = 37 * value + top.hashCode;
+    value = 37 * value + left.hashCode;
+    value = 37 * value + bottom.hashCode;
+    value = 37 * value + right.hashCode;
+    return value;
+  }
+  String toString() => "EdgeDims($top, $right, $bottom, $left)";
+}
+
 class BorderSide {
   const BorderSide({
     this.color: const Color(0xFF000000),
@@ -49,6 +104,10 @@ class Border {
   final BorderSide right;
   final BorderSide bottom;
   final BorderSide left;
+
+  EdgeDims get dimensions {
+    return new EdgeDims(top.width, right.width, bottom.width, left.width);
+  }
 
   int get hashCode {
     int value = 373;

--- a/sky/packages/sky/lib/rendering/box.dart
+++ b/sky/packages/sky/lib/rendering/box.dart
@@ -25,61 +25,6 @@ class _DebugSize extends Size {
   final bool _canBeUsedByParent;
 }
 
-class EdgeDims {
-  // used for e.g. padding
-  const EdgeDims(this.top, this.right, this.bottom, this.left);
-  const EdgeDims.all(double value)
-      : top = value, right = value, bottom = value, left = value;
-  const EdgeDims.only({ this.top: 0.0,
-                        this.right: 0.0,
-                        this.bottom: 0.0,
-                        this.left: 0.0 });
-  const EdgeDims.symmetric({ double vertical: 0.0,
-                             double horizontal: 0.0 })
-    : top = vertical, left = horizontal, bottom = vertical, right = horizontal;
-
-  final double top;
-  final double right;
-  final double bottom;
-  final double left;
-
-  bool operator ==(other) {
-    if (identical(this, other))
-      return true;
-    return other is EdgeDims
-        && top == other.top
-        && right == other.right
-        && bottom == other.bottom
-        && left == other.left;
-  }
-
-  EdgeDims operator+(EdgeDims other) {
-    return new EdgeDims(top + other.top,
-                        right + other.right,
-                        bottom + other.bottom,
-                        left + other.left);
-  }
-
-  EdgeDims operator-(EdgeDims other) {
-    return new EdgeDims(top - other.top,
-                        right - other.right,
-                        bottom - other.bottom,
-                        left - other.left);
-  }
-
-  static const EdgeDims zero = const EdgeDims(0.0, 0.0, 0.0, 0.0);
-
-  int get hashCode {
-    int value = 373;
-    value = 37 * value + top.hashCode;
-    value = 37 * value + left.hashCode;
-    value = 37 * value + bottom.hashCode;
-    value = 37 * value + right.hashCode;
-    return value;
-  }
-  String toString() => "EdgeDims($top, $right, $bottom, $left)";
-}
-
 class BoxConstraints extends Constraints {
   const BoxConstraints({
     this.minWidth: 0.0,

--- a/sky/packages/sky/lib/widgets/basic.dart
+++ b/sky/packages/sky/lib/widgets/basic.dart
@@ -336,14 +336,24 @@ class Container extends Component {
   final double width;
   final double height;
 
+  EdgeDims get _paddingIncludingBorder {
+    if (decoration == null || decoration.border == null)
+      return padding;
+    EdgeDims borderPadding = decoration.border.dimensions;
+    if (padding == null)
+      return borderPadding;
+    return padding + borderPadding;
+  }
+
   Widget build() {
     Widget current = child;
 
     if (child == null && (width == null || height == null))
       current = new ConstrainedBox(constraints: BoxConstraints.expand);
 
-    if (padding != null)
-      current = new Padding(padding: padding, child: current);
+    EdgeDims effectivePadding = _paddingIncludingBorder;
+    if (effectivePadding != null)
+      current = new Padding(padding: effectivePadding, child: current);
 
     if (decoration != null)
       current = new DecoratedBox(decoration: decoration, child: current);

--- a/sky/tests/examples/sector-expected.txt
+++ b/sky/tests/examples/sector-expected.txt
@@ -105,7 +105,7 @@ PAINT FOR FRAME #2 ----------------------------------------------
 2 |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
 2 |  |  |  |  |  | paintChild RenderPadding at Point(187.0, 166.0)
 2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  | paintChild RenderBoxToRenderSectorAdapter at Point(195.0, 174.0)
+2 |  |  |  |  |  |  | paintChild RenderBoxToRenderSectorAdapter at Point(196.0, 175.0)
 2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  |  |  | paintChild RenderSectorRing at Point(400.0, 379.0)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
@@ -231,7 +231,7 @@ PAINT FOR FRAME #3 ----------------------------------------------
 3 |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
 3 |  |  |  |  |  | paintChild RenderPadding at Point(187.0, 166.0)
 3 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-3 |  |  |  |  |  |  | paintChild RenderBoxToRenderSectorAdapter at Point(195.0, 174.0)
+3 |  |  |  |  |  |  | paintChild RenderBoxToRenderSectorAdapter at Point(196.0, 175.0)
 3 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 3 |  |  |  |  |  |  |  | paintChild RenderSectorRing at Point(400.0, 379.0)
 3 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
@@ -360,7 +360,7 @@ PAINT FOR FRAME #4 ----------------------------------------------
 4 |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
 4 |  |  |  |  |  | paintChild RenderPadding at Point(187.0, 166.0)
 4 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-4 |  |  |  |  |  |  | paintChild RenderBoxToRenderSectorAdapter at Point(195.0, 174.0)
+4 |  |  |  |  |  |  | paintChild RenderBoxToRenderSectorAdapter at Point(196.0, 175.0)
 4 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 4 |  |  |  |  |  |  |  | paintChild RenderSectorRing at Point(400.0, 379.0)
 4 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
@@ -492,7 +492,7 @@ PAINT FOR FRAME #5 ----------------------------------------------
 5 |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
 5 |  |  |  |  |  | paintChild RenderPadding at Point(187.0, 166.0)
 5 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-5 |  |  |  |  |  |  | paintChild RenderBoxToRenderSectorAdapter at Point(195.0, 174.0)
+5 |  |  |  |  |  |  | paintChild RenderBoxToRenderSectorAdapter at Point(196.0, 175.0)
 5 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 5 |  |  |  |  |  |  |  | paintChild RenderSectorRing at Point(400.0, 379.0)
 5 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
@@ -627,7 +627,7 @@ PAINT FOR FRAME #6 ----------------------------------------------
 6 |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
 6 |  |  |  |  |  | paintChild RenderPadding at Point(187.0, 166.0)
 6 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-6 |  |  |  |  |  |  | paintChild RenderBoxToRenderSectorAdapter at Point(195.0, 174.0)
+6 |  |  |  |  |  |  | paintChild RenderBoxToRenderSectorAdapter at Point(196.0, 175.0)
 6 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 6 |  |  |  |  |  |  |  | paintChild RenderSectorRing at Point(400.0, 379.0)
 6 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
@@ -759,7 +759,7 @@ PAINT FOR FRAME #7 ----------------------------------------------
 7 |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
 7 |  |  |  |  |  | paintChild RenderPadding at Point(187.0, 166.0)
 7 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-7 |  |  |  |  |  |  | paintChild RenderBoxToRenderSectorAdapter at Point(195.0, 174.0)
+7 |  |  |  |  |  |  | paintChild RenderBoxToRenderSectorAdapter at Point(196.0, 175.0)
 7 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 7 |  |  |  |  |  |  |  | paintChild RenderSectorRing at Point(400.0, 379.0)
 7 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
@@ -888,7 +888,7 @@ PAINT FOR FRAME #8 ----------------------------------------------
 8 |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
 8 |  |  |  |  |  | paintChild RenderPadding at Point(187.0, 166.0)
 8 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-8 |  |  |  |  |  |  | paintChild RenderBoxToRenderSectorAdapter at Point(195.0, 174.0)
+8 |  |  |  |  |  |  | paintChild RenderBoxToRenderSectorAdapter at Point(196.0, 175.0)
 8 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 8 |  |  |  |  |  |  |  | paintChild RenderSectorRing at Point(400.0, 379.0)
 8 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0

--- a/sky/tests/examples/styled_text-expected.txt
+++ b/sky/tests/examples/styled_text-expected.txt
@@ -29,8 +29,10 @@ PAINT FOR FRAME #2 ----------------------------------------------
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0x18000000)))
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
-2 |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(72.0, 223.5)
+2 |  |  |  |  |  |  |  | paintChild RenderPadding at Point(72.0, 223.5)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(72.0, 223.5)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  | paintChild RenderParagraph at Point(8.0, 233.5)
 2 |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  | translate(8.0, 233.5)
@@ -45,8 +47,10 @@ PAINT FOR FRAME #2 ----------------------------------------------
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0x18000000)))
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
-2 |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(72.0, 259.5)
+2 |  |  |  |  |  |  |  | paintChild RenderPadding at Point(72.0, 259.5)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(72.0, 259.5)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  | paintChild RenderParagraph at Point(8.0, 269.5)
 2 |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  | translate(8.0, 269.5)
@@ -61,8 +65,10 @@ PAINT FOR FRAME #2 ----------------------------------------------
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0x18000000)))
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
-2 |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(72.0, 304.5)
+2 |  |  |  |  |  |  |  | paintChild RenderPadding at Point(72.0, 304.5)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(72.0, 304.5)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  | paintChild RenderParagraph at Point(8.0, 314.5)
 2 |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  | translate(8.0, 314.5)
@@ -77,8 +83,10 @@ PAINT FOR FRAME #2 ----------------------------------------------
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0x18000000)))
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
-2 |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(72.0, 340.5)
+2 |  |  |  |  |  |  |  | paintChild RenderPadding at Point(72.0, 340.5)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(72.0, 340.5)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  | paintChild RenderParagraph at Point(8.0, 350.5)
 2 |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  | translate(8.0, 350.5)
@@ -93,8 +101,10 @@ PAINT FOR FRAME #2 ----------------------------------------------
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0x18000000)))
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
-2 |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(72.0, 385.5)
+2 |  |  |  |  |  |  |  | paintChild RenderPadding at Point(72.0, 385.5)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(72.0, 385.5)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  | paintChild RenderParagraph at Point(8.0, 395.5)
 2 |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  | translate(8.0, 395.5)
@@ -109,8 +119,10 @@ PAINT FOR FRAME #2 ----------------------------------------------
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0x18000000)))
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
-2 |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(72.0, 421.5)
+2 |  |  |  |  |  |  |  | paintChild RenderPadding at Point(72.0, 421.5)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(72.0, 421.5)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  | paintChild RenderParagraph at Point(8.0, 431.5)
 2 |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  | translate(8.0, 431.5)
@@ -125,8 +137,10 @@ PAINT FOR FRAME #2 ----------------------------------------------
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0x18000000)))
 2 |  |  |  |  |  |  |  | drawPath(Instance of 'Path', Paint(color:Color(0xff000000)))
-2 |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(72.0, 466.5)
+2 |  |  |  |  |  |  |  | paintChild RenderPadding at Point(72.0, 466.5)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  |  |  |  |  |  |  |  | paintChild RenderConstrainedBox at Point(72.0, 466.5)
+2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  | paintChild RenderParagraph at Point(8.0, 476.5)
 2 |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  | translate(8.0, 476.5)

--- a/sky/tests/widgets/rounded_border-expected.txt
+++ b/sky/tests/widgets/rounded_border-expected.txt
@@ -14,5 +14,7 @@ PAINT FOR FRAME #2 ----------------------------------------------
 2 |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  | drawRRect(Instance of 'RRect', Paint(color:Color(0xff0000ff)))
 2 |  |  |  | drawDRRect(Instance of 'RRect', Instance of 'RRect', Paint(color:Color(0x7fff0000)))
+2 |  |  |  | paintChild RenderPadding at Point(350.0, 250.0)
+2 |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 ------------------------------------------------------------------------
 PAINTED 2 FRAMES


### PR DESCRIPTION
This CL inflates the padding of Container to account for the borders so that
the borders are allocated space in the layout and don't draw behind the
Container's child.