### PR TITLE
Upload sky_viewer symbols to Google Storage.

### DIFF
--- a/sky/dist/BUILD.gn
+++ b/sky/dist/BUILD.gn
@@ -7,6 +7,7 @@ root_dist_dir = "$root_build_dir/dist"
 copy("sky_viewer") {
   sources = [
     "$root_build_dir/sky_viewer.mojo",
+    "$root_build_dir/symbols/libsky_viewer_library.so",
   ]
   outputs = [ "$root_dist_dir/viewer/{{source_file_part}}" ]
 

--- a/sky/tools/big_red_button.py
+++ b/sky/tools/big_red_button.py
@@ -51,12 +51,14 @@ ARTIFACTS = {
     'android-arm': [
         Artifact('shell', 'SkyShell.apk'),
         Artifact('viewer', 'sky_viewer.mojo'),
+        Artifact('viewer', 'libsky_viewer_library.so'),
     ],
     'linux-x64': [
         Artifact('shell', 'icudtl.dat'),
         Artifact('shell', 'sky_shell'),
         Artifact('shell', 'sky_snapshot'),
         Artifact('viewer', 'sky_viewer.mojo'),
+        Artifact('viewer', 'libsky_viewer_library.so'),
     ]
 }
 


### PR DESCRIPTION
With this change, each time `sky_viewer.mojo` is uploaded to Google Storage (both for Linux and Android), debugging symbols are also uploaded in a `symbols/` subdirectory.