### PR TITLE
Add GlobalKey.registerAddListener

### DIFF
--- a/sky/packages/sky/lib/widgets/focus.dart
+++ b/sky/packages/sky/lib/widgets/focus.dart
@@ -104,9 +104,9 @@ class Focus extends StatefulComponent {
     }
   }
 
-  void _widgetRemoved(GlobalKey key) {
+  void _handleWidgetRemoved(GlobalKey key) {
     assert(_focusedWidget == key);
-    _currentlyRegisteredWidgetRemovalListenerKey = null;
+    _updateWidgetRemovalListener(null);
     setState(() {
       _focusedWidget = null;
     });
@@ -115,9 +115,9 @@ class Focus extends StatefulComponent {
   void _updateWidgetRemovalListener(GlobalKey key) {
     if (_currentlyRegisteredWidgetRemovalListenerKey != key) {
       if (_currentlyRegisteredWidgetRemovalListenerKey != null)
-        GlobalKey.unregisterRemovalListener(_currentlyRegisteredWidgetRemovalListenerKey, _widgetRemoved);
+        GlobalKey.unregisterRemoveListener(_currentlyRegisteredWidgetRemovalListenerKey, _handleWidgetRemoved);
       if (key != null)
-        GlobalKey.registerRemovalListener(key, _widgetRemoved);
+        GlobalKey.registerRemoveListener(key, _handleWidgetRemoved);
       _currentlyRegisteredWidgetRemovalListenerKey = key;
     }
   }
@@ -151,9 +151,9 @@ class Focus extends StatefulComponent {
   void _updateScopeRemovalListener(GlobalKey key) {
     if (_currentlyRegisteredScopeRemovalListenerKey != key) {
       if (_currentlyRegisteredScopeRemovalListenerKey != null)
-        GlobalKey.unregisterRemovalListener(_currentlyRegisteredScopeRemovalListenerKey, _scopeRemoved);
+        GlobalKey.unregisterRemoveListener(_currentlyRegisteredScopeRemovalListenerKey, _scopeRemoved);
       if (key != null)
-        GlobalKey.registerRemovalListener(key, _scopeRemoved);
+        GlobalKey.registerRemoveListener(key, _scopeRemoved);
       _currentlyRegisteredScopeRemovalListenerKey = key;
     }
   }

--- a/sky/unit/test/widget/build_utils.dart
+++ b/sky/unit/test/widget/build_utils.dart
@@ -1,0 +1,48 @@
+import 'package:sky/rendering.dart';
+import 'package:sky/widgets.dart';
+
+const Size _kTestViewSize = const Size(800.0, 600.0);
+
+class TestRenderView extends RenderView {
+  TestRenderView({ RenderBox child }) : super(child: child) {
+    attach();
+    rootConstraints = new ViewConstraints(size: _kTestViewSize);
+    scheduleInitialLayout();
+  }
+}
+
+typedef Widget WidgetBuilder();
+
+class TestApp extends App {
+  TestApp();
+
+  WidgetBuilder _builder;
+  void set builder (WidgetBuilder value) {
+    setState(() {
+      _builder = value;
+    });
+  }
+
+  Widget build() {
+    if (_builder != null)
+      return _builder();
+    return new Container();
+  }
+}
+
+class WidgetTester {
+  WidgetTester() {
+    _app = new TestApp();
+    _renderView = new TestRenderView();
+    runApp(_app, renderViewOverride: _renderView);
+  }
+
+  TestApp _app;
+  RenderView _renderView;
+
+  void pumpFrame(WidgetBuilder builder) {
+    _app.builder = builder;
+    Component.flushBuild();
+    RenderObject.flushLayout();
+  }
+}

--- a/sky/unit/test/widget/global_key_test.dart
+++ b/sky/unit/test/widget/global_key_test.dart
@@ -1,0 +1,109 @@
+import 'package:sky/widgets.dart';
+import 'package:test/test.dart';
+
+import 'build_utils.dart';
+
+void main() {
+  test('Global keys notify add and remove', () {
+    GlobalKey globalKey = new GlobalKey();
+    Container container;
+
+    bool syncListenerCalled = false;
+    bool removeListenerCalled = false;
+
+    void syncListener(GlobalKey key, Widget widget) {
+      syncListenerCalled = true;
+      expect(key, equals(globalKey));
+      expect(container, isNotNull);
+      expect(widget, equals(container));
+    }
+
+    void removeListener(GlobalKey key) {
+      removeListenerCalled = true;
+      expect(key, equals(globalKey));
+    }
+
+    WidgetTester tester = new WidgetTester();
+
+    GlobalKey.registerSyncListener(globalKey, syncListener);
+    GlobalKey.registerRemoveListener(globalKey, removeListener);
+    tester.pumpFrame(() {
+      container = new Container(key: globalKey);
+      return container;
+    });
+    expect(syncListenerCalled, isTrue);
+    expect(removeListenerCalled, isFalse);
+
+    syncListenerCalled = false;
+    removeListenerCalled = false;
+    tester.pumpFrame(() => new Container());
+    expect(syncListenerCalled, isFalse);
+    expect(removeListenerCalled, isTrue);
+
+    syncListenerCalled = false;
+    removeListenerCalled = false;
+    GlobalKey.unregisterSyncListener(globalKey, syncListener);
+    GlobalKey.unregisterRemoveListener(globalKey, removeListener);
+    tester.pumpFrame(() {
+      container = new Container(key: globalKey);
+      return container;
+    });
+    expect(syncListenerCalled, isFalse);
+    expect(removeListenerCalled, isFalse);
+
+    tester.pumpFrame(() => new Container());
+    expect(syncListenerCalled, isFalse);
+    expect(removeListenerCalled, isFalse);
+  });
+
+  test('Global key reparenting', () {
+    GlobalKey globalKey = new GlobalKey();
+
+    bool syncListenerCalled = false;
+    bool removeListenerCalled = false;
+
+    void syncListener(GlobalKey key, Widget widget) {
+      syncListenerCalled = true;
+    }
+
+    void removeListener(GlobalKey key) {
+      removeListenerCalled = true;
+    }
+
+    GlobalKey.registerSyncListener(globalKey, syncListener);
+    GlobalKey.registerRemoveListener(globalKey, removeListener);
+    WidgetTester tester = new WidgetTester();
+
+    tester.pumpFrame(() {
+      return new Container(
+        child: new Container(
+          key: globalKey
+        )
+      );
+    });
+    expect(syncListenerCalled, isTrue);
+    expect(removeListenerCalled, isFalse);
+
+    tester.pumpFrame(() {
+      return new Container(
+        key: globalKey,
+        child: new Container()
+      );
+    });
+    expect(syncListenerCalled, isTrue);
+    expect(removeListenerCalled, isFalse);
+
+    tester.pumpFrame(() {
+      return new Container(
+        child: new Container(
+          key: globalKey
+        )
+      );
+    });
+    expect(syncListenerCalled, isTrue);
+    expect(removeListenerCalled, isFalse);
+
+    GlobalKey.unregisterSyncListener(globalKey, syncListener);
+    GlobalKey.unregisterRemoveListener(globalKey, removeListener);
+  });
+}


### PR DESCRIPTION
This lets clients listen for when a particular global key is added to the
registry. We'll need this for mimic to track its mimicable when it moves around
the tree.