### PR TITLE
Include sky_snapshot in the binary artifacts

### DIFF
--- a/sky/tools/big_red_button.py
+++ b/sky/tools/big_red_button.py
@@ -55,6 +55,7 @@ ARTIFACTS = {
     'linux-x64': [
         Artifact('shell', 'icudtl.dat'),
         Artifact('shell', 'sky_shell'),
+        Artifact('shell', 'sky_snapshot'),
         Artifact('viewer', 'sky_viewer.mojo'),
     ]
 }


### PR DESCRIPTION
We'll need sky_snapshot to produce skyx files and eventually APKs.