### PR TITLE
Don't freeze devicePixelRatio at startup

### DIFF
--- a/sky/packages/sky/lib/rendering/sky_binding.dart
+++ b/sky/packages/sky/lib/rendering/sky_binding.dart
@@ -40,7 +40,7 @@ class SkyBinding {
     sky.view.setMetricsChangedCallback(_handleMetricsChanged);
     scheduler.init();
     if (renderViewOverride == null) {
-      _renderView = new RenderView(child: root, devicePixelRatio: sky.view.devicePixelRatio);
+      _renderView = new RenderView(child: root);
       _renderView.attach();
       _renderView.rootConstraints = _createConstraints();
       _renderView.scheduleInitialFrame();


### PR DESCRIPTION
When we start, we might not have initialized the devicePixelRatio value. The
value will be initialized by the time we paint, so now we update the value
every time we paint.