### PR TITLE
Pick a default theme brightness

### DIFF
--- a/sky/packages/sky/lib/theme/theme_data.dart
+++ b/sky/packages/sky/lib/theme/theme_data.dart
@@ -12,7 +12,7 @@ enum ThemeBrightness { dark, light }
 class ThemeData {
 
   ThemeData({
-    ThemeBrightness brightness,
+    ThemeBrightness brightness: ThemeBrightness.light,
     Map<int, Color> primarySwatch,
     Color accentColor,
     this.accentColorBrightness: ThemeBrightness.dark,


### PR DESCRIPTION
There doesn't seem to be any particular reason for us to not default the brightness to _something_.

@collinjackson 