### PR TITLE
Stack squishes positioned elements near the edge

### DIFF
--- a/examples/widgets/card_collection.dart
+++ b/examples/widgets/card_collection.dart
@@ -76,6 +76,8 @@ class CardCollectionApp extends App {
     // background (text and icons) will just be clipped, not resized.
     Widget background = new Positioned(
       top: 0.0,
+      right: 0.0,
+      bottom: 0.0,
       left: 0.0,
       child: new Container(
         margin: const EdgeDims.all(4.0),

--- a/sky/packages/sky/lib/rendering/stack.dart
+++ b/sky/packages/sky/lib/rendering/stack.dart
@@ -146,29 +146,19 @@ class RenderStack extends RenderBox with ContainerRenderObjectMixin<RenderBox, S
     assert(size.width == constraints.constrainWidth(width));
     assert(size.height == constraints.constrainHeight(height));
 
-    BoxConstraints innerConstraints = new BoxConstraints.loose(size);
-
     child = firstChild;
     while (child != null) {
       assert(child.parentData is StackParentData);
       final StackParentData childData = child.parentData;
 
       if (childData.isPositioned) {
-        BoxConstraints childConstraints = innerConstraints;
+        BoxConstraints childConstraints = const BoxConstraints();
 
         if (childData.left != null && childData.right != null)
           childConstraints = childConstraints.applyWidth(size.width - childData.right - childData.left);
-        else if (childData.left != null)
-          childConstraints = childConstraints.applyMaxWidth(size.width - childData.left);
-        else if (childData.right != null)
-          childConstraints = childConstraints.applyMaxWidth(size.width - childData.right);
 
         if (childData.top != null && childData.bottom != null)
           childConstraints = childConstraints.applyHeight(size.height - childData.bottom - childData.top);
-        else if (childData.top != null)
-          childConstraints = childConstraints.applyMaxHeight(size.height - childData.top);
-        else if (childData.bottom != null)
-          childConstraints = childConstraints.applyMaxHeight(size.width - childData.bottom);
 
         child.layout(childConstraints, parentUsesSize: true);
 


### PR DESCRIPTION
When laying out positioned children inside a stack, we should give them
unbounded constraints because if they draw outside of the stack, we'll just
clip them.