### PR TITLE
Abstract out syncChildren().

### DIFF
--- a/sky/packages/sky/lib/rendering/block.dart
+++ b/sky/packages/sky/lib/rendering/block.dart
@@ -272,7 +272,8 @@ class RenderBlockViewport extends RenderBlockBase {
       result = intrinsicCallback(constraints);
       if (result == null)
         result = constrainer(0.0);
-      assert(constrainer(result) == result);
+      else
+        result = constrainer(result);
     } finally {
       _inCallback = false;
     }


### PR DESCRIPTION
The core of MultiChildRenderObjectWrapper.syncRenderObject() could
apply to any subclass that uses a flat child list, so this abstracts
it out into the superclass.

(Also, instead of requiring the callbacks of RenderBlockViewport to
constrain their results, we just constrain it for them. Makes things a
bit easier for users of that class.)