### PR TITLE
Don't include observatory in Release builds

### DIFF
--- a/sky/engine/core/BUILD.gn
+++ b/sky/engine/core/BUILD.gn
@@ -8,6 +8,11 @@ import("//mojo/dart/embedder/embedder.gni")
 
 visibility = [ "//sky/engine/*" ]
 
+declare_args() {
+  enable_observatory = true
+}
+
+
 rel_sky_core_gen_dir = rebase_path(sky_core_output_dir, root_build_dir)
 
 source_set("libraries") {
@@ -49,9 +54,6 @@ source_set("prerequisites") {
 }
 
 dart_embedder_resources("generate_sky_embedder_service_isolate_resources_cc") {
-  deps = [
-    "//mojo/dart/embedder:deploy_observatory",
-  ]
   inputs = [
     "//sky/engine/core/script/dart_service_isolate/loader.dart",
     "//sky/engine/core/script/dart_service_isolate/main.dart",
@@ -59,9 +61,15 @@ dart_embedder_resources("generate_sky_embedder_service_isolate_resources_cc") {
     "//sky/engine/core/script/dart_service_isolate/server.dart",
   ]
   root_prefix = "//sky/engine/core/script/"
-  input_directory = "$root_out_dir/observatory/deployed/web/"
   output = "$target_gen_dir/sky_embedder_service_isolate_resources.cc"
   table_name = "sky_embedder_service_isolate"
+
+  if (enable_observatory) {
+    input_directory = "$root_out_dir/observatory/deployed/web/"
+    deps = [
+      "//mojo/dart/embedder:deploy_observatory",
+    ]
+  }
 }
 
 static_library("core") {

--- a/sky/tools/gn
+++ b/sky/tools/gn
@@ -39,6 +39,8 @@ def to_gn_args(args):
 
     gn_args['is_debug'] = args.debug
     gn_args['is_clang'] = args.clang and args.target_os not in ['android']
+    gn_args['enable_profiling'] = args.profiling
+    gn_args['enable_observatory'] = args.debug or args.profiling
 
     if args.target_os == 'android':
         gn_args['target_os'] = 'android'
@@ -89,6 +91,9 @@ def parse_args(args):
 
   parser.add_argument('--clang', default=True, action='store_true')
   parser.add_argument('--no-clang', dest='clang', action='store_false')
+
+  parser.add_argument('--profiling', default=True, action='store_true')
+  parser.add_argument('--no-profiling', dest='profiling', action='store_false')
 
   return parser.parse_args(args)
 


### PR DESCRIPTION
We only only link observatory in Debug builds and with
`./sky/tools/gn --profiling`. To profile Release builds using observatory,
build with `./sky/tools/gn --android --release --profiling`. This saves 2.6 MB
of binary.

Fixes #357.