### PR TITLE
Only attempt to copy sky_viewer_library symbols on Linux and Android

### DIFF
--- a/sky/dist/BUILD.gn
+++ b/sky/dist/BUILD.gn
@@ -7,8 +7,10 @@ root_dist_dir = "$root_build_dir/dist"
 copy("sky_viewer") {
   sources = [
     "$root_build_dir/sky_viewer.mojo",
-    "$root_build_dir/symbols/libsky_viewer_library.so",
   ]
+  if (is_linux || is_android) {
+    sources += [ "$root_build_dir/symbols/libsky_viewer_library.so" ]
+  }
   outputs = [ "$root_dist_dir/viewer/{{source_file_part}}" ]
 
   deps = [


### PR DESCRIPTION
This fixes the copy rule from #954 to only apply on platforms where we build a .mojo (Linux and Android).