### PR TITLE
Add package:sky/rendering.dart

### DIFF
--- a/examples/mine_digger/lib/main.dart
+++ b/examples/mine_digger/lib/main.dart
@@ -6,7 +6,7 @@ import 'dart:math';
 
 import 'package:sky/mojo/activity.dart' as activity;
 import 'package:sky/painting/text_style.dart';
-import 'package:sky/rendering/flex.dart';
+import 'package:sky/rendering.dart';
 import 'package:sky/theme/colors.dart' as colors;
 import 'package:sky/widgets.dart';
 

--- a/examples/rendering/align_items.dart
+++ b/examples/rendering/align_items.dart
@@ -4,14 +4,7 @@
 
 import 'dart:sky';
 
-import 'package:sky/painting/text_style.dart';
-import 'package:sky/rendering/box.dart';
-import 'package:sky/rendering/flex.dart';
-import 'package:sky/rendering/object.dart';
-import 'package:sky/rendering/paragraph.dart';
-import 'package:sky/rendering/proxy_box.dart';
-import 'package:sky/rendering/shifted_box.dart';
-import 'package:sky/rendering/sky_binding.dart';
+import 'package:sky/rendering.dart';
 
 import 'solid_color_box.dart';
 

--- a/examples/rendering/baseline.dart
+++ b/examples/rendering/baseline.dart
@@ -4,14 +4,7 @@
 
 import 'dart:sky' as sky;
 
