### PR TITLE
Stop running skyanalyzer on Travis

### DIFF
--- a/travis/build.sh
+++ b/travis/build.sh
@@ -3,5 +3,4 @@ set -ex
 
 ./sky/tools/gn --release
 ninja -j 4 -C out/Release
-./sky/tools/skyanalyzer --congratulate examples/stocks/lib/main.dart
 ./sky/tools/run_tests --release -j 1


### PR DESCRIPTION
We use the shipped version of sky_engine and sky_services when running
skyanalyzer on Travis, which means this check fails every time we add an API to
dart:sky. We should re-enable it once it doesn't break with these sorts of
changes.