### PR TITLE
Uncaught exceptions get two stack traces

### DIFF
--- a/sky/engine/core/script/dart_service_isolate/server.dart
+++ b/sky/engine/core/script/dart_service_isolate/server.dart
@@ -179,7 +179,6 @@ class Server {
       _notifyServerState(ip, _server.port);
       return this;
     }).catchError((e, st) {
-      print('Could not start Observatory HTTP server:\n$e\n$st\n');
       _notifyServerState("", 0);
       return this;
     });

--- a/sky/engine/tonic/dart_error.cc
+++ b/sky/engine/tonic/dart_error.cc
@@ -16,15 +16,16 @@ const char kInvalidArgument[] = "Invalid argument.";
 
 bool LogIfError(Dart_Handle handle) {
   if (Dart_IsError(handle)) {
-    LOG(ERROR) << Dart_GetError(handle);
-
     // Only unhandled exceptions have stacktraces.
-    if (!Dart_ErrorHasException(handle))
+    if (!Dart_ErrorHasException(handle)) {
+      LOG(ERROR) << Dart_GetError(handle);
       return true;
+    }
 
     Dart_Handle stacktrace = Dart_ErrorGetStacktrace(handle);
     const char* stacktrace_cstr = "";
     Dart_StringToCString(Dart_ToString(stacktrace), &stacktrace_cstr);
+    LOG(ERROR) << "Unhandled exception:";
     LOG(ERROR) << stacktrace_cstr;
     return true;
   }

--- a/sky/shell/dart/dart_library_provider_files.cc
+++ b/sky/shell/dart/dart_library_provider_files.cc
@@ -42,8 +42,10 @@ base::FilePath SimplifyPath(const base::FilePath& path) {
 DartLibraryProviderFiles::DartLibraryProviderFiles(
     const base::FilePath& package_root)
     : package_root_(package_root) {
-    CHECK(base::DirectoryExists(package_root_)) << "Invalid --package-root "
-      << "\"" << package_root_.LossyDisplayName() << "\"";
+    if (package_root_.empty())
+      package_root_ = base::FilePath(FILE_PATH_LITERAL("packages"));
+    if (!base::DirectoryExists(package_root_))
+      package_root_ = base::FilePath();
 }
 
 DartLibraryProviderFiles::~DartLibraryProviderFiles() {
@@ -65,6 +67,8 @@ void DartLibraryProviderFiles::GetLibraryAsStream(
 std::string DartLibraryProviderFiles::CanonicalizePackageURL(std::string url) {
   DCHECK(base::StartsWithASCII(url, "package:", true));
   base::ReplaceFirstSubstringAfterOffset(&url, 0, "package:", "");
+  CHECK(!package_root_.empty())
+      << "Cannot import packages without a valid --package-root";
   return package_root_.Append(url).AsUTF8Unsafe();
 }
 


### PR DESCRIPTION
Now we print Dart_GetError only when we don't have a stack trace. Also, improve
the usability of the sky_shell command line tool by defaulting to "packages"
for the package-root and not crashing when we don't have a package-root until
we actually try to load a package. Finally, remove console spam when we fail to
bind the observatory port.

Fixes #689