### PR TITLE
Improvements for Layers logic

### DIFF
--- a/sky/packages/sky/lib/rendering/sky_binding.dart
+++ b/sky/packages/sky/lib/rendering/sky_binding.dart
@@ -72,7 +72,7 @@ class SkyBinding {
   }
   void beginFrame(double timeStamp) {
     RenderObject.flushLayout();
-    _renderView.updateCompositing();
+    _renderView.updateCompositingBits();
     RenderObject.flushPaint();
     _renderView.paintFrame();
     _renderView.compositeFrame();

--- a/sky/packages/sky/lib/rendering/viewport.dart
+++ b/sky/packages/sky/lib/rendering/viewport.dart
@@ -122,13 +122,10 @@ class RenderViewport extends RenderBox with RenderObjectWithChildMixin<RenderBox
       Offset roundedScrollOffset = _scrollOffsetRoundedToIntegerDevicePixels;
       bool _needsClip = offset < Offset.zero ||
                         !(offset & size).contains(((offset - roundedScrollOffset) & child.size).bottomRight);
-      if (_needsClip) {
-        context.canvas.save();
-        context.canvas.clipRect(offset & size);
-      }
-      context.paintChild(child, (offset - roundedScrollOffset).toPoint());
       if (_needsClip)
-        context.canvas.restore();
+        context.paintChildWithClipRect(child, (offset - roundedScrollOffset).toPoint(), offset & size);
+      else
+        context.paintChild(child, (offset - roundedScrollOffset).toPoint());
     }
   }
 

--- a/sky/tests/examples/stocks-expected.txt
+++ b/sky/tests/examples/stocks-expected.txt
@@ -96,13 +96,14 @@ PAINT FOR FRAME #2 ----------------------------------------------
 2 |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  | saveLayer(Rect.fromLTRB(728.0, 528.0, 784.0, 584.0), Paint(color:Color(0xff000000)))
 2 |  |  |  |  |  | clipPath(Instance of 'Path')
-2 |  |  |  |  |  | paintChild RenderConstrainedBox at Point(728.0, 528.0)
+2 |  |  |  |  |  | translate(728.0, 528.0)
+2 |  |  |  |  |  | paintChild RenderConstrainedBox at Point(0.0, 0.0)
 2 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  | paintChild RenderInkWell at Point(728.0, 528.0)
+2 |  |  |  |  |  |  | paintChild RenderInkWell at Point(0.0, 0.0)
 2 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(728.0, 528.0)
+2 |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(0.0, 0.0)
 2 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-2 |  |  |  |  |  |  |  |  | paintChild RenderImage at Point(744.0, 544.0)
+2 |  |  |  |  |  |  |  |  | paintChild RenderImage at Point(16.0, 16.0)
 2 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 2 |  |  |  |  |  | restore
 ------------------------------------------------------------------------
@@ -199,13 +200,14 @@ PAINT FOR FRAME #3 ----------------------------------------------
 3 |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 3 |  |  |  |  |  | saveLayer(Rect.fromLTRB(728.0, 528.0, 784.0, 584.0), Paint(color:Color(0xff000000)))
 3 |  |  |  |  |  | clipPath(Instance of 'Path')
-3 |  |  |  |  |  | paintChild RenderConstrainedBox at Point(728.0, 528.0)
+3 |  |  |  |  |  | translate(728.0, 528.0)
+3 |  |  |  |  |  | paintChild RenderConstrainedBox at Point(0.0, 0.0)
 3 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-3 |  |  |  |  |  |  | paintChild RenderInkWell at Point(728.0, 528.0)
+3 |  |  |  |  |  |  | paintChild RenderInkWell at Point(0.0, 0.0)
 3 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-3 |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(728.0, 528.0)
+3 |  |  |  |  |  |  |  | paintChild RenderPositionedBox at Point(0.0, 0.0)
 3 |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-3 |  |  |  |  |  |  |  |  | paintChild RenderImage at Point(744.0, 544.0)
+3 |  |  |  |  |  |  |  |  | paintChild RenderImage at Point(16.0, 16.0)
 3 |  |  |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 3 |  |  |  |  |  | restore
 ------------------------------------------------------------------------

--- a/sky/tests/resources/display_list.dart
+++ b/sky/tests/resources/display_list.dart
@@ -3,10 +3,8 @@ import 'dart:async';
 import 'dart:sky' as sky;
 import 'dart:typed_data';
 
