### PR TITLE
Move lerp for the engine types into dart:sky

### DIFF
--- a/sky/engine/bindings/scripts/templates/dart_blink.template
+++ b/sky/engine/bindings/scripts/templates/dart_blink.template
@@ -25,3 +25,14 @@ final Tracing tracing = new Tracing();
 View view;
 
 typedef EventListener(Event event);
+
+/// Linearly interpolate between two numbers.
+double lerpDouble(double a, double b, double t) {
+  if (a == null && b == null)
+    return null;
+  if (a == null)
+    a = 0.0;
+  if (b == null)
+    b = 0.0;
+  return a + (b - a) * t;
+}

--- a/sky/engine/core/painting/Color.dart
+++ b/sky/engine/core/painting/Color.dart
@@ -4,8 +4,21 @@
 
 part of dart.sky;
 
+Color _scaleAlpha(Color a, double factor) {
+  return a.withAlpha((a.alpha * factor).round());
+}
+
+/// An immutable 32 bit color value in ARGB
 class Color {
+  /// Construct a color from the lower 32 bits of an int
+  ///
+  /// Bits 24-31 are the alpha value.
+  /// Bits 16-23 are the red value.
+  /// Bits 8-15 are the green value.
+  /// Bits 0-7 are the blue value.
   const Color(int value) : _value = (value & 0xFFFFFFFF);
+
+  /// Construct a color from the lower 8 bits of four integers.
   const Color.fromARGB(int a, int r, int g, int b) :
     _value = ((((a & 0xff) << 24) |
                 ((r & 0xff) << 16) |
@@ -13,29 +26,65 @@ class Color {
                 ((b & 0xff) << 0)) & 0xFFFFFFFF);
 
   final int _value;
+  /// A 32 bit value representing this color
+  ///
+  /// Bits 24-31 are the alpha value.
+  /// Bits 16-23 are the red value.
+  /// Bits 8-15 are the green value.
+  /// Bits 0-7 are the blue value.
   int get value => _value;
 
+  /// The alpha channel of this color in an 8 bit value
   int get alpha => (0xff000000 & _value) >> 24;
+
+  /// The red channel of this color in an 8 bit value
   int get red => (0x00ff0000 & _value) >> 16;
+
+  /// The green channel of this color in an 8 bit value
   int get green => (0x0000ff00 & _value) >> 8;
+
+  /// The blue channel of this color in an 8 bit value
   int get blue => (0x000000ff & _value) >> 0;
 
   bool operator ==(other) => other is Color && _value == other._value;
 
+  /// Returns a new color that matches this color with the alpha channel replaced with a.
   Color withAlpha(int a) {
     return new Color.fromARGB(a, red, green, blue);
   }
 
+  /// Returns a new color that matches this color with the red channel replaced with r.
   Color withRed(int r) {
     return new Color.fromARGB(alpha, r, green, blue);
   }
 
+  /// Returns a new color that matches this color with the green channel replaced with g.
   Color withGreen(int g) {
     return new Color.fromARGB(alpha, red, g, blue);
   }
 
+  /// Returns a new color that matches this color with the blue channel replaced with b.
   Color withBlue(int b) {
     return new Color.fromARGB(alpha, red, green, b);
+  }
+
+  /// Linearly interpolate between two colors
+  ///
+  /// If either color is null, this function linearly interpolates from a
+  /// transparent instance of the other color.
+  static Color lerp(Color a, Color b, double t) {
+    if (a == null && b == null)
+      return null;
+    if (a == null)
+      return _scaleAlpha(b, t);
+    if (b == null)
+      return _scaleAlpha(a, 1.0 - t);
+    return new Color.fromARGB(
+      lerpNum(a.alpha, b.alpha, t).toInt(),
+      lerpNum(a.red, b.red, t).toInt(),
+      lerpNum(a.green, b.green, t).toInt(),
+      lerpNum(a.blue, b.blue, t).toInt()
+    );
   }
 
   int get hashCode => _value.hashCode;

--- a/sky/engine/core/painting/Offset.dart
+++ b/sky/engine/core/painting/Offset.dart
@@ -4,21 +4,31 @@
 
 part of dart.sky;
 
-/// Holds a 2D floating-point offset.
-/// Think of this as a vector from an unspecified point
+/// An immutable 2D floating-point offset
+///
+/// An Offset represents a vector from an unspecified point
 class Offset extends OffsetBase {
   const Offset(dx, dy) : super(dx, dy);
-  Offset.copy(Offset source) : super(source.dx, source.dy);
 
+  /// The x component of the offset
   double get dx => _dx;
+
+  /// The y component of the offset
   double get dy => _dy;
 
+  /// The magnitude of the offset
   double get distance => math.sqrt(_dx * _dx + _dy * _dy);
 
+  /// An offset with zero magnitude
   static const Offset zero = const Offset(0.0, 0.0);
+
+  /// An offset with infinite x and y components
   static const Offset infinite = const Offset(double.INFINITY, double.INFINITY);
 
+  /// Returns a new offset with the x component scaled by scaleX and the y component scaled by scaleY
   Offset scale(double scaleX, double scaleY) => new Offset(dx * scaleX, dy * scaleY);
+
+  /// Returns a new offset with translateX added to the x component and translateY added to the y component
   Offset translate(double translateX, double translateY) => new Offset(dx + translateX, dy + translateY);
 
   Offset operator -() => new Offset(-dx, -dy);
@@ -28,10 +38,25 @@ class Offset extends OffsetBase {
   Offset operator /(double operand) => new Offset(dx / operand, dy / operand);
   Offset operator ~/(double operand) => new Offset((dx ~/ operand).toDouble(), (dy ~/ operand).toDouble());
   Offset operator %(double operand) => new Offset(dx % operand, dy % operand);
+
+  /// Returns a rect of the given size that starts at (0, 0) plus this offset
   Rect operator &(Size other) => new Rect.fromLTWH(dx, dy, other.width, other.height);
 
-  // does the equivalent of "return new Point(0,0) + this"
+  /// Returns the point at (0, 0) plus this offset.
   Point toPoint() => new Point(this.dx, this.dy);
+
+  /// Linearly interpolate between two offsets
+  ///
+  /// If either offset is null, this function interpolates from [Offset.zero].
+  static Offset lerp(Offset a, Offset b, double t) {
+    if (a == null && b == null)
+      return null;
+    if (a == null)
+      return b * t;
+    if (b == null)
+      return a * (1.0 - t);
+    return new Offset(lerpNum(a.dx, b.dx, t), lerpNum(a.dy, b.dy, t));
+  }
 
   String toString() => "Offset($dx, $dy)";
 }

--- a/sky/engine/core/painting/Rect.dart
+++ b/sky/engine/core/painting/Rect.dart
@@ -4,10 +4,11 @@
 
 part of dart.sky;
 
-/// Holds 4 floating-point coordinates for a rectangle.
+/// An immutable 2D, axis-aligned, floating-point rectangle
 class Rect {
   Rect();
 
+  /// Construct a rectangle from left, top, right, and bottom edges
   Rect.fromLTRB(double left, double top, double right, double bottom) {
     _value
       ..[0] = left
@@ -16,6 +17,7 @@ class Rect {
       ..[3] = bottom;
   }
 
+  /// Construct a rectangle from left, top edges and a width and height
   Rect.fromLTWH(double left, double top, double width, double height) {
     _value
       ..[0] = left
@@ -25,20 +27,38 @@ class Rect {
   }
 
   final Float32List _value = new Float32List(4);
+
+  /// The offset of the left edge of this rectangle from the x axis
   double get left => _value[0];
+
+  /// The offset of the top edge of this rectangle from the y axis
   double get top => _value[1];
+
+  /// The offset of the right edge of this rectangle from the x axis
   double get right => _value[2];
+
+  /// The offset of the bottom edge of this rectangle from the y axis
   double get bottom => _value[3];
 
+  /// A rectangle with left, top, right, and bottom edges all at zero
+  static final Rect zero = new Rect();
+
+  /// Returns a new rectangle translated by the given offset
   Rect shift(Offset offset) {
     return new Rect.fromLTRB(left + offset.dx, top + offset.dy, right + offset.dx, bottom + offset.dy);
   }
+
+  /// Returns a new rectangle with edges moved outwards by the given delta
   Rect inflate(double delta) {
     return new Rect.fromLTRB(left - delta, top - delta, right + delta, bottom + delta);
   }
+
+  /// Returns a new rectangle with edges moved inwards by the given delta
   Rect deflate(double delta) {
     return inflate(-delta);
   }
+
+  /// Returns a new rectangle that is the intersection of the given rectangle and this rectangle
   Rect intersect(Rect other) {
     return new Rect.fromLTRB(
       math.max(left, other.left),
@@ -47,27 +67,62 @@ class Rect {
       math.max(bottom, other.bottom));
   }
 
+  /// The distance between the left and right edges of this rectangle
   double get width => right - left;
+
+  /// The distance between the top and bottom edges of this rectangle
   double get height => bottom - top;
 
+  /// The distance between upper-left corner and the lower-right corner of this rectangle
   Size get size => new Size(width, height);
 
+  /// The lesser of the width and the height of this rectangle
   double get shortestSide {
     double w = width.abs();
     double h = height.abs();
     return w < h ? w : h;
   }
 
+  /// The point halfway between the left and right and the top and bottom edges of this rectangle
   Point get center => new Point(left + width / 2.0, top + height / 2.0);
+
+  /// The point at the intersection of the top and left edges of this rectangle
   Point get topLeft => new Point(left, top);
+
+  /// The point at the intersection of the top and right edges of this rectangle
   Point get topRight => new Point(right, top);
+
+  /// The point at the intersection of the bottom and left edges of this rectangle
   Point get bottomLeft => new Point(left, bottom);
+
+  /// The point at the intersection of the bottom and right edges of this rectangle
   Point get bottomRight => new Point(right, bottom);
 
-  // Rects are inclusive of the top and left edges but exclusive of the bottom
-  // right edges.
+  /// Whether the given point lies between the left and right and the top and bottom edges of this rectangle
+  ///
+  /// Rectangles include their top and left edges but exclude their bottom and right edges.
   bool contains(Point point) {
     return point.x >= left && point.x < right && point.y >= top && point.y < bottom;
+  }
+
+  /// Linearly interpolate between two rectangles
+  ///
+  /// If either rect is null, this function interpolates from [Rect.zero].
+  static Rect lerp(Rect a, Rect b, double t) {
+    if (a == null && b == null)
+      return null;
+    if (a == null)
+      return new Rect.fromLTRB(b.left * t, b.top * t, b.right * t, b.bottom * t);
+    if (b == null) {
+      double k = 1.0 - t;
+      return new Rect.fromLTRB(b.left * k, b.top * k, b.right * k, b.bottom * k);
+    }
+    return new Rect.fromLTRB(
+      lerpNum(a.left, b.left, t),
+      lerpNum(a.top, b.top, t),
+      lerpNum(a.right, b.right, t),
+      lerpNum(a.bottom, b.bottom, t)
+    );
   }
 
   bool operator ==(other) {


### PR DESCRIPTION
This patch just adds them to dart:sky. A future patch will actually use them in
the framework once we've published an updated sky_engine package. Also, add
dartdoc to the classes touched in this patch.