### PR TITLE
DrawerItem, DrawerHeader should take a child instead of children

### DIFF
--- a/examples/fitness/lib/feed.dart
+++ b/examples/fitness/lib/feed.dart
@@ -100,26 +100,26 @@ class FeedFragment extends StatefulComponent {
       onDismissed: _handleDrawerDismissed,
       navigator: navigator,
       children: [
-        new DrawerHeader(children: [new Text('Fitness')]),
+        new DrawerHeader(child: new Text('Fitness')),
         new DrawerItem(
           icon: 'action/view_list',
           onPressed: () => _handleFitnessModeChange(FitnessMode.feed),
           selected: _fitnessMode == FitnessMode.feed,
-          children: [new Text('Feed')]),
+          child: new Text('Feed')),
         new DrawerItem(
           icon: 'action/assessment',
           onPressed: () => _handleFitnessModeChange(FitnessMode.chart),
           selected: _fitnessMode == FitnessMode.chart,
-          children: [new Text('Chart')]),
+          child: new Text('Chart')),
         new DrawerDivider(),
         new DrawerItem(
           icon: 'action/settings',
           onPressed: _handleShowSettings,
-          children: [new Text('Settings')]),
+          child: new Text('Settings')),
         new DrawerItem(
           icon: 'action/help',
-          children: [new Text('Help & Feedback')])
-     ]
+          child: new Text('Help & Feedback'))
+      ]
     );
   }
 

--- a/examples/fitness/lib/settings.dart
+++ b/examples/fitness/lib/settings.dart
@@ -112,19 +112,17 @@ class SettingsFragment extends StatefulComponent {
           child: new BlockBody([
             new DrawerItem(
               onPressed: () { _handleBackupChanged(!(userData.backupMode == BackupMode.enabled)); },
-              children: [
+              child: new Flex([
                 new Flexible(child: new Text('Back up data to the cloud')),
                 new Switch(value: userData.backupMode == BackupMode.enabled, onChanged: _handleBackupChanged)
-              ]
+              ], direction: FlexDirection.horizontal)
             ),
             new DrawerItem(
               onPressed: () => _handleGoalWeightPressed(),
-              children: [
-                new Flex([
-                  new Text('Goal Weight'),
-                  new Text(goalWeightText, style: Theme.of(this).text.caption),
-                ], direction: FlexDirection.vertical, alignItems: FlexAlignItems.start)
-              ]
+              child: new Flex([
+                new Text('Goal Weight'),
+                new Text(goalWeightText, style: Theme.of(this).text.caption),
+              ], direction: FlexDirection.vertical, alignItems: FlexAlignItems.start)
             ),
           ])
         )

--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -122,37 +122,37 @@ class StockHome extends StatefulComponent {
       onDismissed: _handleDrawerDismissed,
       navigator: navigator,
       children: [
-        new DrawerHeader(children: [new Text('Stocks')]),
+        new DrawerHeader(child: new Text('Stocks')),
         new DrawerItem(
           icon: 'action/assessment',
           selected: true,
-          children: [new Text('Stock List')]),
+          child: new Text('Stock List')),
         new DrawerItem(
           icon: 'action/account_balance',
-          children: [new Text('Account Balance')]),
+          child: new Text('Account Balance')),
         new DrawerDivider(),
         new DrawerItem(
           icon: 'action/thumb_up',
           onPressed: () => _handleStockModeChange(StockMode.optimistic),
-          children: [
+          child: new Flex([
             new Flexible(child: new Text('Optimistic')),
             new Radio(value: StockMode.optimistic, groupValue: stockMode, onChanged: _handleStockModeChange)
-          ]),
+          ], direction: FlexDirection.horizontal)),
         new DrawerItem(
           icon: 'action/thumb_down',
           onPressed: () => _handleStockModeChange(StockMode.pessimistic),
-          children: [
+          child: new Flex([
             new Flexible(child: new Text('Pessimistic')),
             new Radio(value: StockMode.pessimistic, groupValue: stockMode, onChanged: _handleStockModeChange)
-          ]),
+          ], direction: FlexDirection.horizontal)),
         new DrawerDivider(),
         new DrawerItem(
           icon: 'action/settings',
           onPressed: _handleShowSettings,
-          children: [new Text('Settings')]),
+          child: new Text('Settings')),
         new DrawerItem(
           icon: 'action/help',
-          children: [new Text('Help & Feedback')])
+          child: new Text('Help & Feedback'))
      ]
     );
   }

