### PR TITLE
Fix android build

### DIFF
--- a/ui/gl/egl_util.cc
+++ b/ui/gl/egl_util.cc
@@ -4,6 +4,8 @@
 
 #include "ui/gl/egl_util.h"
 
+#include "build/build_config.h"
+
 #if !defined(OS_ANDROID)
 #error EGL should only be used on Android.
 #endif

--- a/ui/gl/gl_bindings_egl.cc
+++ b/ui/gl/gl_bindings_egl.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "build/build_config.h"
+
 #if !defined(OS_ANDROID)
 #error EGL should only be used on Android.
 #endif


### PR DESCRIPTION
The OS_FOO macros are set by build/build_config.h, so be sure to
include that before testing the macros.