### PR TITLE
Remove --only from run_tests

### DIFF
--- a/sky/tools/run_tests
+++ b/sky/tools/run_tests
@@ -24,7 +24,6 @@ def main():
     parser.add_argument('--config', default='Debug')
     parser.add_argument('--debug', dest='config', action='store_const', const='Debug')
     parser.add_argument('--release', dest='config', action='store_const', const='Release')
-    parser.add_argument('--only', help='Run only the specified test')
     args, remaining = parser.parse_known_args()
 
     build_dir = os.path.join(SRC_ROOT, 'out', args.config)
@@ -34,13 +33,6 @@ def main():
         sky_shell = os.path.join(build_dir, 'sky_shell')
     elif sys.platform == 'darwin':
         sky_shell = os.path.join(build_dir, 'SkyShell.app', 'Contents', 'MacOS', 'SkyShell')
-
-    if args.only:
-        return subprocess.call([
-            sky_shell,
-            '--package-root=%s' % PACKAGES_DIR,
-            args.only,
-        ])
 
     env = os.environ.copy()
     env['PUB_CACHE'] = PUB_CACHE


### PR DESCRIPTION
This feature is built into package:test. We don't need to reimplement it
poorly.