### PR TITLE
Fix crash when a MixedViewport is initially offset at a non-zero position

### DIFF
--- a/sky/packages/sky/lib/widgets/mixed_viewport.dart
+++ b/sky/packages/sky/lib/widgets/mixed_viewport.dart
@@ -372,14 +372,13 @@ class MixedViewport extends RenderObjectWrapper {
           }
           _Key widgetKey = new _Key.fromWidget(widget);
           if (offsets.last > startOffset) {
+            // it's visible
             newChildren[widgetKey] = widget;
             builtChildren[startIndex] = widget;
             break;
           }
-          if (!childrenByKey.containsKey(widgetKey)) {
-            // we don't actually need this one, release it
-            syncChild(null, widget, null);
-          } // else we'll get rid of it later, when we remove old children
+          childrenByKey.remove(widgetKey);
+          syncChild(null, widget, null);
           startIndex += 1;
           assert(startIndex == offsets.length - 1);
         }


### PR DESCRIPTION
We need to always remove the widget when you sync a non-visible
widget, even if we already have it, because otherwise we'll try to
sync it with null again later, which causes a crash.

Test in #938.