### PR TITLE
Remove RenderView.paintFrame

### DIFF
--- a/sky/packages/sky/lib/rendering/layer.dart
+++ b/sky/packages/sky/lib/rendering/layer.dart
@@ -169,6 +169,19 @@ class ContainerLayer extends Layer {
     child._parent = null;
   }
 
+  void removeAllChildren() {
+    Layer child = _firstChild;
+    while (child != null) {
+      Layer next = child.nextSibling;
+      child._previousSibling = null;
+      child._nextSibling = null;
+      child._parent = null;
+      child = next;
+    }
+    _firstChild = null;
+    _lastChild = null;
+  }
+
   void paint(sky.Canvas canvas) {
     canvas.translate(offset.dx, offset.dy);
     paintChildren(canvas);

--- a/sky/packages/sky/lib/rendering/sky_binding.dart
+++ b/sky/packages/sky/lib/rendering/sky_binding.dart
@@ -44,6 +44,7 @@ class SkyBinding {
       _renderView.attach();
       _renderView.rootConstraints = _createConstraints();
       _renderView.scheduleInitialLayout();
+      _renderView.initializeLayerTree();
     } else {
       _renderView = renderViewOverride;
     }
@@ -74,7 +75,6 @@ class SkyBinding {
     RenderObject.flushLayout();
     _renderView.updateCompositingBits();
     RenderObject.flushPaint();
-    _renderView.paintFrame();
     _renderView.compositeFrame();
   }
 

--- a/sky/packages/sky/lib/rendering/view.dart
+++ b/sky/packages/sky/lib/rendering/view.dart
@@ -42,6 +42,12 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
     markNeedsLayout();
   }
 
+  void initializeLayerTree() {
+    final double devicePixelRatio = sky.view.devicePixelRatio;
+    Matrix4 logicalToDeviceZoom = new Matrix4.diagonal3Values(devicePixelRatio, devicePixelRatio, 1.0);
+    scheduleInitialPaint(new TransformLayer(transform: logicalToDeviceZoom));
+  }
+
   // We never call layout() on this class, so this should never get
   // checked. (This class is laid out using scheduleInitialLayout().)
   bool debugDoesMeetConstraints() { assert(false); return false; }
@@ -82,18 +88,6 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   void paint(PaintingContext context, Offset offset) {
     if (child != null)
       context.paintChild(child, offset.toPoint());
-  }
-
-  void paintFrame() {
-    sky.tracing.begin('RenderView.paintFrame');
-    try {
-      final double devicePixelRatio = sky.view.devicePixelRatio;
-      Matrix4 logicalToDeviceZoom = new Matrix4.diagonal3Values(devicePixelRatio, devicePixelRatio, 1.0);
-      ContainerLayer rootLayer = new TransformLayer(transform: logicalToDeviceZoom);
-      initialPaint(rootLayer, size);
-    } finally {
-      sky.tracing.end('RenderView.paintFrame');
-    }
   }
 
   void compositeFrame() {


### PR DESCRIPTION
We now use the repaint system to do all the painting. During initialization, we
set up a root layer that applies the device pixel ratio.

Fixes #706