### PR TITLE
Use C bindings to Mojo GL entry points exclusively

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -19,7 +19,7 @@
 
 vars = {
   'chromium_git': 'https://chromium.googlesource.com',
-  'mojo_sdk_revision': 'eb7dac2f90187db12c0d29792a0bd999bc96cbe5',
+  'mojo_sdk_revision': 'f9c33d6eb1106c0f9edbbfb607da94fb76245238',
   'mojo_devtools_revision': '2feda37728d3e551ef543b8f6c4f4b20eaa2d81f',
   'skia_revision': '6904d1d3f1a2903fcaa4c4bd17b07d5f10af2e8e',
   'dart_revision': 'cab003366785773ace16b5305ac1f33c228cac54',

--- a/mojo/gpu/BUILD.gn
+++ b/mojo/gpu/BUILD.gn
@@ -12,10 +12,6 @@ source_set("gpu") {
     "gl_context_owner.h",
     "gl_texture.cc",
     "gl_texture.h",
-    "mojo_context_support.cc",
-    "mojo_context_support.h",
-    "mojo_gles2_impl_autogen.cc",
-    "mojo_gles2_impl_autogen.h",
     "texture_cache.cc",
     "texture_cache.h",
     "texture_uploader.cc",
@@ -24,8 +20,6 @@ source_set("gpu") {
 
   deps = [
     "//base",
-    "//gpu/command_buffer/client:gles2_interface",
-    "//gpu/command_buffer/common",
     "//mojo/environment:chromium",
     "//mojo/public/c/gles2",
     "//mojo/public/c/gpu",

--- a/mojo/gpu/gl_context.h
+++ b/mojo/gpu/gl_context.h
@@ -8,16 +8,9 @@
 #include "base/basictypes.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
-#include "mojo/public/c/gles2/gles2.h"
-
-namespace gpu {
-namespace gles2 {
-class GLES2Interface;
-}
-}
+#include "mojo/public/c/gpu/MGL/mgl.h"
 
 namespace mojo {
-class MojoGLES2Impl;
 class Shell;
 
 class GLContext {
@@ -33,9 +26,8 @@ class GLContext {
   static base::WeakPtr<GLContext> Create(Shell* shell);
 
   void MakeCurrent();
+  bool IsCurrent();
   void Destroy();
-
-  gpu::gles2::GLES2Interface* gl() const;
 
   void AddObserver(Observer* observer);
   void RemoveObserver(Observer* observer);
@@ -47,8 +39,7 @@ class GLContext {
   static void ContextLostThunk(void* self);
   void OnContextLost();
 
-  MojoGLES2Context context_;
-  scoped_ptr<MojoGLES2Impl> gl_impl_;
+  MGLContext context_;
 
   base::ObserverList<Observer> observers_;
   base::WeakPtrFactory<GLContext> weak_factory_;

--- a/mojo/skia/BUILD.gn
+++ b/mojo/skia/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-static_library("skia") {
+source_set("skia") {
   sources = [
     "ganesh_context.cc",
     "ganesh_context.h",
@@ -11,10 +11,21 @@ static_library("skia") {
   ]
 
   deps = [
+    ":skia_bindings",
     "//base",
-    "//gpu/command_buffer/client:gles2_c_lib",
-    "//gpu/skia_bindings",
     "//mojo/gpu",
+    "//mojo/public/c/gpu",
+    "//skia",
+  ]
+}
+
+source_set("skia_bindings") {
+  sources = [
+    "gl_bindings_skia.cc",
+    "gl_bindings_skia.h",
+  ]
+  deps = [
+    "//mojo/public/c/gpu",
     "//skia",
   ]
 }

--- a/mojo/skia/ganesh_context.h
+++ b/mojo/skia/ganesh_context.h
@@ -11,29 +11,23 @@
 #include "skia/ext/refptr.h"
 #include "third_party/skia/include/gpu/GrContext.h"
 
-namespace gpu {
-namespace gles2 {
-class GLES2Interface;
-}
-}
-
 namespace mojo {
 
 class GaneshContext : public GLContext::Observer {
  public:
   class Scope {
    public:
-    explicit Scope(GaneshContext*);
+    explicit Scope(GaneshContext* context);
     ~Scope();
 
    private:
-    gpu::gles2::GLES2Interface* previous_;
+    MGLContext previous_;
   };
 
   explicit GaneshContext(base::WeakPtr<GLContext> gl_context);
   ~GaneshContext() override;
 
-  // Note: You must be in a GaneshContext::Scope to use GrContext.
+  void MakeCurrent();
   GrContext* gr() const {
     DCHECK(InScope());
     return context_.get();

--- a/mojo/skia/gl_bindings_skia.cc
+++ b/mojo/skia/gl_bindings_skia.cc
@@ -1,0 +1,152 @@
+// Copyright 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "mojo/skia/gl_bindings_skia.h"
+
+#ifndef GL_GLEXT_PROTOTYPES
+#define GL_GLEXT_PROTOTYPES
+#endif
+#include "mojo/public/c/gpu/GLES2/gl2.h"
+#include "mojo/public/c/gpu/GLES2/gl2ext.h"
+#include "mojo/public/c/gpu/GLES2/gl2extmojo.h"
+#include "third_party/skia/include/gpu/gl/GrGLInterface.h"
+
+namespace skia_bindings {
+
+GrGLInterface* CreateMojoSkiaGLBinding() {
+  GrGLInterface* interface = new GrGLInterface;
+  interface->fStandard = kGLES_GrGLStandard;
+  interface->fExtensions.init(kGLES_GrGLStandard,
+                              glGetString,
+                              nullptr,
+                              glGetIntegerv);
+
+  GrGLInterface::Functions* functions = &interface->fFunctions;
+  functions->fActiveTexture = glActiveTexture;
+  functions->fAttachShader = glAttachShader;
+  functions->fBindAttribLocation = glBindAttribLocation;
+  functions->fBindBuffer = glBindBuffer;
+  functions->fBindTexture = glBindTexture;
+  functions->fBindVertexArray = glBindVertexArrayOES;
+  functions->fBlendEquation = glBlendEquation;
+  functions->fBlendBarrier = glBlendBarrierKHR;
+  functions->fBlendColor = glBlendColor;
+  functions->fBlendFunc = glBlendFunc;
+  functions->fBufferData = glBufferData;
+  functions->fBufferSubData = glBufferSubData;
+  functions->fClear = glClear;
+  functions->fClearColor = glClearColor;
+  functions->fClearStencil = glClearStencil;
+  functions->fColorMask = glColorMask;
+  functions->fCompileShader = glCompileShader;
+  functions->fCompressedTexImage2D = glCompressedTexImage2D;
+  functions->fCopyTexSubImage2D = glCopyTexSubImage2D;
+  functions->fCreateProgram = glCreateProgram;
+  functions->fCreateShader = glCreateShader;
+  functions->fCullFace = glCullFace;
+  functions->fDeleteBuffers = glDeleteBuffers;
+  functions->fDeleteProgram = glDeleteProgram;
+  functions->fDeleteShader = glDeleteShader;
+  functions->fDeleteTextures = glDeleteTextures;
+  functions->fDeleteVertexArrays = glDeleteVertexArraysOES;
+  functions->fDepthMask = glDepthMask;
+  functions->fDisable = glDisable;
+  functions->fDisableVertexAttribArray = glDisableVertexAttribArray;
+  functions->fDiscardFramebuffer = glDiscardFramebufferEXT;
+  functions->fDrawArrays = glDrawArrays;
+  functions->fDrawElements = glDrawElements;
+  functions->fEnable = glEnable;
+  functions->fEnableVertexAttribArray = glEnableVertexAttribArray;
+  functions->fFinish = glFinish;
+  functions->fFlush = glFlush;
+  functions->fFrontFace = glFrontFace;
+  functions->fGenBuffers = glGenBuffers;
+  functions->fGenTextures = glGenTextures;
+  functions->fGenVertexArrays = glGenVertexArraysOES;
+  functions->fGetBufferParameteriv = glGetBufferParameteriv;
+  functions->fGetError = glGetError;
+  functions->fGetIntegerv = glGetIntegerv;
+  functions->fGetProgramInfoLog = glGetProgramInfoLog;
+  functions->fGetProgramiv = glGetProgramiv;
+  functions->fGetShaderInfoLog = glGetShaderInfoLog;
+  functions->fGetShaderiv = glGetShaderiv;
+  functions->fGetShaderPrecisionFormat = glGetShaderPrecisionFormat;
+  functions->fGetString = glGetString;
+  functions->fGetUniformLocation = glGetUniformLocation;
+  functions->fInsertEventMarker = glInsertEventMarkerEXT;
+  functions->fLineWidth = glLineWidth;
+  functions->fLinkProgram = glLinkProgram;
+  functions->fMapBufferSubData = glMapBufferSubDataCHROMIUM;
+  functions->fMapTexSubImage2D = glMapTexSubImage2DCHROMIUM;
+  functions->fPixelStorei = glPixelStorei;
+  functions->fPopGroupMarker = glPopGroupMarkerEXT;
+  functions->fPushGroupMarker = glPushGroupMarkerEXT;
+  functions->fReadPixels = glReadPixels;
+  functions->fScissor = glScissor;
+  functions->fShaderSource = glShaderSource;
+  functions->fStencilFunc = glStencilFunc;
+  functions->fStencilFuncSeparate = glStencilFuncSeparate;
+  functions->fStencilMask = glStencilMask;
+  functions->fStencilMaskSeparate = glStencilMaskSeparate;
+  functions->fStencilOp = glStencilOp;
+  functions->fStencilOpSeparate = glStencilOpSeparate;
+  functions->fTexImage2D = glTexImage2D;
+  functions->fTexParameteri = glTexParameteri;
+  functions->fTexParameteriv = glTexParameteriv;
+  functions->fTexStorage2D = glTexStorage2DEXT;
+  functions->fTexSubImage2D = glTexSubImage2D;
+  functions->fUniform1f = glUniform1f;
+  functions->fUniform1i = glUniform1i;
+  functions->fUniform1fv = glUniform1fv;
+  functions->fUniform1iv = glUniform1iv;
+  functions->fUniform2f = glUniform2f;
+  functions->fUniform2i = glUniform2i;
+  functions->fUniform2fv = glUniform2fv;
+  functions->fUniform2iv = glUniform2iv;
+  functions->fUniform3f = glUniform3f;
+  functions->fUniform3i = glUniform3i;
+  functions->fUniform3fv = glUniform3fv;
+  functions->fUniform3iv = glUniform3iv;
+  functions->fUniform4f = glUniform4f;
+  functions->fUniform4i = glUniform4i;
+  functions->fUniform4fv = glUniform4fv;
+  functions->fUniform4iv = glUniform4iv;
+  functions->fUniformMatrix2fv = glUniformMatrix2fv;
+  functions->fUniformMatrix3fv = glUniformMatrix3fv;
+  functions->fUniformMatrix4fv = glUniformMatrix4fv;
+  functions->fUnmapBufferSubData = glUnmapBufferSubDataCHROMIUM;
+  functions->fUnmapTexSubImage2D = glUnmapTexSubImage2DCHROMIUM;
+  functions->fUseProgram = glUseProgram;
+  functions->fVertexAttrib1f = glVertexAttrib1f;
+  functions->fVertexAttrib2fv = glVertexAttrib2fv;
+  functions->fVertexAttrib3fv = glVertexAttrib3fv;
+  functions->fVertexAttrib4fv = glVertexAttrib4fv;
+  functions->fVertexAttribPointer = glVertexAttribPointer;
+  functions->fViewport = glViewport;
+  functions->fBindFramebuffer = glBindFramebuffer;
+  functions->fBindRenderbuffer = glBindRenderbuffer;
+  functions->fCheckFramebufferStatus = glCheckFramebufferStatus;
+  functions->fDeleteFramebuffers = glDeleteFramebuffers;
+  functions->fDeleteRenderbuffers = glDeleteRenderbuffers;
+  functions->fFramebufferRenderbuffer = glFramebufferRenderbuffer;
+  functions->fFramebufferTexture2D = glFramebufferTexture2D;
+  functions->fFramebufferTexture2DMultisample =
+      glFramebufferTexture2DMultisampleEXT;
+  functions->fGenFramebuffers = glGenFramebuffers;
+  functions->fGenRenderbuffers = glGenRenderbuffers;
+  functions->fGetFramebufferAttachmentParameteriv =
+      glGetFramebufferAttachmentParameteriv;
+  functions->fGetRenderbufferParameteriv = glGetRenderbufferParameteriv;
+  functions->fRenderbufferStorage = glRenderbufferStorage;
+  functions->fRenderbufferStorageMultisample = nullptr;  // TODO: Implement.
+  functions->fRenderbufferStorageMultisampleES2EXT =
+      glRenderbufferStorageMultisampleEXT;
+  functions->fBindUniformLocation = glBindUniformLocationCHROMIUM;
+  functions->fBlitFramebuffer = nullptr;  // TODO: Implement.
+  functions->fGenerateMipmap = glGenerateMipmap;
+
+  return interface;
+}
+
+}  // namespace skia

--- a/mojo/skia/gl_bindings_skia.h
+++ b/mojo/skia/gl_bindings_skia.h
@@ -1,0 +1,20 @@
+// Copyright 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MOJO_SKIA_GL_BINDINGS_SKIA_H_
+#define MOJO_SKIA_GL_BINDINGS_SKIA_H_
+
+#include "third_party/skia/include/core/SkTypes.h"
+
+struct GrGLInterface;
+
+namespace skia_bindings {
+
+// The GPU back-end for skia requires pointers to GL functions. This function
+// returns a binding for skia-gpu to the Mojo C GL entry points.
+GrGLInterface* CreateMojoSkiaGLBinding();
+
+}  // namespace skia_bindings
+
+#endif  // MOJO_SKIA_GL_BINDINGS_SKIA_H_

--- a/sky/engine/bindings/BUILD.gn
+++ b/sky/engine/bindings/BUILD.gn
@@ -57,10 +57,10 @@ action("generate_snapshot_bin") {
   ]
   inputs = [
     "//dart/runtime/tools/create_snapshot_bin.py",
-    "//mojo/public/dart/sdk_ext/internal.dart",
-    "//mojo/public/dart/sdk_ext/src/handle_watcher.dart",
-    "//mojo/public/dart/sdk_ext/src/natives.dart",
-    "//mojo/public/dart/sdk_ext/src/timer_queue.dart",
+    "//mojo/public/dart/mojo/sdk_ext/internal.dart",
+    "//mojo/public/dart/mojo/sdk_ext/src/handle_watcher.dart",
+    "//mojo/public/dart/mojo/sdk_ext/src/natives.dart",
+    "//mojo/public/dart/mojo/sdk_ext/src/timer_queue.dart",
     "//sky/engine/bindings/builtin_natives.dart",
     "//sky/engine/bindings/sky_internals.dart",
     "snapshot.dart",
@@ -73,7 +73,7 @@ action("generate_snapshot_bin") {
   ]
 
   dart_mojo_internal_path =
-      rebase_path("//mojo/public/dart/sdk_ext/internal.dart")
+      rebase_path("//mojo/public/dart/mojo/sdk_ext/internal.dart")
   dart_sky_builtin_natives_path =
       rebase_path("//sky/engine/bindings/builtin_natives.dart")
   dart_sky_internals_path =

--- a/sky/tools/roll/roll.py
+++ b/sky/tools/roll/roll.py
@@ -80,8 +80,6 @@ dirs_from_mojo = [
     'mojo/data_pipe_utils',
     'mojo/edk',
     'mojo/environment',
-    'mojo/gles2',
-    'mojo/gpu',
     'mojo/icu',
     'mojo/java',
     'mojo/message_pump',


### PR DESCRIPTION
This uses the Mojo-provided C entry points and headers for setting up skia's GrGLInterface
instead of using the command buffer's C library.  With this patch //gpu is unreachable (except
for one export header referenced in //third_party/khronos), but I've left it in for this patch to
allow GitHub to render the commit.