### PR TITLE
Plumb physical size along with SkPicture

### DIFF
--- a/sky/shell/gpu/rasterizer.cc
+++ b/sky/shell/gpu/rasterizer.cc
@@ -17,14 +17,6 @@
 
 namespace sky {
 namespace shell {
-namespace {
-
-gfx::Size GetSize(SkPicture* picture) {
-  const SkRect& rect = picture->cullRect();
-  return gfx::Size(rect.width(), rect.height());
-}
-
-}  // namespace
 
 Rasterizer::Rasterizer()
     : share_group_(new gfx::GLShareGroup()), weak_factory_(this) {
@@ -43,14 +35,10 @@ void Rasterizer::OnAcceleratedWidgetAvailable(gfx::AcceleratedWidget widget) {
   CHECK(surface_) << "GLSurface required.";
 }
 
-void Rasterizer::Draw(PassRefPtr<SkPicture> picture) {
+void Rasterizer::Draw(PassRefPtr<SkPicture> picture, gfx::Size size) {
   TRACE_EVENT0("sky", "Rasterizer::Draw");
 
   if (!surface_)
-    return;
-
-  gfx::Size size = GetSize(picture.get());
-  if (size.IsEmpty())
     return;
 
   if (surface_->GetSize() != size)

--- a/sky/shell/gpu/rasterizer.h
+++ b/sky/shell/gpu/rasterizer.h
@@ -34,7 +34,7 @@ class Rasterizer : public GPUDelegate {
 
   void OnAcceleratedWidgetAvailable(gfx::AcceleratedWidget widget) override;
   void OnOutputSurfaceDestroyed() override;
-  void Draw(PassRefPtr<SkPicture> picture) override;
+  void Draw(PassRefPtr<SkPicture> picture, gfx::Size size) override;
 
  private:
   void EnsureGLContext();

--- a/sky/shell/gpu_delegate.h
+++ b/sky/shell/gpu_delegate.h
@@ -6,6 +6,7 @@
 #define SKY_SHELL_GPU_DELEGATE_H_
 
 #include "sky/engine/wtf/PassRefPtr.h"
+#include "ui/gfx/geometry/size.h"
 #include "ui/gfx/native_widget_types.h"
 
 class SkPicture;
@@ -17,7 +18,7 @@ class GPUDelegate {
  public:
   virtual void OnAcceleratedWidgetAvailable(gfx::AcceleratedWidget widget) = 0;
   virtual void OnOutputSurfaceDestroyed() = 0;
-  virtual void Draw(PassRefPtr<SkPicture> picture) = 0;
+  virtual void Draw(PassRefPtr<SkPicture> picture, gfx::Size size) = 0;
 
  protected:
   virtual ~GPUDelegate();

--- a/sky/shell/ui/animator.cc
+++ b/sky/shell/ui/animator.cc
@@ -76,7 +76,8 @@ void Animator::BeginFrame(int64_t time_stamp) {
 
   config_.gpu_task_runner->PostTaskAndReply(
       FROM_HERE,
-      base::Bind(&GPUDelegate::Draw, config_.gpu_delegate, picture),
+      base::Bind(&GPUDelegate::Draw, config_.gpu_delegate, picture,
+                 engine_->physical_size()),
       base::Bind(&Animator::OnFrameComplete, weak_factory_.GetWeakPtr()));
 }
 

--- a/sky/shell/ui/engine.h
+++ b/sky/shell/ui/engine.h
@@ -56,6 +56,7 @@ class Engine : public UIDelegate,
 
   void BeginFrame(base::TimeTicks frame_time);
   PassRefPtr<SkPicture> Paint();
+  const gfx::Size& physical_size() { return physical_size_; }
 
   void StartDartTracing();
   void StopDartTracing(mojo::ScopedDataPipeProducerHandle producer);


### PR DESCRIPTION
Previously we were using the cull rect of the SkPicture to size the GPU buffer,
but Skia is too smart and shrinkwraps the cull rect, which meant we weren't
sizing the GPU buffer to the right size.

Fixes #814