### PR TITLE
Sector demo is broken because of compositor changes

### DIFF
--- a/examples/rendering/sector_layout.dart
+++ b/examples/rendering/sector_layout.dart
@@ -166,6 +166,14 @@ class RenderSectorWithChildren extends RenderDecoratedSector with ContainerRende
       child = child.parentData.previousSibling;
     }
   }
+
+  void visitChildren(RenderObjectVisitor visitor) {
+    RenderSector child = lastChild;
+    while (child != null) {
+      visitor(child);
+      child = child.parentData.previousSibling;
+    }
+  }
 }
 
 class RenderSectorRing extends RenderSectorWithChildren {
@@ -411,6 +419,10 @@ class RenderBoxToRenderSectorAdapter extends RenderBox {
   void setupParentData(RenderObject child) {
     if (child.parentData is! SectorParentData)
       child.parentData = new SectorParentData();
+  }
+
+  void visitChildren(RenderObjectVisitor visitor) {
+    visitor(_child);
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {

--- a/sky/unit/test/examples/sector_layout_test.dart
+++ b/sky/unit/test/examples/sector_layout_test.dart
@@ -1,0 +1,10 @@
+import 'package:test/test.dart';
+import '../rendering/layout_utils.dart';
+import '../../../../examples/rendering/sector_layout.dart';
+
+void main() {
+  test('Sector layout can paint', () {
+    RenderingTester tester = new RenderingTester(root: buildSectorExample());
+    tester.pumpFrame();
+  });
+}

--- a/sky/unit/test/rendering/viewport_test.dart
+++ b/sky/unit/test/rendering/viewport_test.dart
@@ -15,16 +15,16 @@ void main() {
       child: size);
 
     RenderViewport viewport = new RenderViewport(child: red, scrollOffset: new Offset(0.0, -10.0));
-    RenderView renderView = layout(viewport);
+    RenderingTester tester = layout(viewport);
 
     HitTestResult result;
 
     result = new HitTestResult();
-    renderView.hitTest(result, position: new Point(15.0, 0.0));
+    tester.renderView.hitTest(result, position: new Point(15.0, 0.0));
     expect(result.path.first.target, equals(viewport));
 
     result = new HitTestResult();
-    renderView.hitTest(result, position: new Point(15.0, 15.0));
+    tester.renderView.hitTest(result, position: new Point(15.0, 15.0));
     expect(result.path.first.target, equals(size));
   });
 }


### PR DESCRIPTION
We need to implement visitChildren for the RenderObjects in the sector demo.
Also, add a test.

Fixes #790