### PR TITLE
Fix typos in dart:sky

### DIFF
--- a/sky/engine/core/painting/Color.dart
+++ b/sky/engine/core/painting/Color.dart
@@ -80,10 +80,10 @@ class Color {
     if (b == null)
       return _scaleAlpha(a, 1.0 - t);
     return new Color.fromARGB(
-      lerpNum(a.alpha, b.alpha, t).toInt(),
-      lerpNum(a.red, b.red, t).toInt(),
-      lerpNum(a.green, b.green, t).toInt(),
-      lerpNum(a.blue, b.blue, t).toInt()
+      lerpDouble(a.alpha, b.alpha, t).toInt(),
+      lerpDouble(a.red, b.red, t).toInt(),
+      lerpDouble(a.green, b.green, t).toInt(),
+      lerpDouble(a.blue, b.blue, t).toInt()
     );
   }
 

--- a/sky/engine/core/painting/Offset.dart
+++ b/sky/engine/core/painting/Offset.dart
@@ -55,7 +55,7 @@ class Offset extends OffsetBase {
       return b * t;
     if (b == null)
       return a * (1.0 - t);
-    return new Offset(lerpNum(a.dx, b.dx, t), lerpNum(a.dy, b.dy, t));
+    return new Offset(lerpDouble(a.dx, b.dx, t), lerpDouble(a.dy, b.dy, t));
   }
 
   String toString() => "Offset($dx, $dy)";

--- a/sky/engine/core/painting/Rect.dart
+++ b/sky/engine/core/painting/Rect.dart
@@ -118,10 +118,10 @@ class Rect {
       return new Rect.fromLTRB(b.left * k, b.top * k, b.right * k, b.bottom * k);
     }
     return new Rect.fromLTRB(
-      lerpNum(a.left, b.left, t),
-      lerpNum(a.top, b.top, t),
-      lerpNum(a.right, b.right, t),
-      lerpNum(a.bottom, b.bottom, t)
+      lerpDouble(a.left, b.left, t),
+      lerpDouble(a.top, b.top, t),
+      lerpDouble(a.right, b.right, t),
+      lerpDouble(a.bottom, b.bottom, t)
     );
   }
 


### PR DESCRIPTION
We renamed lerpNum to lerpDouble and forgot to update these callers.