### PR TITLE
Workaround for Drawer.initState() fails

### DIFF
--- a/sky/packages/sky/lib/widgets/drawer.dart
+++ b/sky/packages/sky/lib/widgets/drawer.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:sky' as sky;
 
 import 'package:sky/animation/animated_value.dart';
@@ -68,7 +69,9 @@ class Drawer extends StatefulComponent {
     _performance.attachedForce = kDefaultSpringForce;
 
     if (navigator != null) {
-      navigator.pushState(this, (_) => _performance.reverse());
+      scheduleMicrotask(() {
+        navigator.pushState(this, (_) => _performance.reverse());
+      });
     }
   }
 


### PR DESCRIPTION
This is a hack to avoid #715 

In theory, the navigator's state should be updated in the event handler that triggers opening the drawer. It's not obvious how to do this, since we only build the Drawer when it's supposed to be visible (and once we're building it's too late). Perhaps responsibility needs to be borne by the StockHome class?