### PR TITLE
Better exception handling for rendering library.

### DIFF
--- a/sky/packages/sky/lib/rendering/flex.dart
+++ b/sky/packages/sky/lib/rendering/flex.dart
@@ -512,7 +512,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
 
   String toStringName() {
     String header = super.toStringName();
-    if (_overflow > 0.0)
+    if (_overflow is double && _overflow > 0.0)
       header += ' OVERFLOWING';
     return header;
   }

--- a/sky/packages/sky/lib/widgets/framework.dart
+++ b/sky/packages/sky/lib/widgets/framework.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:sky' as sky;
 
+import 'package:sky/base/debug.dart';
 import 'package:sky/base/hit_test.dart';
 import 'package:sky/base/scheduler.dart' as scheduler;
 import 'package:sky/mojo/activity.dart';
@@ -954,6 +955,13 @@ abstract class RenderObjectWrapper extends Widget {
       _renderObject = old.renderObject;
       _ancestor = old._ancestor;
       assert(_renderObject != null);
+    }
+    if (inDebugBuild) {
+      try {
+        throw null;
+      } catch (_, stack) {
+        _renderObject.debugExceptionContext = stack;
+      }
     }
     assert(_renderObject == renderObject); // in case a subclass reintroduces it
     assert(renderObject != null);


### PR DESCRIPTION
- Catch exceptions closer to the source.
- Factor out exception printing code.
- Have widget library hand the rendering library some context when syncing RenderObjectWrappers to aid with debugging.
- Fix a bug in flex.dart whereby _overflow was compared when null.

Performance of exception handling:
![image 2](https://cloud.githubusercontent.com/assets/551196/9454657/8bc62c78-4a78-11e5-8af2-6c4e3198f833.png)