### PR TITLE
Positioned 'remembers' things it shouldn't

### DIFF
--- a/sky/packages/sky/lib/rendering/flex.dart
+++ b/sky/packages/sky/lib/rendering/flex.dart
@@ -9,10 +9,10 @@ import 'package:sky/rendering/object.dart';
 
 export 'package:sky/rendering/object.dart' show EventDisposition;
 
-class FlexBoxParentData extends BoxParentData with ContainerParentDataMixin<RenderBox> {
+class FlexParentData extends BoxParentData with ContainerParentDataMixin<RenderBox> {
   int flex;
 
-  void merge(FlexBoxParentData other) {
+  void merge(FlexParentData other) {
     if (other.flex != null)
       flex = other.flex;
     super.merge(other);
@@ -41,8 +41,8 @@ enum FlexAlignItems {
 
 typedef double _ChildSizingFunction(RenderBox child, BoxConstraints constraints);
 
-class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, FlexBoxParentData>,
-                                        RenderBoxContainerDefaultsMixin<RenderBox, FlexBoxParentData> {
+class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, FlexParentData>,
+                                        RenderBoxContainerDefaultsMixin<RenderBox, FlexParentData> {
   // lays out RenderBox children using flexible layout
 
   RenderFlex({
@@ -98,8 +98,8 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
   double _overflow;
 
   void setupParentData(RenderBox child) {
-    if (child.parentData is! FlexBoxParentData)
-      child.parentData = new FlexBoxParentData();
+    if (child.parentData is! FlexParentData)
+      child.parentData = new FlexParentData();
   }
 
   double _getIntrinsicSize({ BoxConstraints constraints,
@@ -133,7 +133,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
         } else {
           inflexibleSpace += childSize(child, childConstraints);
         }
-        assert(child.parentData is FlexBoxParentData);
+        assert(child.parentData is FlexParentData);
         child = child.parentData.nextSibling;
       }
       double mainSize = maxFlexFractionSoFar * totalFlex + inflexibleSpace;
@@ -196,7 +196,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
           inflexibleSpace += mainSize;
           maxCrossSize = math.max(maxCrossSize, crossSize);
         }
-        assert(child.parentData is FlexBoxParentData);
+        assert(child.parentData is FlexParentData);
         child = child.parentData.nextSibling;
       }
 
@@ -224,7 +224,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
           }
           maxCrossSize = math.max(maxCrossSize, crossSize);
         }
-        assert(child.parentData is FlexBoxParentData);
+        assert(child.parentData is FlexParentData);
         child = child.parentData.nextSibling;
       }
 
@@ -276,7 +276,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
   }
 
   int _getFlex(RenderBox child) {
-    assert(child.parentData is FlexBoxParentData);
+    assert(child.parentData is FlexParentData);
     return child.parentData.flex != null ? child.parentData.flex : 0;
   }
 
@@ -301,7 +301,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     double freeSpace = canFlex ? mainSize : 0.0;
     RenderBox child = firstChild;
     while (child != null) {
-      assert(child.parentData is FlexBoxParentData);
+      assert(child.parentData is FlexParentData);
       totalChildren++;
       int flex = _getFlex(child);
       if (flex > 0) {
@@ -392,7 +392,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
           if (distance != null)
             maxBaselineDistance = math.max(maxBaselineDistance, distance);
         }
-        assert(child.parentData is FlexBoxParentData);
+        assert(child.parentData is FlexParentData);
         child = child.parentData.nextSibling;
       }
     }
@@ -461,7 +461,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     double childMainPosition = leadingSpace;
     child = firstChild;
     while (child != null) {
-      assert(child.parentData is FlexBoxParentData);
+      assert(child.parentData is FlexParentData);
       double childCrossPosition;
       switch (_alignItems) {
         case FlexAlignItems.stretch:

--- a/sky/unit/test/widget/stack_test.dart
+++ b/sky/unit/test/widget/stack_test.dart
@@ -1,0 +1,46 @@
+import 'package:sky/widgets.dart';
+import 'package:test/test.dart';
+
+import 'widget_tester.dart';
+
+void main() {
+  test('Can change position data', () {
+    WidgetTester tester = new WidgetTester();
+
+    tester.pumpFrame(() {
+      return new Stack([
+        new Positioned(
+          left: 10.0,
+          child: new Container(
+            width: 10.0,
+            height: 10.0
+          )
+        )
+      ]);
+    });
+
+    Container container = tester.findWidget((Widget widget) => widget is Container);
+    expect(container.renderObject.parentData.top, isNull);
+    expect(container.renderObject.parentData.right, isNull);
+    expect(container.renderObject.parentData.bottom, isNull);
+    expect(container.renderObject.parentData.left, equals(10.0));
+
+    tester.pumpFrame(() {
+      return new Stack([
+        new Positioned(
+          right: 10.0,
+          child: new Container(
+            width: 10.0,
+            height: 10.0
+          )
+        )
+      ]);
+    });
+
+    container = tester.findWidget((Widget widget) => widget is Container);
+    expect(container.renderObject.parentData.top, isNull);
+    expect(container.renderObject.parentData.right, equals(10.0));
+    expect(container.renderObject.parentData.bottom, isNull);
+    expect(container.renderObject.parentData.left, isNull);
+  });
+}


### PR DESCRIPTION
This patch makes ParentDataNode less general purpose and instead teaches Flex
and Stack how to program the parent data for their children. We used to have
this general system because parent data used to carry CSS styling, but we don't
need it anymore.

Fixes #957