### PR TITLE
Avoid generating dSYM files using GN rules.

### DIFF
--- a/build/config/ios/XcodeHarness/Harness.xcodeproj/project.pbxproj
+++ b/build/config/ios/XcodeHarness/Harness.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 				9E842EDD1B864EA100C84ECC /* Frameworks */,
 				9EA9970A1B867E74007B8C62 /* Copy Application + Debugging Symbols */,
 				9E3A4F5C1B8F82BE00095803 /* Nuke Fake Binary */,
+				9EB8E2DA1B90DF6F006BFAC2 /* Generate dSYM */,
 			);
 			buildRules = (
 			);
@@ -117,6 +118,7 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "rm ${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Harness";
+			showEnvVarsInLog = 0;
 		};
 		9EA9970A1B867E74007B8C62 /* Copy Application + Debugging Symbols */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -130,8 +132,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cp -R ${SOURCE_ROOT}/Application/ ${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app\ncp -R ${SOURCE_ROOT}/Harness.app.dSYM ${BUILT_PRODUCTS_DIR}";
+			shellScript = "cp -R ${SOURCE_ROOT}/Application/ ${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app";
 			showEnvVarsInLog = 0;
+		};
+		9EB8E2DA1B90DF6F006BFAC2 /* Generate dSYM */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Application/",
+			);
+			name = "Generate dSYM";
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/Harness.app.dSYM",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "ACTUAL_EXECUTABLE_NAME=`(PlistBuddy -c \"print CFBundleExecutable\" ${INFOPLIST_FILE})`\ndsymutil -o ${BUILT_PRODUCTS_DIR}/Harness.app.dSYM ${SOURCE_ROOT}/Application/${ACTUAL_EXECUTABLE_NAME}";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/build/config/ios/rules.gni
+++ b/build/config/ios/rules.gni
@@ -60,29 +60,6 @@ template("xcode_harness_ios") {
     ]
   }
 
-  dsym_gen_target_name = app_name + "_dsym"
-  action(dsym_gen_target_name) {
-    sources = [
-      "$root_build_dir/$app_name"
-    ]
-
-    script = ios_app_script
-
-    outputs = [
-      "$root_build_dir/$xcode_project_gen_target_name/Harness.app.dSYM"
-    ]
-
-    args = [
-      "dsym",
-      "-e",
-      rebase_path("$root_build_dir/$app_name", root_build_dir),
-      "-o",
-      rebase_path("$root_build_dir/$xcode_project_gen_target_name/Harness.app.dSYM", root_build_dir),
-    ]
-
-    deps = invoker.deps
-  }
-
   bundle_copy_gen_target_name = app_name + "_bundle_copy"
   copy(bundle_copy_gen_target_name) {
     sources = [
@@ -98,7 +75,6 @@ template("xcode_harness_ios") {
   group(target_name) {
     deps = [
       ":$xcode_project_gen_target_name",
-      ":$dsym_gen_target_name",
       ":$bundle_copy_gen_target_name",
     ]
   }


### PR DESCRIPTION
Generating dSYM files takes a very long time and these files are not necessary if the application is never launched from Xcode. Also, dSYM files need to be generated for all sky_app targets.

The same dSYM generation logic has been moved into an Xcode project build rule. The first time the project is run in Xcode, the dSYM file will be generated.