### PR TITLE
Scrolls should start immediately when possible

### DIFF
--- a/sky/packages/sky/lib/base/hit_test.dart
+++ b/sky/packages/sky/lib/base/hit_test.dart
@@ -28,7 +28,11 @@ class HitTestEntry {
 }
 
 class HitTestResult {
-  final List<HitTestEntry> path = new List<HitTestEntry>();
+  HitTestResult({ List<HitTestEntry> path })
+    : path = path != null ? path : new List<HitTestEntry>();
+
+  final List<HitTestEntry> path;
+
   void add(HitTestEntry data) {
     path.add(data);
   }

--- a/sky/packages/sky/lib/base/pointer_router.dart
+++ b/sky/packages/sky/lib/base/pointer_router.dart
@@ -4,11 +4,9 @@
 
 import 'dart:sky' as sky;
 
-import 'package:sky/base/hit_test.dart';
-
 typedef void _Route(sky.PointerEvent event);
 
-class PointerRouter extends HitTestTarget {
+class PointerRouter {
   final Map<int, List<_Route>> _routeMap = new Map<int, List<_Route>>();
 
   void addRoute(int pointer, _Route route) {
@@ -26,15 +24,11 @@ class PointerRouter extends HitTestTarget {
       _routeMap.remove(pointer);
   }
 
-  EventDisposition handleEvent(sky.Event e, HitTestEntry entry) {
-    if (e is! sky.PointerEvent)
-      return EventDisposition.ignored;
-    sky.PointerEvent event = e;
+  void route(sky.PointerEvent event) {
     List<_Route> routes = _routeMap[event.pointer];
     if (routes == null)
-      return EventDisposition.ignored;
+      return;
     for (_Route route in new List<_Route>.from(routes))
       route(event);
-    return EventDisposition.processed;
   }
 }

--- a/sky/packages/sky/lib/gestures/recognizer.dart
+++ b/sky/packages/sky/lib/gestures/recognizer.dart
@@ -118,12 +118,14 @@ abstract class PrimaryPointerGestureRecognizer extends GestureRecognizer {
   }
 
   void rejectGesture(int pointer) {
-    _stopTimer();
-    if (pointer == primaryPointer)
+    if (pointer == primaryPointer) {
+      _stopTimer();
       state = GestureRecognizerState.defunct;
+    }
   }
 
   void didStopTrackingLastPointer() {
+    _stopTimer();
     state = GestureRecognizerState.ready;
   }
 

--- a/sky/packages/sky/lib/widgets/framework.dart
+++ b/sky/packages/sky/lib/widgets/framework.dart
@@ -1273,12 +1273,9 @@ class WidgetSkyBinding extends SkyBinding {
     assert(SkyBinding.instance is WidgetSkyBinding);
   }
 
-  EventDisposition dispatchEvent(sky.Event event, HitTestResult result) {
-    assert(SkyBinding.instance == this);
-    EventDisposition disposition = super.dispatchEvent(event, result);
-    if (disposition == EventDisposition.consumed)
-      return EventDisposition.consumed;
-    for (HitTestEntry entry in result.path.reversed) {
+  EventDisposition handleEvent(sky.Event event, BindingHitTestEntry entry) {
+    EventDisposition disposition = EventDisposition.ignored;
+    for (HitTestEntry entry in entry.result.path.reversed) {
       if (entry.target is! RenderObject)
         continue;
       for (Widget target in RenderObjectWrapper.getWidgetsForRenderObject(entry.target)) {
@@ -1293,7 +1290,7 @@ class WidgetSkyBinding extends SkyBinding {
         target = target._parent;
       }
     }
-    return disposition;
+    return combineEventDispositions(disposition, super.handleEvent(event, entry));
   }
 
   void beginFrame(double timeStamp) {

--- a/sky/unit/test/base/pointer_router_test.dart
+++ b/sky/unit/test/base/pointer_router_test.dart
@@ -1,6 +1,5 @@
 import 'dart:sky' as sky;
 
-import 'package:sky/base/hit_test.dart';
 import 'package:sky/base/pointer_router.dart';
 import 'package:test/test.dart';
 
@@ -13,15 +12,18 @@ void main() {
       callbackRan = true;
     }
 
+    TestPointer pointer2 = new TestPointer(2);
+    TestPointer pointer3 = new TestPointer(3);
+
     PointerRouter router = new PointerRouter();
     router.addRoute(3, callback);
-    expect(router.handleEvent(new TestPointerEvent(pointer: 2), null), equals(EventDisposition.ignored));
+    router.route(pointer2.down());
     expect(callbackRan, isFalse);
-    expect(router.handleEvent(new TestPointerEvent(pointer: 3), null), equals(EventDisposition.processed));
+    router.route(pointer3.down());
     expect(callbackRan, isTrue);
     callbackRan = false;
     router.removeRoute(3, callback);
-    expect(router.handleEvent(new TestPointerEvent(pointer: 3), null), equals(EventDisposition.ignored));
+    router.route(pointer3.up());
     expect(callbackRan, isFalse);
   });
 }

--- a/sky/unit/test/engine/mock_events.dart
+++ b/sky/unit/test/engine/mock_events.dart
@@ -1,5 +1,7 @@
 import 'dart:sky' as sky;
 
+export 'dart:sky' show Point;
+
 class TestPointerEvent extends sky.PointerEvent {
   TestPointerEvent({
     this.type,
@@ -78,4 +80,61 @@ class TestGestureEvent extends sky.GestureEvent {
   double dy;
   double velocityX;
   double velocityY;
+}
+
+class TestPointer {
+  TestPointer([ this.pointer = 1 ]);
+
+  int pointer;
+  bool isDown = false;
+  sky.Point location;
+
+  sky.PointerEvent down([sky.Point newLocation = sky.Point.origin ]) {
+    assert(!isDown);
+    isDown = true;
+    location = newLocation;
+    return new TestPointerEvent(
+      type: 'pointerdown',
+      pointer: pointer,
+      x: location.x,
+      y: location.y
+    );
+  }
+
+  sky.PointerEvent move([sky.Point newLocation = sky.Point.origin ]) {
+    assert(isDown);
+    sky.Offset delta = newLocation - location;
+    location = newLocation;
+    return new TestPointerEvent(
+      type: 'pointermove',
+      pointer: pointer,
+      x: newLocation.x,
+      y: newLocation.y,
+      dx: delta.dx,
+      dy: delta.dy
+    );
+  }
+
+  sky.PointerEvent up() {
+    assert(isDown);
+    isDown = false;
+    return new TestPointerEvent(
+      type: 'pointerup',
+      pointer: pointer,
+      x: location.x,
+      y: location.y
+    );
+  }
+
+  sky.PointerEvent cancel() {
+    assert(isDown);
+    isDown = false;
+    return new TestPointerEvent(
+      type: 'pointercancel',
+      pointer: pointer,
+      x: location.x,
+      y: location.y
+    );
+  }
+
 }

--- a/sky/unit/test/gestures/arena_test.dart
+++ b/sky/unit/test/gestures/arena_test.dart
@@ -52,6 +52,7 @@ void main() {
 
     GestureArenaEntry firstEntry = arena.add(primaryKey, first);
     arena.add(primaryKey, second);
+    arena.close(primaryKey);
 
     expect(firstAcceptRan, isFalse);
     expect(firstRejectRan, isFalse);

--- a/sky/unit/test/gestures/long_press_test.dart
+++ b/sky/unit/test/gestures/long_press_test.dart
@@ -1,5 +1,6 @@
 import 'package:quiver/testing/async.dart';
 import 'package:sky/base/pointer_router.dart';
+import 'package:sky/gestures/arena.dart';
 import 'package:sky/gestures/long_press.dart';
 import 'package:sky/gestures/show_press.dart';
 import 'package:test/test.dart';
@@ -32,8 +33,9 @@ void main() {
 
     new FakeAsync().run((async) {
       longPress.addPointer(down);
+      GestureArena.instance.close(5);
       expect(longPressRecognized, isFalse);
-      router.handleEvent(down, null);
+      router.route(down);
       expect(longPressRecognized, isFalse);
       async.elapse(new Duration(milliseconds: 300));
       expect(longPressRecognized, isFalse);
@@ -55,12 +57,13 @@ void main() {
 
     new FakeAsync().run((async) {
       longPress.addPointer(down);
+      GestureArena.instance.close(5);
       expect(longPressRecognized, isFalse);
-      router.handleEvent(down, null);
+      router.route(down);
       expect(longPressRecognized, isFalse);
       async.elapse(new Duration(milliseconds: 300));
       expect(longPressRecognized, isFalse);
-      router.handleEvent(up, null);
+      router.route(up);
       expect(longPressRecognized, isFalse);
       async.elapse(new Duration(seconds: 1));
       expect(longPressRecognized, isFalse);
@@ -87,9 +90,10 @@ void main() {
     new FakeAsync().run((async) {
       showPress.addPointer(down);
       longPress.addPointer(down);
+      GestureArena.instance.close(5);
       expect(showPressRecognized, isFalse);
       expect(longPressRecognized, isFalse);
-      router.handleEvent(down, null);
+      router.route(down);
       expect(showPressRecognized, isFalse);
       expect(longPressRecognized, isFalse);
       async.elapse(new Duration(milliseconds: 300));

--- a/sky/unit/test/gestures/show_press_test.dart
+++ b/sky/unit/test/gestures/show_press_test.dart
@@ -1,5 +1,6 @@
 import 'package:quiver/testing/async.dart';
 import 'package:sky/base/pointer_router.dart';
+import 'package:sky/gestures/arena.dart';
 import 'package:sky/gestures/show_press.dart';
 import 'package:test/test.dart';
 
@@ -31,8 +32,9 @@ void main() {
 
     new FakeAsync().run((async) {
       showPress.addPointer(down);
+      GestureArena.instance.close(5);
       expect(showPressRecognized, isFalse);
-      router.handleEvent(down, null);
+      router.route(down);
       expect(showPressRecognized, isFalse);
       async.elapse(new Duration(milliseconds: 300));
       expect(showPressRecognized, isTrue);
@@ -52,12 +54,13 @@ void main() {
 
     new FakeAsync().run((async) {
       showPress.addPointer(down);
+      GestureArena.instance.close(5);
       expect(showPressRecognized, isFalse);
-      router.handleEvent(down, null);
+      router.route(down);
       expect(showPressRecognized, isFalse);
       async.elapse(new Duration(milliseconds: 50));
       expect(showPressRecognized, isFalse);
-      router.handleEvent(up, null);
+      router.route(up);
       expect(showPressRecognized, isFalse);
       async.elapse(new Duration(seconds: 1));
       expect(showPressRecognized, isFalse);

--- a/sky/unit/test/gestures/tap_test.dart
+++ b/sky/unit/test/gestures/tap_test.dart
@@ -1,4 +1,5 @@
 import 'package:sky/base/pointer_router.dart';
+import 'package:sky/gestures/arena.dart';
 import 'package:sky/gestures/tap.dart';
 import 'package:test/test.dart';
 
@@ -22,8 +23,9 @@ void main() {
     );
 
     tap.addPointer(down);
+    GestureArena.instance.close(5);
     expect(tapRecognized, isFalse);
-    router.handleEvent(down, null);
+    router.route(down);
     expect(tapRecognized, isFalse);
 
     TestPointerEvent up = new TestPointerEvent(
@@ -33,7 +35,7 @@ void main() {
       y: 9.0
     );
 
-    router.handleEvent(up, null);
+    router.route(up);
     expect(tapRecognized, isTrue);
 
     tap.dispose();

--- a/sky/unit/test/widget/gesture_detector_test.dart
+++ b/sky/unit/test/widget/gesture_detector_test.dart
@@ -1,0 +1,58 @@
+import 'package:sky/widgets.dart';
+import 'package:test/test.dart';
+
+import '../engine/mock_events.dart';
+import 'widget_tester.dart';
+
+void main() {
+  test('Uncontested scrolls start immediately', () {
+    WidgetTester tester = new WidgetTester();
+    TestPointer pointer = new TestPointer(7);
+
+    bool didStartScroll = false;
+    double updatedScrollDelta;
+    bool didEndScroll = false;
+
+    Widget builder() {
+      return new GestureDetector(
+        onVerticalScrollStart: () {
+          didStartScroll = true;
+        },
+        onVerticalScrollUpdate: (double scrollDelta) {
+          updatedScrollDelta = scrollDelta;
+        },
+        onVerticalScrollEnd: () {
+          didEndScroll = true;
+        },
+        child: new Container()
+      );
+    }
+
+    tester.pumpFrame(builder);
+    expect(didStartScroll, isFalse);
+    expect(updatedScrollDelta, isNull);
+    expect(didEndScroll, isFalse);
+
+    Point firstLocation = new Point(10.0, 10.0);
+    tester.dispatchEvent(pointer.down(firstLocation), firstLocation);
+    expect(didStartScroll, isTrue);
+    didStartScroll = false;
+    expect(updatedScrollDelta, isNull);
+    expect(didEndScroll, isFalse);
+
+    Point secondLocation = new Point(10.0, 9.0);
+    tester.dispatchEvent(pointer.move(secondLocation), secondLocation);
+    expect(didStartScroll, isFalse);
+    expect(updatedScrollDelta, 1.0);
+    updatedScrollDelta = null;
+    expect(didEndScroll, isFalse);
+
+    tester.dispatchEvent(pointer.up(), secondLocation);
+    expect(didStartScroll, isFalse);
+    expect(updatedScrollDelta, isNull);
+    expect(didEndScroll, isTrue);
+    didEndScroll = false;
+
+    tester.pumpFrame(() => new Container());
+  });
+}

--- a/sky/unit/test/widget/widget_tester.dart
+++ b/sky/unit/test/widget/widget_tester.dart
@@ -89,29 +89,22 @@ class WidgetTester {
     return SkyBinding.instance.dispatchEvent(event, result);
   }
 
-  void tap(Widget widget) {
+  void tap(Widget widget, { int pointer: 1 }) {
     Point location = getCenter(widget);
     HitTestResult result = _hitTest(location);
-    _dispatchEvent(new TestPointerEvent(type: 'pointerdown', x: location.x, y: location.y), result);
-    _dispatchEvent(new TestPointerEvent(type: 'pointerup', x: location.x, y: location.y), result);
+    TestPointer p = new TestPointer(pointer);
+    _dispatchEvent(p.down(location), result);
+    _dispatchEvent(p.up(), result);
   }
 
-  void scroll(Widget widget, Offset offset) {
+  void scroll(Widget widget, Offset offset, { int pointer: 1 }) {
     Point startLocation = getCenter(widget);
-    HitTestResult result = _hitTest(startLocation);
-    _dispatchEvent(new TestPointerEvent(type: 'pointerdown', x: startLocation.x, y: startLocation.y), result);
     Point endLocation = startLocation + offset;
-    _dispatchEvent(
-      new TestPointerEvent(
-        type: 'pointermove',
-        x: endLocation.x,
-        y: endLocation.y,
-        dx: offset.dx,
-        dy: offset.dy
-      ),
-      result
-    );
-    _dispatchEvent(new TestPointerEvent(type: 'pointerup', x: endLocation.x, y: endLocation.y), result);
+    HitTestResult result = _hitTest(startLocation);
+    TestPointer p = new TestPointer(pointer);
+    _dispatchEvent(p.down(startLocation), result);
+    _dispatchEvent(p.move(endLocation), result);
+    _dispatchEvent(p.up(), result);
   }
 
   void dispatchEvent(sky.Event event, Point location) {


### PR DESCRIPTION
If there are no other gestures in the arena, we should kick off the scroll
gesture right away. This change pulled a refactoring of how we dispatch events
to Widgets. Now we dispatch events to Widgets interleaved with their associated
RenderObjects. (Previously we dispatched to all of the RenderObjects first.)