### PR TITLE
Don't divide by zero

### DIFF
--- a/sky/packages/sky/lib/widgets/scrollable.dart
+++ b/sky/packages/sky/lib/widgets/scrollable.dart
@@ -439,7 +439,7 @@ abstract class ScrollableWidgetList extends Scrollable {
     int itemShowCount = 0;
     Offset viewportOffset = Offset.zero;
 
-    if (_containerExtent != null && _containerExtent > 0.0) {
+    if (_containerExtent != null && _containerExtent > 0.0 && itemCount > 0) {
       if (paddedScrollOffset < scrollBehavior.minScrollOffset) {
         // Underscroll
         double visibleExtent = _containerExtent + paddedScrollOffset;


### PR DESCRIPTION
If there aren't any items, there's no point in computing which items to show.