### PR TITLE
Provide a fast path for MultiChildRenderObjectWrapper.syncRenderObject() when the children lists are identical.

### DIFF
--- a/sky/packages/sky/lib/widgets/framework.dart
+++ b/sky/packages/sky/lib/widgets/framework.dart
@@ -1001,6 +1001,9 @@ abstract class RenderObjectWrapper extends Widget {
 
   // for use by subclasses that manage their children using lists
   void syncChildren(List<Widget> newChildren, List<Widget> oldChildren) {
+    assert(newChildren != null);
+    assert(oldChildren != null);
+    assert(!identical(newChildren, oldChildren));
 
     // This attempts to diff the new child list (this.children) with
     // the old child list (old.children), and update our renderObject
@@ -1260,7 +1263,19 @@ abstract class MultiChildRenderObjectWrapper extends RenderObjectWrapper {
 
   void syncRenderObject(MultiChildRenderObjectWrapper old) {
     super.syncRenderObject(old);
-    syncChildren(children, old == null ? const <Widget>[] : old.children);
+    List<Widget> oldChildren = old == null ? const <Widget>[] : old.children;
+    if (oldChildren == children) {
+      int index = children.length;
+      Widget nextSibling = null;
+      while (index > 0) {
+        index -= 1;
+        Widget child = children[index];
+        nextSibling = syncChild(child, child, nextSibling);
+        children[index] = nextSibling;
+      }
+    } else {
+      syncChildren(children, oldChildren);
+    }
   }
 
 }


### PR DESCRIPTION
This isn't so much for performance so much as because I don't want to
have to keep checking that the main syncChildren() function maintains
the invariant of not screwing up when the two lists are actually the
same list.