### PR TITLE
Introduce sky/unit/test

### DIFF
--- a/sky/packages/sky/pubspec.yaml
+++ b/sky/packages/sky/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   newton: ^0.1.2
   sky_engine: ^0.0.12
   sky_services: ^0.0.12
-  sky_tools: ^0.0.9
+  sky_tools: ^0.0.10
   vector_math: ^1.4.3
 environment:
   sdk: '>=1.8.0 <2.0.0'

--- a/sky/tools/run_tests
+++ b/sky/tools/run_tests
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# Copyright 2015 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import os
+import sys
+import subprocess
+import argparse
+
+SKY_TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
+SKY_ROOT = os.path.dirname(SKY_TOOLS_DIR)
+SRC_ROOT = os.path.dirname(SKY_ROOT)
+
+DART_SDK = os.path.join(SRC_ROOT, 'third_party', 'dart-sdk', 'dart-sdk', 'bin')
+PUB = os.path.join(DART_SDK, 'pub')
+PUB_CACHE = os.path.join(SRC_ROOT, 'dart-pub-cache')
+
+UNIT_DIR = os.path.join(SRC_ROOT, 'sky', 'unit')
+
+def main():
+    parser = argparse.ArgumentParser(description='Runs Sky tests')
+    parser.add_argument('--config', default='Debug')
+    parser.add_argument('--debug', dest='config', action='store_const', const='Debug')
+    parser.add_argument('--release', dest='config', action='store_const', const='Release')
+    args = parser.parse_args()
+
+    build_dir = os.path.join(SRC_ROOT, 'out', args.config)
+
+    sky_shell = None
+    if sys.platform == 'linux2':
+        sky_shell = os.path.join(build_dir, 'sky_shell')
+    elif sys.platform == 'darwin':
+        sky_shell = os.path.join(build_dir, 'SkyShell.app', 'Contents', 'MacOS', 'SkyShell')
+
+    env = os.environ.copy()
+    env['PUB_CACHE'] = PUB_CACHE
+    env['SKY_SHELL'] = sky_shell
+    return subprocess.call([
+        PUB, 'run', 'sky_tools:sky_test',
+    ], cwd=UNIT_DIR, env=env)
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/sky/unit/.gitignore
+++ b/sky/unit/.gitignore
@@ -1,0 +1,3 @@
+.pub
+packages
+pubspec.lock

--- a/sky/unit/pubspec.yaml
+++ b/sky/unit/pubspec.yaml
@@ -1,0 +1,10 @@
+name: sky_unit_tests
+dependencies:
+  sky: any
+  sky_tools: any
+  test: any
+dependency_overrides:
+  material_design_icons:
+    path: ../packages/material_design_icons
+  sky:
+    path: ../packages/sky

--- a/sky/unit/test/harness/trivial_test.dart
+++ b/sky/unit/test/harness/trivial_test.dart
@@ -1,0 +1,7 @@
+import 'package:test/test.dart';
+
+void main() {
+  test("should pass", () {
+    expect(1 + 1, equals(2));
+  });
+}

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -4,3 +4,4 @@ set -ex
 ./sky/tools/gn --release
 ninja -j 4 -C out/Release
 ./sky/tools/skyanalyzer --congratulate examples/stocks/lib/main.dart
+./sky/tools/run_tests --release


### PR DESCRIPTION
This patch adds a new test harness and a first, trivial test to run with the
harness. The new test harness is built on package:test and should run on
Travis. Over time, we'll migrate our existing tests into this harness.