-import 'package:sky/rendering/box.dart';
-import 'package:sky/rendering/object.dart';
-import 'package:sky/rendering/view.dart';
-import 'package:sky/widgets/basic.dart';
+import 'package:sky/rendering.dart';
+import 'package:sky/widgets.dart';
 
 import 'harness.dart';
 
@@ -128,10 +126,14 @@ class TestPaintingContext extends PaintingContext {
 
   TestPaintingCanvas get canvas => super.canvas;
 
-  void paintChild(RenderObject child, Point position) {
-    canvas.log("paintChild ${child.runtimeType} at $position");
+  void insertChild(RenderObject child, Offset offset) {
+    canvas.log("paintChild ${child.runtimeType} at ${offset.toPoint()}");
     TestPaintingCanvas childCanvas = new TestPaintingCanvas(new sky.PictureRecorder(), canvas.size, canvas.logger, indent: "${canvas.indent}  |");
-    child.paint(new TestPaintingContext(childCanvas), position.toOffset());
+    child.paint(new TestPaintingContext(childCanvas), offset);
+  }
+
+  void compositeChild(RenderObject child, { Offset childOffset: Offset.zero, ContainerLayer parentLayer }) {
+    _insertChild(child, childOffset);
   }
 }
 
@@ -197,6 +199,7 @@ class TestRenderView extends RenderView {
   void syncCheckFrame() {
     Component.flushBuild();
     RenderObject.flushLayout();
+    updateCompositingBits();
     paintFrame();
     print(lastPaint); // TODO(ianh): figure out how to make this fit the unit testing framework better
   }

--- a/sky/tests/widgets/buttons-expected.txt
+++ b/sky/tests/widgets/buttons-expected.txt
@@ -64,16 +64,17 @@ PAINT FOR FRAME #4 ----------------------------------------------
 4 |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
 4 |  |  |  | saveLayer(Rect.fromLTRB(372.0, 272.0, 428.0, 328.0), Paint(color:Color(0xff000000)))
 4 |  |  |  | clipPath(Instance of 'Path')
-4 |  |  |  | paintChild RenderConstrainedBox at Point(372.0, 272.0)
+4 |  |  |  | translate(372.0, 272.0)
+4 |  |  |  | paintChild RenderConstrainedBox at Point(0.0, 0.0)
 4 |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-4 |  |  |  |  | paintChild RenderInkWell at Point(372.0, 272.0)
+4 |  |  |  |  | paintChild RenderInkWell at Point(0.0, 0.0)
 4 |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-4 |  |  |  |  |  | paintChild RenderPositionedBox at Point(372.0, 272.0)
+4 |  |  |  |  |  | paintChild RenderPositionedBox at Point(0.0, 0.0)
 4 |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-4 |  |  |  |  |  |  | paintChild RenderParagraph at Point(394.0, 290.0)
+4 |  |  |  |  |  |  | paintChild RenderParagraph at Point(22.0, 18.0)
 4 |  |  |  |  |  |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
-4 |  |  |  |  |  |  |  | translate(394.0, 290.0)
-4 |  |  |  |  |  |  |  | translate(-394.0, -290.0)
+4 |  |  |  |  |  |  |  | translate(22.0, 18.0)
+4 |  |  |  |  |  |  |  | translate(-22.0, -18.0)
 4 |  |  |  | restore
 ------------------------------------------------------------------------
 PAINTED 4 FRAMES


### PR DESCRIPTION
- Introduce some new Layer classes.
- Introduce paintChildWith* methods.
- Convert paint() methods to use paintChildWith* where appropriate.
- Fix paintBounds logic in Layer world.
- Introduce Layer.replaceWith(), so that it's clearer what's going on.
- Make RenderObjects have a ContainerLayer, not a PictureLayer.
- Introduce a PaintingContext.replacingLayer() constructor to highlight
  where we are creating a layer just to replace an older one.
- Rename some layer-related methods and fields for clarity:
   requiresCompositing -> hasLayer
   hasCompositedDescendant -> needsCompositing
   updateCompositing -> updateCompositingBits
   _needsCompositingUpdate -> _needsCompositingBitsUpdate
   markNeedsCompositingUpdate -> markNeedsCompositingBitsUpdate
- After updating compositing bits, if we find that the bit changed, we
  now call markNeedsPaint().
- Reorder markNeedsPaint() logic for clarity.
- Make flushPaint() start at the deepest node.
- Make _compositeChild() avoid repainting children with hasLayer that
  aren't dirty, instead it just reuses their existing layer.
- Made RenderView reuse the RenderObject layer instead of having its own.
- Made RenderView have hasLayer set to true.
- Add various asserts and comments.