### PR TITLE
Update playfair revision

### DIFF
--- a/examples/BUILD.gn
+++ b/examples/BUILD.gn
@@ -7,8 +7,7 @@ group("examples") {
 
   deps = [
     "//examples/demo_launcher",
-    # TODO(abarth): Add fitness back once playfair rolls
-    #"//examples/fitness",
+    "//examples/fitness",
     "//examples/game",
     "//examples/mine_digger",
     "//examples/rendering",

--- a/examples/fitness/pubspec.yaml
+++ b/examples/fitness/pubspec.yaml
@@ -2,7 +2,7 @@ name: fitness
 dependencies:
   sky: any
   sky_tools: any
-  playfair: any
+  playfair: "^0.0.5"
   path: "^1.3.6"
 dependency_overrides:
   material_design_icons:


### PR DESCRIPTION
... and reattach fitness to the build. We detached fitness from the build
because it was seeing an old version of playfair that didn't work with the most
recent version of the Sky package.