### PR TITLE
Update skydoc.py now that dartdoc is in the Dart SDK

### DIFF
--- a/sky/tools/skydoc.py
+++ b/sky/tools/skydoc.py
@@ -12,38 +12,27 @@ import webbrowser
 SKY_TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
 SKY_ROOT = os.path.dirname(SKY_TOOLS_DIR)
 SRC_ROOT = os.path.dirname(SKY_ROOT)
-WORKBENCH_ROOT = os.path.join(SRC_ROOT, 'sky', 'packages', 'workbench')
+WORKBENCH_DIR = os.path.join(SRC_ROOT, 'sky', 'packages', 'workbench')
+SKY_PACKAGE = os.path.join(SRC_ROOT, 'sky', 'packages', 'sky')
 
-DARTDOC = 'dartdoc'
-
+DART_SDK = os.path.join(SRC_ROOT, 'third_party', 'dart-sdk', 'dart-sdk', 'bin')
+DARTDOC = os.path.join(DART_SDK, 'dartdoc')
+PUB_CACHE = os.path.join(SRC_ROOT, 'dart-pub-cache')
 
 def main():
-    try:
-        subprocess.check_output(['pub', 'global', 'run', DARTDOC, '--version'])
-    except:
-        print 'Cannot find "dartdoc". Did you run `pub global activate dartdoc` ?'
-        return 1
-
     parser = argparse.ArgumentParser(description='Sky Documentation Generator')
-    parser.add_argument('build_dir', type=str, help='Path to build output')
     parser.add_argument('--open', action='store_true',
          help='Open docs after building.')
     args = parser.parse_args()
 
-    build_dir = os.path.abspath(args.build_dir)
+    doc_dir = os.path.join(SKY_PACKAGE, 'doc')
 
-    sky_package = os.path.join(SRC_ROOT, 'sky/packages/sky')
-    doc_dir = os.path.join(build_dir, 'gen/dart-pkg/sky/doc')
-
-    analyzer_args = [
-        'pub',
-        'global',
-        'run',
+    cmd = [
         DARTDOC,
-        '--input', sky_package,
+        '--input', SKY_PACKAGE,
         '--output', doc_dir
     ]
-    subprocess.check_call(analyzer_args)
+    subprocess.check_call(cmd, cwd=WORKBENCH_DIR)
 
     if args.open:
         webbrowser.open(os.path.join(doc_dir, 'index.html'))


### PR DESCRIPTION
Now that dartdoc is part of the Dart SDK, we can use the SDK version directly.