### PR TITLE
Remove a number of unneeded filters from skyanalyzer

### DIFF
--- a/sky/tools/skyanalyzer
+++ b/sky/tools/skyanalyzer
@@ -28,20 +28,11 @@ _IGNORED_PATTERNS = [
   # Ignore analyzer status output.
   re.compile(r'^[0-9]+ errors(, [0-9]+ warnings)? and [0-9]+ hints found.'),
 
-  # Ignored because they don't affect Sky code
-  re.compile(r'\[hint\] When compiled to JS, this test might return true when the left hand side is an int'),
-
   # TODO: Fix all the warnings in the mojo packages
   re.compile(r'.*dart-pub-cache.*\.mojom\.dart'),
-  re.compile(r'.*dart-pub-cache.*/mojo-'),
-  re.compile(r'.*/mojo/public/dart/'),
 
   # It'd be nice if the other packages we used didn't have warnings, too...
   re.compile(r'.*/dart-pub-cache/hosted/pub.dartlang.org/'),
-
-  # TODO: Remove this once Sky no longer generates this warning.
-  # dartbug.com/22836
-  re.compile(r'.*cannot both be unnamed'),
 ]
 
 def main():


### PR DESCRIPTION
The dartanalyzer no longer emits these warnings (or the code has been cleaned
up).