### PR TITLE
Rewrite the MultiChildRenderObjectWrapper syncing algorithm.

### DIFF
--- a/sky/tests/widgets/syncs2-expected.txt
+++ b/sky/tests/widgets/syncs2-expected.txt
@@ -1,0 +1,36 @@
+TestRenderView enabled
+
+PAINT FOR FRAME #1 ----------------------------------------------
+1 | TestPaintingCanvas() constructor: 800.0 x 600.0
+------------------------------------------------------------------------
+
+PAINT FOR FRAME #2 ----------------------------------------------
+2 | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 | paintChild RenderFlex at Point(0.0, 0.0)
+2 |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  | paintChild RenderConstrainedBox at Point(350.0, 0.0)
+2 |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+2 |  | paintChild RenderConstrainedBox at Point(350.0, 100.0)
+2 |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+------------------------------------------------------------------------
+
+PAINT FOR FRAME #3 ----------------------------------------------
+3 | TestPaintingCanvas() constructor: 800.0 x 600.0
+3 | paintChild RenderFlex at Point(0.0, 0.0)
+3 |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+3 |  | paintChild RenderConstrainedBox at Point(350.0, 0.0)
+3 |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+3 |  | paintChild RenderPadding at Point(390.0, 100.0)
+3 |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+------------------------------------------------------------------------
+
+PAINT FOR FRAME #4 ----------------------------------------------
+4 | TestPaintingCanvas() constructor: 800.0 x 600.0
+4 | paintChild RenderFlex at Point(0.0, 0.0)
+4 |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+4 |  | paintChild RenderPadding at Point(390.0, 0.0)
+4 |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+4 |  | paintChild RenderPadding at Point(390.0, 20.0)
+4 |  |  | TestPaintingCanvas() constructor: 800.0 x 600.0
+------------------------------------------------------------------------
+PAINTED 4 FRAMES

--- a/sky/tests/widgets/syncs2.dart
+++ b/sky/tests/widgets/syncs2.dart
@@ -1,0 +1,57 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:sky/widgets.dart';
+
+import '../resources/display_list.dart';
+
+// see issue 626
+
+class ProblemComponent extends StatefulComponent {
+
+  void syncFields(ProblemComponent source) { }
+
+  bool _flag = false;
+
+  void flip() {
+    setState(() {
+      _flag = true;
+    });
+  }
+
+  Widget build() {
+    if (_flag)
+      return new Padding(padding: const EdgeDims.all(10.0));
+    return new SizedBox(width: 100.0, height: 100.0);
+  }
+}
+
+ProblemComponent a;
+ProblemComponent b;
+
+class TestApp extends App {
+  Widget build() {
+    return new Flex([
+        a = new ProblemComponent(),
+        b = new ProblemComponent()
+      ],
+    direction: FlexDirection.vertical);
+  }
+}
+
+main() async {
+  try {
+    TestRenderView renderViewOverride = new TestRenderView();
+    TestApp app = new TestApp();
+    runApp(app, renderViewOverride: renderViewOverride);
+    await renderViewOverride.checkFrame();
+    b.flip();
+    await renderViewOverride.checkFrame();
+    a.flip();
+    await renderViewOverride.checkFrame();
+    renderViewOverride.endTest();
+  } catch (e, s) {
+    print("Exception: $e\nStack:\n$s\n");
+  }
+}


### PR DESCRIPTION
This also changes the way we insert nodes into a
MultiChildRenderObjectWrapper's renderObject, which fixes issue #626.
Now, instead of the slot being a renderObject, it's the Widget that
currently uses that renderObject. That way when the Widget changes
which renderObject to use, the siblings of that Widget in the same
child list don't have to be notified of the change.

I tested performance of the new algorithm vs the old algorithm using
the stocks demo at idle and the stocks demo scrolling steadily. The
data suggests the algorithms are roughly equivalent in performance:
![image 1](https://cloud.githubusercontent.com/assets/551196/9395992/9919c464-4746-11e5-9e99-57de849f4fc1.png)