### PR TITLE
Use //third_party/khronos headers only on linux+android

### DIFF
--- a/ui/gl/BUILD.gn
+++ b/ui/gl/BUILD.gn
@@ -103,14 +103,6 @@ component("gl") {
   ]
 
   all_dependent_configs = [ ":gl_config" ]
-  direct_dependent_configs = [
-    "//third_party/khronos:khronos_headers",
-  ]
-
-  configs += [
-    "//third_party/khronos:khronos_headers",
-  ]
-
   deps = [
     "//base/third_party/dynamic_annotations",
     "//skia",
@@ -127,6 +119,10 @@ component("gl") {
     sources += [
       "gl_implementation_osmesa.cc",
       "gl_implementation_osmesa.h",
+    ]
+
+    configs += [
+      "//third_party/khronos:khronos_headers",
     ]
   }
   if (is_linux) {

--- a/ui/gl/gl_bindings.h
+++ b/ui/gl/gl_bindings.h
@@ -14,8 +14,11 @@
 
 #include <GL/gl.h>
 #include <GL/glext.h>
+
+#if defined(OS_ANDROID) || defined(OS_LINUX)
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
+#endif
 
 #include "base/logging.h"
 #include "base/threading/thread_local.h"

--- a/ui/gl/gl_enums.cc
+++ b/ui/gl/gl_enums.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include <sstream>
-#include <GLES2/gl2.h>
 
 #include "ui/gl/gl_enums.h"
 
@@ -25,7 +24,7 @@ std::string GLEnums::GetStringEnum(uint32 value) {
 }
 
 std::string GLEnums::GetStringError(uint32 value) {
-  if (value == GL_NONE)
+  if (value == 0u)
     return "GL_NONE";
   return GetStringEnum(value);
 }


### PR DESCRIPTION
Mac and iOS builds should only be using the OpenGL headers from the relevant frameworks. This
restricts use of the //third_party/khronos headers to only Linux and Android builds, which need their
definition of EGL types (currently).