### PR TITLE
Split up paintChildWithPaint into paintChildWithOpacity and paintChildWithColorFilter

### DIFF
--- a/sky/packages/sky/lib/rendering/object.dart
+++ b/sky/packages/sky/lib/rendering/object.dart
@@ -188,16 +188,45 @@ class PaintingContext {
     }
   }
 
-  void paintChildWithPaint(RenderObject child, Point childPosition, Rect bounds, Paint paint) {
+  void paintChildWithOpacity(RenderObject child,
+                             Point childPosition,
+                             Rect bounds,
+                             int alpha) {
     assert(debugCanPaintChild(child));
     final Offset childOffset = childPosition.toOffset();
     if (!child.needsCompositing) {
-      canvas.saveLayer(bounds, paint);
+      canvas.saveLayer(bounds, OpacityLayer.paintForAlpha(alpha));
       canvas.translate(childOffset.dx, childOffset.dy);
       insertChild(child, Offset.zero);
       canvas.restore();
     } else {
-      PaintLayer paintLayer = new PaintLayer(offset: childOffset, bounds: bounds, paintSettings: paint);
+      OpacityLayer paintLayer = new OpacityLayer(
+          offset: childOffset,
+          bounds: bounds,
+          alpha: alpha);
+      _containerLayer.add(paintLayer);
+      compositeChild(child, parentLayer: paintLayer);
+    }
+  }
+
+  void paintChildWithColorFilter(RenderObject child,
+                                 Point childPosition,
+                                 Rect bounds,
+                                 Color color,
+                                 sky.TransferMode transferMode) {
+    assert(debugCanPaintChild(child));
+    final Offset childOffset = childPosition.toOffset();
+    if (!child.needsCompositing) {
+      canvas.saveLayer(bounds, ColorFilterLayer.paintForColorFilter(color, transferMode));
+      canvas.translate(childOffset.dx, childOffset.dy);
+      insertChild(child, Offset.zero);
+      canvas.restore();
+    } else {
+      ColorFilterLayer paintLayer = new ColorFilterLayer(
+          offset: childOffset,
+          bounds: bounds,
+          color: color,
+          transferMode: transferMode);
       _containerLayer.add(paintLayer);
       compositeChild(child, parentLayer: paintLayer);
     }

--- a/sky/packages/sky/lib/rendering/proxy_box.dart
+++ b/sky/packages/sky/lib/rendering/proxy_box.dart
@@ -275,22 +275,10 @@ class RenderOpacity extends RenderProxyBox {
     if (_opacity == value)
       return;
     _opacity = value;
-    _cachedPaint = null;
     markNeedsPaint();
   }
 
   int get _alpha => (_opacity * 255).round();
-
-  Paint _cachedPaint;
-  Paint get _paint {
-    if (_cachedPaint == null) {
-      _cachedPaint = new Paint()
-        ..color = new Color.fromARGB(_alpha, 0, 0, 0)
-        ..setTransferMode(sky.TransferMode.srcOver)
-        ..isAntiAlias = false;
-    }
-    return _cachedPaint;
-  }
 
   void paint(PaintingContext context, Offset offset) {
     if (child != null) {
@@ -300,7 +288,7 @@ class RenderOpacity extends RenderProxyBox {
       if (a == 255)
         context.paintChild(child, offset.toPoint());
       else
-        context.paintChildWithPaint(child, offset.toPoint(), null, _paint);
+        context.paintChildWithOpacity(child, offset.toPoint(), null, a);
     }
   }
 }
@@ -317,7 +305,6 @@ class RenderColorFilter extends RenderProxyBox {
     if (_color == value)
       return;
     _color = value;
-    _cachedPaint = null;
     markNeedsPaint();
   }
 
@@ -328,23 +315,12 @@ class RenderColorFilter extends RenderProxyBox {
     if (_transferMode == value)
       return;
     _transferMode = value;
-    _cachedPaint = null;
     markNeedsPaint();
-  }
-
-  Paint _cachedPaint;
-  Paint get _paint {
-    if (_cachedPaint == null) {
-      _cachedPaint = new Paint()
-        ..setColorFilter(new sky.ColorFilter.mode(_color, _transferMode))
-        ..isAntiAlias = false;
-    }
-    return _cachedPaint;
   }
 
   void paint(PaintingContext context, Offset offset) {
     if (child != null)
-      context.paintChildWithPaint(child, offset.toPoint(), offset & size, _paint);
+      context.paintChildWithColorFilter(child, offset.toPoint(), offset & size, _color, _transferMode);
   }
 }
 


### PR DESCRIPTION
The compositor backends we're planning to use can't handle a general-purpose
paint layer and instead need lower-level operations.

Fixes #707