### PR TITLE
Use the GL headers from the Mojo SDK when building for Mojo

### DIFF
--- a/mojo/gpu/BUILD.gn
+++ b/mojo/gpu/BUILD.gn
@@ -21,7 +21,6 @@ source_set("gpu") {
   deps = [
     "//base",
     "//mojo/environment:chromium",
-    "//mojo/public/c/gles2",
     "//mojo/public/c/gpu",
     "//mojo/public/c/gpu:gpu_onscreen",
     "//mojo/public/c/system",

--- a/mojo/gpu/gl_texture.cc
+++ b/mojo/gpu/gl_texture.cc
@@ -4,7 +4,7 @@
 
 #include "mojo/gpu/gl_texture.h"
 
-#include "mojo/public/c/gles2/gles2.h"
+#include "mojo/public/c/gpu/GLES2/gl2.h"
 
 namespace mojo {
 

--- a/mojo/gpu/texture_cache.cc
+++ b/mojo/gpu/texture_cache.cc
@@ -6,7 +6,7 @@
 #define GL_GLEXT_PROTOTYPES
 #endif
 
-#include <GLES2/gl2extchromium.h>
+#include <GLES2/gl2extmojo.h>
 
 #include "mojo/gpu/gl_context.h"
 #include "mojo/gpu/gl_texture.h"

--- a/mojo/gpu/texture_uploader.cc
+++ b/mojo/gpu/texture_uploader.cc
@@ -9,10 +9,8 @@
 #endif
 
 #include <GLES2/gl2.h>
-#include <GLES2/gl2chromium.h>
-#include <GLES2/gl2extchromium.h>
+#include <GLES2/gl2extmojo.h>
 
-#include "mojo/public/c/gles2/gles2.h"
 #include "mojo/services/geometry/public/cpp/geometry_util.h"
 #include "mojo/services/surfaces/public/cpp/surfaces_utils.h"
 

--- a/mojo/services/view_manager/public/cpp/BUILD.gn
+++ b/mojo/services/view_manager/public/cpp/BUILD.gn
@@ -43,9 +43,8 @@ mojo_sdk_source_set("cpp") {
   ]
 
   mojo_sdk_deps = [
-    "mojo/public/c/gles2:headers",
     "mojo/public/cpp/application",
-    "mojo/public/cpp/bindings:bindings",
+    "mojo/public/cpp/bindings",
     "mojo/public/cpp/system",
     "mojo/public/interfaces/application",
   ]

--- a/services/sky/compositor/BUILD.gn
+++ b/services/sky/compositor/BUILD.gn
@@ -35,7 +35,7 @@ source_set("compositor") {
     "//mojo/application",
     "//mojo/converters/geometry",
     "//mojo/gpu",
-    "//mojo/public/c/gles2",
+    "//mojo/public/c/gpu",
     "//mojo/public/cpp/bindings",
     "//mojo/public/cpp/environment",
     "//mojo/public/cpp/system",

--- a/services/sky/compositor/resource_manager.cc
+++ b/services/sky/compositor/resource_manager.cc
@@ -7,15 +7,14 @@
 #ifndef GL_GLEXT_PROTOTYPES
 #define GL_GLEXT_PROTOTYPES
 #endif
+#include <GLES2/gl2.h>
+#include <GLES2/gl2extmojo.h>
 
 #include "base/logging.h"
 #include "base/stl_util.h"
-#include "gpu/GLES2/gl2chromium.h"
-#include "gpu/GLES2/gl2extchromium.h"
 #include "mojo/converters/geometry/geometry_type_converters.h"
 #include "mojo/gpu/gl_context.h"
 #include "mojo/gpu/gl_texture.h"
-#include "mojo/public/c/gles2/gles2.h"
 #include "services/sky/compositor/layer.h"
 
 namespace sky {


### PR DESCRIPTION
This avoids using the headers in //gpu or //third_party/khronos when building targets for
Mojo.