-import 'package:sky/painting/text_style.dart';
-import 'package:sky/rendering/box.dart';
-import 'package:sky/rendering/flex.dart';
-import 'package:sky/rendering/object.dart';
-import 'package:sky/rendering/paragraph.dart';
-import 'package:sky/rendering/proxy_box.dart';
-import 'package:sky/rendering/shifted_box.dart';
-import 'package:sky/rendering/sky_binding.dart';
+import 'package:sky/rendering.dart';
 
 RenderBox getBox(double lh) {
   RenderParagraph paragraph = new RenderParagraph(

--- a/examples/rendering/borders.dart
+++ b/examples/rendering/borders.dart
@@ -4,11 +4,7 @@
 
 import 'dart:sky' as sky;
 
-import 'package:sky/rendering/block.dart';
-import 'package:sky/rendering/box.dart';
-import 'package:sky/rendering/proxy_box.dart';
-import 'package:sky/rendering/shifted_box.dart';
-import 'package:sky/rendering/sky_binding.dart';
+import 'package:sky/rendering.dart';
 
 void main() {
   var root = new RenderBlock(children: [

--- a/examples/rendering/flex.dart
+++ b/examples/rendering/flex.dart
@@ -4,11 +4,7 @@
 
 import 'dart:sky' as sky;
 
-import 'package:sky/rendering/box.dart';
-import 'package:sky/rendering/flex.dart';
-import 'package:sky/rendering/proxy_box.dart';
-import 'package:sky/rendering/shifted_box.dart';
-import 'package:sky/rendering/sky_binding.dart';
+import 'package:sky/rendering.dart';
 
 class RenderSolidColor extends RenderDecoratedBox {
   final sky.Size desiredSize;

--- a/examples/rendering/interactive_flex.dart
+++ b/examples/rendering/interactive_flex.dart
@@ -7,14 +7,7 @@ import 'dart:math' as math;
 
 import 'package:sky/mojo/activity.dart' as activity;
 import 'package:sky/mojo/net/image_cache.dart' as image_cache;
-import 'package:sky/painting/text_style.dart';
-import 'package:sky/rendering/flex.dart';
-import 'package:sky/rendering/image.dart';
-import 'package:sky/rendering/object.dart';
-import 'package:sky/rendering/paragraph.dart';
-import 'package:sky/rendering/proxy_box.dart';
-import 'package:sky/rendering/shifted_box.dart';
-import 'package:sky/rendering/sky_binding.dart';
+import 'package:sky/rendering.dart';
 
 import 'solid_color_box.dart';
 

--- a/examples/rendering/justify_content.dart
+++ b/examples/rendering/justify_content.dart
@@ -4,13 +4,7 @@
 
 import 'dart:sky';
 
-import 'package:sky/painting/text_style.dart';
-import 'package:sky/rendering/flex.dart';
-import 'package:sky/rendering/object.dart';
-import 'package:sky/rendering/paragraph.dart';
-import 'package:sky/rendering/proxy_box.dart';
-import 'package:sky/rendering/shifted_box.dart';
-import 'package:sky/rendering/sky_binding.dart';
+import 'package:sky/rendering.dart';
 
 import 'solid_color_box.dart';
 

--- a/examples/rendering/render_paragraph.dart
+++ b/examples/rendering/render_paragraph.dart
@@ -4,12 +4,7 @@
 
 import 'dart:sky';
 
-import 'package:sky/painting/text_style.dart';
-import 'package:sky/rendering/flex.dart';
-import 'package:sky/rendering/object.dart';
-import 'package:sky/rendering/paragraph.dart';
-import 'package:sky/rendering/sky_binding.dart';
-import 'package:sky/rendering/proxy_box.dart';
+import 'package:sky/rendering.dart';
 
 import 'solid_color_box.dart';
 

--- a/examples/rendering/sector_layout.dart
+++ b/examples/rendering/sector_layout.dart
@@ -5,10 +5,7 @@
 import 'dart:math' as math;
 import 'dart:sky' as sky;
 
-import 'package:sky/rendering/box.dart';
-import 'package:sky/rendering/object.dart';
-import 'package:sky/rendering/proxy_box.dart';
-import 'package:sky/rendering/sky_binding.dart';
+import 'package:sky/rendering.dart';
 
 const double kTwoPi = 2 * math.PI;
 

--- a/examples/rendering/shadowed_box.dart
+++ b/examples/rendering/shadowed_box.dart
@@ -4,10 +4,8 @@
 
 import 'dart:sky';
 
-import 'package:sky/rendering/proxy_box.dart';
-import 'package:sky/rendering/shifted_box.dart';
-import 'package:sky/rendering/sky_binding.dart';
-import 'package:sky/theme/colors.dart';
+import 'package:sky/rendering.dart';
+import 'package:sky/theme/colors.dart' as colors;
 import 'package:sky/theme/shadows.dart';
 
 void main() {
@@ -15,7 +13,7 @@ void main() {
     decoration: new BoxDecoration(
       gradient: new RadialGradient(
         center: Point.origin, radius: 500.0,
-        colors: [Yellow[500], Blue[500]]),
+        colors: [colors.Yellow[500], colors.Blue[500]]),
       boxShadow: shadows[3])
   );
   var paddedBox = new RenderPadding(

--- a/examples/rendering/simple_autolayout.dart
+++ b/examples/rendering/simple_autolayout.dart
@@ -5,10 +5,7 @@
 import 'dart:sky';
 
 import 'package:cassowary/cassowary.dart' as al;
-import 'package:sky/rendering/auto_layout.dart';
-import 'package:sky/rendering/object.dart';
-import 'package:sky/rendering/proxy_box.dart';
-import 'package:sky/rendering/sky_binding.dart';
+import 'package:sky/rendering.dart';
 
 void main() {
   RenderDecoratedBox c1 = new RenderDecoratedBox(

--- a/examples/rendering/solid_color_box.dart
+++ b/examples/rendering/solid_color_box.dart
@@ -4,9 +4,7 @@
 
 import 'dart:sky' as sky;
 
-import 'package:sky/rendering/box.dart';
-import 'package:sky/rendering/object.dart';
-import 'package:sky/rendering/proxy_box.dart';
+import 'package:sky/rendering.dart';
 
 class RenderSolidColorBox extends RenderDecoratedBox {
   final Size desiredSize;

--- a/examples/rendering/spinning_flex.dart
+++ b/examples/rendering/spinning_flex.dart
@@ -4,12 +4,8 @@
 
 import 'dart:sky' as sky;
 
-import 'package:sky/base/scheduler.dart';
-import 'package:sky/rendering/flex.dart';
-import 'package:sky/rendering/proxy_box.dart';
-import 'package:sky/rendering/shifted_box.dart';
-import 'package:sky/rendering/sky_binding.dart';
-import 'package:vector_math/vector_math.dart';
+import 'package:sky/base/scheduler.dart' as scheduler;
+import 'package:sky/rendering.dart';
 
 import 'solid_color_box.dart';
 
@@ -35,7 +31,7 @@ void main() {
 
   new SkyBinding(root: root);
 
-  addPersistentFrameCallback(rotate);
+  scheduler.addPersistentFrameCallback(rotate);
 }
 
 void rotate(double timeStamp) {

--- a/examples/rendering/touch_demo.dart
+++ b/examples/rendering/touch_demo.dart
@@ -4,21 +4,17 @@
 
 import 'dart:sky' as sky;
 
-import 'package:sky/rendering/box.dart';
-import 'package:sky/rendering/object.dart';
-import 'package:sky/rendering/paragraph.dart';
-import 'package:sky/rendering/sky_binding.dart';
-import 'package:sky/rendering/stack.dart';
-import 'package:sky/theme/colors.dart';
+import 'package:sky/rendering.dart';
+import 'package:sky/theme/colors.dart' as colors;
 
 // Material design colors. :p
-List<Color> colors = [
-  Teal[500],
-  Amber[500],
-  Purple[500],
-  LightBlue[500],
-  DeepPurple[500],
-  Lime[500],
+List<Color> kColors = [
+  colors.Teal[500],
+  colors.Amber[500],
+  colors.Purple[500],
+  colors.LightBlue[500],
+  colors.DeepPurple[500],
+  colors.Lime[500],
 ];
 
 class Dot {
@@ -47,7 +43,7 @@ class RenderTouchDemo extends RenderBox {
     if (event is sky.PointerEvent) {
       switch (event.type) {
         case 'pointerdown':
-          Color color = colors[event.pointer.remainder(colors.length)];
+          Color color = kColors[event.pointer.remainder(kColors.length)];
           dots[event.pointer] = new Dot(color: color)..update(event);
           break;
         case 'pointerup':

--- a/examples/rendering/transform.dart
+++ b/examples/rendering/transform.dart
@@ -4,11 +4,7 @@
 
 import 'dart:sky' as sky;
 
-import 'package:sky/rendering/box.dart';
-import 'package:sky/rendering/flex.dart';
-import 'package:sky/rendering/proxy_box.dart';
-import 'package:sky/rendering/sky_binding.dart';
-import 'package:vector_math/vector_math.dart';
+import 'package:sky/rendering.dart';
 
 void main() {
   RenderDecoratedBox green = new RenderDecoratedBox(

--- a/examples/stocks/lib/main.dart
+++ b/examples/stocks/lib/main.dart
@@ -8,7 +8,6 @@ import 'dart:math' as math;
 import 'dart:sky' as sky;
 
 import 'package:sky/editing/input.dart';
-import 'package:sky/painting/text_style.dart';
 import 'package:sky/theme/colors.dart' as colors;
 import 'package:sky/theme/typography.dart' as typography;
 import 'package:sky/widgets.dart';

--- a/examples/widgets/big_switch.dart
+++ b/examples/widgets/big_switch.dart
@@ -3,8 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:sky/widgets.dart';
-import 'package:sky/theme/colors.dart';
-import 'package:vector_math/vector_math.dart';
+import 'package:sky/theme/colors.dart' as colors;
 
 class BigSwitchApp extends App {
   bool _value = false;
@@ -23,7 +22,7 @@ class BigSwitchApp extends App {
         padding: new EdgeDims.all(20.0),
         transform: scale,
         decoration: new BoxDecoration(
-          backgroundColor: Teal[600]
+          backgroundColor: colors.Teal[600]
         )
     );
   }

--- a/examples/widgets/block_viewport.dart
+++ b/examples/widgets/block_viewport.dart
@@ -4,14 +4,7 @@
 
 import 'dart:math' as math;
 
-import 'package:sky/widgets/basic.dart';
-import 'package:sky/widgets/block_viewport.dart';
-import 'package:sky/widgets/material.dart';
-import 'package:sky/widgets/raised_button.dart';
-import 'package:sky/widgets/scaffold.dart';
-import 'package:sky/widgets/theme.dart';
-import 'package:sky/widgets/tool_bar.dart';
-import 'package:sky/widgets/framework.dart';
+import 'package:sky/widgets.dart';
 
 class BlockViewportApp extends App {
 

--- a/examples/widgets/card_collection.dart
+++ b/examples/widgets/card_collection.dart
@@ -3,20 +3,9 @@
 // found in the LICENSE file.
 
 import 'package:sky/base/lerp.dart';
-import 'package:sky/painting/text_style.dart';
-import 'package:sky/theme/colors.dart';
-import 'package:sky/widgets/basic.dart';
-import 'package:sky/widgets/block_viewport.dart';
-import 'package:sky/widgets/card.dart';
-import 'package:sky/widgets/dismissable.dart';
-import 'package:sky/widgets/icon.dart';
-import 'package:sky/widgets/scrollable.dart';
-import 'package:sky/widgets/scaffold.dart';
-import 'package:sky/widgets/theme.dart';
-import 'package:sky/widgets/tool_bar.dart';
+import 'package:sky/theme/colors.dart' as colors;
 import 'package:sky/theme/typography.dart' as typography;
-import 'package:sky/widgets/framework.dart';
-import 'package:sky/widgets/task_description.dart';
+import 'package:sky/widgets.dart';
 
 class CardModel {
   CardModel(this.value, this.height, this.color);
@@ -30,7 +19,7 @@ class CardModel {
 class CardCollectionApp extends App {
 
   static const TextStyle cardLabelStyle =
-    const TextStyle(color: white, fontSize: 18.0, fontWeight: bold);
+    const TextStyle(color: colors.white, fontSize: 18.0, fontWeight: bold);
 
   final TextStyle backgroundTextStyle =
     typography.white.title.copyWith(textAlign: TextAlign.center);
@@ -45,7 +34,7 @@ class CardCollectionApp extends App {
       48.0, 63.0, 82.0, 146.0, 60.0, 55.0, 84.0, 96.0, 50.0
     ];
     cardModels = new List.generate(cardHeights.length, (i) {
-      Color color = lerpColor(Red[300], Blue[900], i / cardHeights.length);
+      Color color = lerpColor(colors.Red[300], colors.Blue[900], i / cardHeights.length);
       return new CardModel(i, cardHeights[i], color);
     });
     super.initState();
@@ -123,8 +112,8 @@ class CardCollectionApp extends App {
       child: new Theme(
         data: new ThemeData(
           brightness: ThemeBrightness.light,
-          primarySwatch: Blue,
-          accentColor: RedAccent[200]
+          primarySwatch: colors.Blue,
+          accentColor: colors.RedAccent[200]
         ),
         child: new TaskDescription(
           label: 'Cards',

--- a/examples/widgets/container.dart
+++ b/examples/widgets/container.dart
@@ -2,9 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:sky/rendering/flex.dart';
-import 'package:sky/widgets/raised_button.dart';
-import 'package:sky/widgets/basic.dart';
+import 'package:sky/widgets.dart';
 
 class ContainerApp extends App {
   Widget build() {

--- a/examples/widgets/ensure_visible.dart
+++ b/examples/widgets/ensure_visible.dart
@@ -6,19 +6,8 @@ import 'package:sky/animation/animated_value.dart';
 import 'package:sky/animation/animation_performance.dart';
 import 'package:sky/animation/curves.dart';
 import 'package:sky/base/lerp.dart';
-import 'package:sky/painting/box_painter.dart';
-import 'package:sky/painting/text_style.dart';
-import 'package:sky/theme/colors.dart';
-import 'package:sky/widgets/basic.dart';
-import 'package:sky/widgets/block_viewport.dart';
-import 'package:sky/widgets/card.dart';
-import 'package:sky/widgets/icon.dart';
-import 'package:sky/widgets/scrollable.dart';
-import 'package:sky/widgets/scaffold.dart';
-import 'package:sky/widgets/theme.dart';
-import 'package:sky/widgets/tool_bar.dart';
-import 'package:sky/widgets/framework.dart';
-import 'package:sky/widgets/task_description.dart';
+import 'package:sky/theme/colors.dart' as colors;
+import 'package:sky/widgets.dart';
 
 class CardModel {
   CardModel(this.value, this.height, this.color);
@@ -32,7 +21,7 @@ class CardModel {
 class EnsureVisibleApp extends App {
 
   static const TextStyle cardLabelStyle =
-    const TextStyle(color: white, fontSize: 18.0, fontWeight: bold);
+    const TextStyle(color: colors.white, fontSize: 18.0, fontWeight: bold);
 
   List<CardModel> cardModels;
   BlockViewportLayoutState layoutState = new BlockViewportLayoutState();
@@ -46,7 +35,7 @@ class EnsureVisibleApp extends App {
       48.0, 63.0, 82.0, 146.0, 60.0, 55.0, 84.0, 96.0, 50.0
     ];
     cardModels = new List.generate(cardHeights.length, (i) {
-      Color color = lerpColor(Red[300], Blue[900], i / cardHeights.length);
+      Color color = lerpColor(colors.Red[300], colors.Blue[900], i / cardHeights.length);
       return new CardModel(i, cardHeights[i], color);
     });
 
@@ -97,8 +86,8 @@ class EnsureVisibleApp extends App {
       child: new Theme(
         data: new ThemeData(
           brightness: ThemeBrightness.light,
-          primarySwatch: Blue,
-          accentColor: RedAccent[200]
+          primarySwatch: colors.Blue,
+          accentColor: colors.RedAccent[200]
         ),
         child: new TaskDescription(
           label: 'Cards',

--- a/examples/widgets/horizontal_scrolling.dart
+++ b/examples/widgets/horizontal_scrolling.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:sky/painting/box_painter.dart';
 import 'package:sky/widgets.dart';
 
 class Circle extends Component {

--- a/examples/widgets/navigation.dart
+++ b/examples/widgets/navigation.dart
@@ -2,9 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:sky/widgets/basic.dart';
-import 'package:sky/widgets/navigator.dart';
-import 'package:sky/widgets/raised_button.dart';
+import 'package:sky/widgets.dart';
 
 List<Route> routes = [
   new Route(

--- a/examples/widgets/overlay_geometry.dart
+++ b/examples/widgets/overlay_geometry.dart
@@ -5,20 +5,9 @@
 import 'dart:sky' as sky;
 
 import 'package:sky/base/lerp.dart';
-import 'package:sky/painting/box_painter.dart';
-import 'package:sky/painting/text_style.dart';
-import 'package:sky/rendering/box.dart';
-import 'package:sky/theme/colors.dart';
-import 'package:sky/widgets/basic.dart';
-import 'package:sky/widgets/block_viewport.dart';
-import 'package:sky/widgets/card.dart';
-import 'package:sky/widgets/icon.dart';
-import 'package:sky/widgets/scrollable.dart';
-import 'package:sky/widgets/scaffold.dart';
-import 'package:sky/widgets/theme.dart';
-import 'package:sky/widgets/tool_bar.dart';
-import 'package:sky/widgets/framework.dart';
-import 'package:sky/widgets/task_description.dart';
+import 'package:sky/rendering.dart';
+import 'package:sky/theme/colors.dart' as colors;
+import 'package:sky/widgets.dart';
 
 class CardModel {
   CardModel(this.value, this.height, this.color);
@@ -79,7 +68,7 @@ class Marker extends Component {
 class OverlayGeometryApp extends App {
 
   static const TextStyle cardLabelStyle =
-    const TextStyle(color: white, fontSize: 18.0, fontWeight: bold);
+    const TextStyle(color: colors.white, fontSize: 18.0, fontWeight: bold);
 
   List<CardModel> cardModels;
   BlockViewportLayoutState layoutState = new BlockViewportLayoutState();
@@ -94,7 +83,7 @@ class OverlayGeometryApp extends App {
       48.0, 63.0, 82.0, 146.0, 60.0, 55.0, 84.0, 96.0, 50.0
     ];
     cardModels = new List.generate(cardHeights.length, (i) {
-      Color color = lerpColor(Red[300], Blue[900], i / cardHeights.length);
+      Color color = lerpColor(colors.Red[300], colors.Blue[900], i / cardHeights.length);
       return new CardModel(i, cardHeights[i], color);
     });
     super.initState();
@@ -175,8 +164,8 @@ class OverlayGeometryApp extends App {
       child: new Theme(
         data: new ThemeData(
           brightness: ThemeBrightness.light,
-          primarySwatch: Blue,
-          accentColor: RedAccent[200]
+          primarySwatch: colors.Blue,
+          accentColor: colors.RedAccent[200]
         ),
         child: new TaskDescription(label: 'Cards', child: new Stack(layers))
       )

--- a/examples/widgets/piano.dart
+++ b/examples/widgets/piano.dart
@@ -3,12 +3,12 @@
 // found in the LICENSE file.
 
 import 'package:mojo/mojo/url_response.mojom.dart';
+import 'package:sky_services/media/media.mojom.dart';
 import 'package:sky/mojo/net/fetch.dart';
 import 'package:sky/mojo/shell.dart' as shell;
-import 'package:sky/rendering/flex.dart';
+import 'package:sky/rendering.dart';
 import 'package:sky/theme/colors.dart' as colors;
-import 'package:sky/widgets/basic.dart';
-import 'package:sky_services/media/media.mojom.dart';
+import 'package:sky/widgets.dart';
 
 // All of these sounds are marked as public domain at soundbible.
 const String chimes = "http://soundbible.com/grab.php?id=2030&type=wav";

--- a/examples/widgets/pop_out_and_expand.dart
+++ b/examples/widgets/pop_out_and_expand.dart
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:sky/painting/box_painter.dart';
-import 'package:sky/theme/colors.dart';
+import 'package:sky/theme/colors.dart' as colors;
 import 'package:sky/widgets.dart';
 
 class GreenCard extends Component {
@@ -75,8 +74,8 @@ class ExampleApp extends App {
       child: new Theme(
         data: new ThemeData(
           brightness: ThemeBrightness.light,
-          primarySwatch: Blue,
-          accentColor: RedAccent[200]
+          primarySwatch: colors.Blue,
+          accentColor: colors.RedAccent[200]
         ),
         child: new Scaffold(
           toolbar: new ToolBar(

--- a/examples/widgets/progress_indicator.dart
+++ b/examples/widgets/progress_indicator.dart
@@ -7,16 +7,8 @@ import 'dart:sky' as sky;
 import 'package:sky/animation/animation_performance.dart';
 import 'package:sky/animation/animated_value.dart';
 import 'package:sky/animation/curves.dart';
-import 'package:sky/theme/colors.dart';
-import 'package:sky/widgets/basic.dart';
-import 'package:sky/widgets/icon.dart';
-import 'package:sky/widgets/progress_indicator.dart';
-import 'package:sky/widgets/scaffold.dart';
-import 'package:sky/widgets/theme.dart';
-import 'package:sky/widgets/tool_bar.dart';
-import 'package:sky/widgets/framework.dart';
-import 'package:sky/widgets/task_description.dart';
-import 'package:sky/widgets/transitions.dart';
+import 'package:sky/theme/colors.dart' as colors;
+import 'package:sky/widgets.dart';
 
 class ProgressIndicatorApp extends App {
 
@@ -103,8 +95,8 @@ class ProgressIndicatorApp extends App {
       child: new Theme(
         data: new ThemeData(
           brightness: ThemeBrightness.light,
-          primarySwatch: Blue,
-          accentColor: RedAccent[200]
+          primarySwatch: colors.Blue,
+          accentColor: colors.RedAccent[200]
         ),
         child: new TaskDescription(
           label: 'Cards',

--- a/examples/widgets/sector.dart
+++ b/examples/widgets/sector.dart
@@ -4,16 +4,8 @@
 
 import 'dart:math' as math;
 
-import 'package:sky/rendering/box.dart';
-import 'package:sky/rendering/flex.dart';
-import 'package:sky/widgets/basic.dart';
-import 'package:sky/widgets/material.dart';
-import 'package:sky/widgets/raised_button.dart';
-import 'package:sky/widgets/scaffold.dart';
-import 'package:sky/widgets/task_description.dart';
-import 'package:sky/widgets/theme.dart';
-import 'package:sky/widgets/tool_bar.dart';
-import 'package:sky/widgets/framework.dart';
+import 'package:sky/rendering.dart';
+import 'package:sky/widgets.dart';
 
 import '../rendering/sector_layout.dart';
 

--- a/examples/widgets/spinning_mixed.dart
+++ b/examples/widgets/spinning_mixed.dart
@@ -5,14 +5,8 @@
 import 'dart:sky' as sky;
 
 import 'package:sky/base/scheduler.dart' as scheduler;
-import 'package:sky/rendering/flex.dart';
-import 'package:sky/rendering/proxy_box.dart';
-import 'package:sky/rendering/shifted_box.dart';
-import 'package:sky/rendering/sky_binding.dart';
-import 'package:sky/widgets/basic.dart';
-import 'package:sky/widgets/framework.dart';
-import 'package:sky/widgets/raised_button.dart';
-import 'package:vector_math/vector_math.dart';
+import 'package:sky/rendering.dart';
+import 'package:sky/widgets.dart';
 
 import '../rendering/solid_color_box.dart';
 

--- a/examples/widgets/styled_text.dart
+++ b/examples/widgets/styled_text.dart
@@ -2,17 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:sky/painting/text_style.dart';
-import 'package:sky/rendering/box.dart';
-import 'package:sky/rendering/flex.dart';
+import 'package:sky/rendering.dart';
 import 'package:sky/theme/colors.dart' as colors;
-import 'package:sky/widgets/basic.dart';
-import 'package:sky/widgets/material.dart';
-import 'package:sky/widgets/scaffold.dart';
-import 'package:sky/widgets/theme.dart';
-import 'package:sky/widgets/tool_bar.dart';
-import 'package:sky/widgets/framework.dart';
-
+import 'package:sky/widgets.dart';
 
 class StyledTextApp extends App {
 

--- a/examples/widgets/tabs.dart
+++ b/examples/widgets/tabs.dart
@@ -2,15 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:sky/painting/text_style.dart';
 import 'package:sky/theme/typography.dart' as typography;
-import 'package:sky/widgets/basic.dart';
-import 'package:sky/widgets/card.dart';
-import 'package:sky/widgets/scaffold.dart';
-import 'package:sky/widgets/tabs.dart';
-import 'package:sky/widgets/theme.dart';
-import 'package:sky/widgets/tool_bar.dart';
-import 'package:sky/widgets/framework.dart';
+import 'package:sky/widgets.dart';
 
 class TabbedNavigatorApp extends App {
   // The index of the selected tab for each of the TabNavigators constructed below.

--- a/sky/packages/sky/lib/painting/paragraph_painter.dart
+++ b/sky/packages/sky/lib/painting/paragraph_painter.dart
@@ -6,6 +6,8 @@ import 'dart:sky' as sky;
 
 import 'package:sky/painting/text_style.dart';
 
+export 'package:sky/painting/text_style.dart';
+
 // This must be immutable, because we won't notice when it changes
 abstract class TextSpan {
   sky.Node _toDOM(sky.Document owner);

--- a/sky/packages/sky/lib/rendering.dart
+++ b/sky/packages/sky/lib/rendering.dart
@@ -1,0 +1,23 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Includes and re-exports all Sky rendering classes.
+
+export 'rendering/auto_layout.dart';
+export 'rendering/block.dart';
+export 'rendering/box.dart';
+export 'rendering/flex.dart';
+export 'rendering/image.dart';
+export 'rendering/layer.dart';
+export 'rendering/object.dart';
+export 'rendering/paragraph.dart';
+export 'rendering/proxy_box.dart';
+export 'rendering/shifted_box.dart';
+export 'rendering/sky_binding.dart';
+export 'rendering/stack.dart';
+export 'rendering/toggleable.dart';
+export 'rendering/view.dart';
+export 'rendering/viewport.dart';
+
+export 'package:vector_math/vector_math.dart' show Matrix4;

--- a/sky/packages/sky/lib/rendering/paragraph.dart
+++ b/sky/packages/sky/lib/rendering/paragraph.dart
@@ -6,7 +6,7 @@ import 'package:sky/painting/paragraph_painter.dart';
 import 'package:sky/rendering/box.dart';
 import 'package:sky/rendering/object.dart';
 
-export 'package:sky/painting/paragraph_painter.dart' show TextSpan, PlainTextSpan, StyledTextSpan;
+export 'package:sky/painting/paragraph_painter.dart';
 
 // Unfortunately, using full precision floating point here causes bad layouts
 // because floating point math isn't associative. If we add and subtract

--- a/sky/packages/sky/lib/widgets.dart
+++ b/sky/packages/sky/lib/widgets.dart
@@ -34,6 +34,7 @@ export 'widgets/modal_overlay.dart';
 export 'widgets/navigator.dart';
 export 'widgets/popup_menu.dart';
 export 'widgets/popup_menu_item.dart';
+export 'widgets/progress_indicator.dart';
 export 'widgets/radio.dart';
 export 'widgets/raised_button.dart';
 export 'widgets/scaffold.dart';
@@ -45,3 +46,5 @@ export 'widgets/task_description.dart';
 export 'widgets/theme.dart';
 export 'widgets/tool_bar.dart';
 export 'widgets/transitions.dart';
+
+export 'package:vector_math/vector_math.dart' show Matrix4;

--- a/sky/packages/sky/lib/widgets/basic.dart
+++ b/sky/packages/sky/lib/widgets/basic.dart
@@ -25,11 +25,12 @@ import 'package:sky/widgets/default_text_style.dart';
 import 'package:sky/widgets/framework.dart';
 
 export 'package:sky/base/hit_test.dart' show EventDisposition, combineEventDispositions;
+export 'package:sky/painting/text_style.dart';
 export 'package:sky/rendering/block.dart' show BlockDirection;
 export 'package:sky/rendering/box.dart' show BoxConstraints;
 export 'package:sky/rendering/flex.dart' show FlexDirection, FlexJustifyContent, FlexAlignItems;
 export 'package:sky/rendering/object.dart' show Point, Offset, Size, Rect, Color, Paint, Path;
-export 'package:sky/rendering/proxy_box.dart' show BackgroundImage, BoxDecoration, BoxShadow, Border, BorderSide, EdgeDims;
+export 'package:sky/rendering/proxy_box.dart' show BackgroundImage, BoxDecoration, BoxShadow, Border, BorderSide, EdgeDims, Shape;
 export 'package:sky/rendering/toggleable.dart' show ValueChanged;
 export 'package:sky/rendering/viewport.dart' show ScrollDirection;
 export 'package:sky/widgets/framework.dart' show Key, GlobalKey, Widget, Component, StatefulComponent, App, runApp, Listener, ParentDataNode;


### PR DESCRIPTION
Similar to widgets.dart, rendering.dart exports the entire rendering layer.
Also, update the examples to use rendering.dart and widgets.dart. Also clean up
some exports so that the examples have more sensible imports.