### PR TITLE
include build/build_config.h in gl_bindings.h for macro checks to work

### DIFF
--- a/ui/gl/gl_bindings.h
+++ b/ui/gl/gl_bindings.h
@@ -15,7 +15,9 @@
 #include <GL/gl.h>
 #include <GL/glext.h>
 
-#if defined(OS_ANDROID) || defined(OS_LINUX)
+#include "build/build_config.h"
+
+#if defined(OS_ANDROID) || defined(USE_X11)
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #endif


### PR DESCRIPTION
Without an explicit #include of build/build_config.h the USE_ and OS_ macros work inconsistently.