### PR TITLE
Cleanup how we manage scrollOffset in Scrollable

### DIFF
--- a/sky/packages/sky/lib/animation/scroll_behavior.dart
+++ b/sky/packages/sky/lib/animation/scroll_behavior.dart
@@ -17,32 +17,33 @@ abstract class ScrollBehavior {
 
 class BoundedBehavior extends ScrollBehavior {
   BoundedBehavior({ double contentsSize: 0.0, double containerSize: 0.0 })
-    : _contentsSize = contentsSize,
-      _containerSize = containerSize;
+    : _contentsExtents = contentsSize,
+      _containerExtents = containerSize;
 
-  double _contentsSize;
-  double get contentsSize => _contentsSize;
-  void set contentsSize (double value) {
-    if (_contentsSize != value) {
-      _contentsSize = value;
-      // TODO(ianh) now what? what if we have a simulation ongoing?
-    }
-  }
+  double _contentsExtents;
+  double get contentsExtents => _contentsExtents;
 
-  double _containerSize;
-  double get containerSize => _containerSize;
-  void set containerSize (double value) {
-    if (_containerSize != value) {
-      _containerSize = value;
-      // TODO(ianh) now what? what if we have a simulation ongoing?
-    }
+  double _containerExtents;
+  double get containerExtents => _containerExtents;
+
+  /// Returns the new scrollOffset.
+  double updateExtents({
+    double contentsExtents,
+    double containerExtents,
+    double scrollOffset: 0.0
+  }) {
+    if (contentsExtents != null)
+      _contentsExtents = contentsExtents;
+    if (containerExtents != null)
+      _containerExtents = containerExtents;
+    return scrollOffset.clamp(minScrollOffset, maxScrollOffset);
   }
 
   final double minScrollOffset = 0.0;
-  double get maxScrollOffset => math.max(0.0, _contentsSize - _containerSize);
+  double get maxScrollOffset => math.max(0.0, _contentsExtents - _containerExtents);
 
   double applyCurve(double scrollOffset, double scrollDelta) {
-    return (scrollOffset + scrollDelta).clamp(0.0, maxScrollOffset);
+    return (scrollOffset + scrollDelta).clamp(minScrollOffset, maxScrollOffset);
   }
 }
 
@@ -80,7 +81,7 @@ class OverscrollBehavior extends BoundedBehavior {
 }
 
 class OverscrollWhenScrollableBehavior extends OverscrollBehavior {
-  bool get isScrollable => contentsSize > containerSize;
+  bool get isScrollable => contentsExtents > containerExtents;
 
   Simulation release(double position, double velocity) {
     if (isScrollable || position < minScrollOffset || position > maxScrollOffset)

--- a/sky/packages/sky/lib/widgets/tabs.dart
+++ b/sky/packages/sky/lib/widgets/tabs.dart
@@ -460,7 +460,7 @@ class TabBar extends Scrollable {
   }
 
   double _centeredTabScrollOffset(int tabIndex) {
-    double viewportWidth = scrollBehavior.containerSize;
+    double viewportWidth = scrollBehavior.containerExtents;
     return (_tabRect(tabIndex).left + _tabWidths[tabIndex] / 2.0 - viewportWidth / 2.0)
       .clamp(scrollBehavior.minScrollOffset, scrollBehavior.maxScrollOffset);
   }
@@ -495,8 +495,9 @@ class TabBar extends Scrollable {
     setState(() {
       _tabBarSize = tabBarSize;
       _tabWidths = tabWidths;
-      scrollBehavior.containerSize = _tabBarSize.width;
-      scrollBehavior.contentsSize = _tabWidths.reduce((sum, width) => sum + width);
+      scrollBehavior.updateExtents(
+        containerExtents: _tabBarSize.width,
+        contentsExtents: _tabWidths.reduce((sum, width) => sum + width));
     });
   }
 


### PR DESCRIPTION
- Introduce _setScrollOffset as a backend for the animations so that scrollTo
   can stop animations.

 - Create a single function that stops both kinds of scroll animations.

 - Refactor how we update the bounds for bounded scroll behaviors so that we
   update the bounds and compute the new scroll offset at the same time.