### PR TITLE
Make 'save failed' snackbar show up

### DIFF
--- a/examples/fitness/lib/measurement.dart
+++ b/examples/fitness/lib/measurement.dart
@@ -132,7 +132,7 @@ class MeasurementFragment extends StatefulComponent {
     if (_errorMessage == null)
       return null;
     // TODO(jackson): This doesn't show up, unclear why.
-    return new SnackBar(content: new Text(_errorMessage));
+    return new SnackBar(content: new Text(_errorMessage), showing: true);
   }
 
   Widget build() {


### PR DESCRIPTION
SnackBar's crash if you fail to provide a showing bool.

I tried to edit it in the framework, but this seemed easier for now.

The snackbar still shows behind the keyboard unfortunately.
https://github.com/domokit/sky_engine/issues/810

@collinjackson