--- a/examples/stocks/lib/stock_settings.dart
+++ b/examples/stocks/lib/stock_settings.dart
@@ -102,18 +102,18 @@ class StockSettings extends StatefulComponent {
             new DrawerItem(
               icon: 'action/thumb_up',
               onPressed: () => _confirmOptimismChange(),
-              children: [
+              child: new Flex([
                 new Flexible(child: new Text('Everything is awesome')),
                 new Checkbox(value: optimism == StockMode.optimistic, onChanged: (_) => _confirmOptimismChange())
-              ]
+              ], direction: FlexDirection.horizontal)
             ),
             new DrawerItem(
               icon: 'action/backup',
               onPressed: () { _handleBackupChanged(!(backup == BackupMode.enabled)); },
-              children: [
+              child: new Flex([
                 new Flexible(child: new Text('Back up stock list to the cloud')),
                 new Switch(value: backup == BackupMode.enabled, onChanged: _handleBackupChanged)
-              ]
+              ], direction: FlexDirection.horizontal)
             ),
           ])
         )

--- a/sky/packages/sky/lib/widgets/drawer_header.dart
+++ b/sky/packages/sky/lib/widgets/drawer_header.dart
@@ -12,9 +12,9 @@ import 'package:sky/widgets/theme.dart';
 
 class DrawerHeader extends Component {
 
-  DrawerHeader({ Key key, this.children }) : super(key: key);
+  DrawerHeader({ Key key, this.child }) : super(key: key);
 
-  final List<Widget> children;
+  final Widget child;
 
   Widget build() {
     return new Container(
@@ -36,7 +36,7 @@ class DrawerHeader extends Component {
           padding: const EdgeDims.symmetric(horizontal: 16.0),
           child: new DefaultTextStyle(
             style: Theme.of(this).text.body2,
-            child: new Flex(children, direction: FlexDirection.horizontal)
+            child: child
           )
         )],
         direction: FlexDirection.vertical

--- a/sky/packages/sky/lib/widgets/drawer_item.dart
+++ b/sky/packages/sky/lib/widgets/drawer_item.dart
@@ -17,17 +17,17 @@ import 'package:sky/widgets/framework.dart';
 typedef EventDisposition OnPressedFunction();
 
 class DrawerItem extends ButtonBase {
-  DrawerItem({ Key key, this.icon, this.children, this.onPressed, this.selected: false })
+  DrawerItem({ Key key, this.icon, this.child, this.onPressed, this.selected: false })
     : super(key: key);
 
   String icon;
-  List<Widget> children;
+  Widget child;
   OnPressedFunction onPressed;
   bool selected;
 
   void syncConstructorArguments(DrawerItem source) {
     icon = source.icon;
-    children = source.children;
+    child = source.child;
     onPressed = source.onPressed;
     selected = source.selected;
     super.syncConstructorArguments(source);
@@ -75,7 +75,7 @@ class DrawerItem extends ButtonBase {
           padding: const EdgeDims.symmetric(horizontal: 16.0),
           child: new DefaultTextStyle(
             style: _getTextStyle(themeData),
-            child: new Flex(children, direction: FlexDirection.horizontal)
+            child: child
           )
         )
       )


### PR DESCRIPTION
These widgets were designed in CSS where you need to specify a layout model for
your children. This patch updates them to the modern style of just taking a
unique child.

Fixes #755