### PR TITLE
Fix global key error while using fitness app

### DIFF
--- a/sky/unit/test/widget/global_key_test.dart
+++ b/sky/unit/test/widget/global_key_test.dart
@@ -106,4 +106,48 @@ void main() {
     GlobalKey.unregisterSyncListener(globalKey, syncListener);
     GlobalKey.unregisterRemoveListener(globalKey, removeListener);
   });
+
+  test('Global key mutate during iteration', () {
+    GlobalKey globalKey = new GlobalKey();
+
+    bool syncListenerCalled = false;
+    bool removeListenerCalled = false;
+
+    void syncListener(GlobalKey key, Widget widget) {
+      GlobalKey.unregisterSyncListener(globalKey, syncListener);
+      syncListenerCalled = true;
+    }
+
+    void removeListener(GlobalKey key) {
+      GlobalKey.unregisterRemoveListener(globalKey, removeListener);
+      removeListenerCalled = true;
+    }
+
+    GlobalKey.registerSyncListener(globalKey, syncListener);
+    GlobalKey.registerRemoveListener(globalKey, removeListener);
+    WidgetTester tester = new WidgetTester();
+
+    tester.pumpFrame(() {
+      return new Container(key: globalKey);
+    });
+    expect(syncListenerCalled, isTrue);
+    expect(removeListenerCalled, isFalse);
+
+    syncListenerCalled = false;
+    removeListenerCalled = false;
+    tester.pumpFrame(() {
+      return new Container();
+    });
+    expect(syncListenerCalled, isFalse);
+    expect(removeListenerCalled, isTrue);
+
+    syncListenerCalled = false;
+    removeListenerCalled = false;
+    tester.pumpFrame(() {
+      return new Container(key: globalKey);
+    });
+    expect(syncListenerCalled, isFalse);
+    expect(removeListenerCalled, isFalse);
+
+  });
 }


### PR DESCRIPTION
We were making local copies of the listener maps, but we were actually
iterating the underlying sets. Now we make local copies of the sets.

Fixes #803