### PR TITLE
Simplify sources listings in //ui/gl/BUILD.gn

### DIFF
--- a/ui/gl/BUILD.gn
+++ b/ui/gl/BUILD.gn
@@ -10,33 +10,17 @@ if (is_android) {
 
 source_set("gl") {
   sources = [
-    "android/gl_jni_registrar.cc",
-    "android/gl_jni_registrar.h",
-    "android/scoped_java_surface.cc",
-    "android/scoped_java_surface.h",
-    "android/surface_texture.cc",
-    "android/surface_texture.h",
-    "android/surface_texture_listener.cc",
-    "android/surface_texture_listener.h",
-    "gl_bindings.cc",
     "gl_bindings.h",
     "gl_bindings_autogen_gl.cc",
     "gl_bindings_autogen_gl.h",
-    "gl_bindings_autogen_osmesa.cc",
-    "gl_bindings_autogen_osmesa.h",
     "gl_bindings_skia_in_process.cc",
     "gl_bindings_skia_in_process.h",
     "gl_context.cc",
     "gl_context.h",
-    "gl_context_android.cc",
-    "gl_context_mac.mm",
-    "gl_context_osmesa.cc",
-    "gl_context_osmesa.h",
     "gl_context_stub.cc",
     "gl_context_stub.h",
     "gl_context_stub_with_extensions.cc",
     "gl_context_stub_with_extensions.h",
-    "gl_context_win.cc",
     "gl_enums.cc",
     "gl_enums.h",
     "gl_enums_implementation_autogen.h",
@@ -45,48 +29,20 @@ source_set("gl") {
     "gl_gl_api_implementation.h",
     "gl_implementation.cc",
     "gl_implementation.h",
-    "gl_implementation_android.cc",
-    "gl_implementation_mac.cc",
-    "gl_implementation_win.cc",
-    "gl_osmesa_api_implementation.cc",
-    "gl_osmesa_api_implementation.h",
     "gl_share_group.cc",
     "gl_share_group.h",
-    "gl_state_restorer.cc",
-    "gl_state_restorer.h",
     "gl_surface.cc",
     "gl_surface.h",
-    "gl_surface_android.cc",
-    "gl_surface_mac.mm",
-    "gl_surface_osmesa.cc",
-    "gl_surface_osmesa.h",
     "gl_surface_stub.cc",
     "gl_surface_stub.h",
-    "gl_surface_win.cc",
     "gl_switches.cc",
     "gl_switches.h",
     "gl_version_info.cc",
     "gl_version_info.h",
-    "gpu_switching_manager.cc",
-    "gpu_switching_manager.h",
     "gpu_timing.cc",
     "gpu_timing.h",
-    "scoped_binders.cc",
-    "scoped_binders.h",
-    "scoped_make_current.cc",
-    "scoped_make_current.h",
-    "sync_control_vsync_provider.cc",
-    "sync_control_vsync_provider.h",
   ]
 
-  include_dirs = [
-    "//third_party/mesa/src/include",
-  ]
-
-  deps = [
-    "//base/third_party/dynamic_annotations",
-    "//skia",
-  ]
   public_deps = [
     "//base",
     "//third_party/mesa:mesa_headers",
@@ -95,10 +51,32 @@ source_set("gl") {
     "//ui/gfx/geometry",
   ]
 
+  deps = [
+    "//base/third_party/dynamic_annotations",
+    "//skia",
+  ]
+
   if (is_android || is_linux) {
     sources += [
+      "gl_bindings.cc",
+      "gl_bindings_autogen_osmesa.cc",
+      "gl_bindings_autogen_osmesa.h",
+      "gl_context_osmesa.cc",
+      "gl_context_osmesa.h",
       "gl_implementation_osmesa.cc",
       "gl_implementation_osmesa.h",
+      "gl_osmesa_api_implementation.cc",
+      "gl_osmesa_api_implementation.h",
+      "gl_state_restorer.cc",
+      "gl_state_restorer.h",
+      "gl_surface_osmesa.cc",
+      "gl_surface_osmesa.h",
+      "scoped_binders.cc",
+      "scoped_binders.h",
+      "scoped_make_current.cc",
+      "scoped_make_current.h",
+      "sync_control_vsync_provider.cc",
+      "sync_control_vsync_provider.h",
     ]
   }
   if (is_linux) {
@@ -121,14 +99,25 @@ source_set("gl") {
   }
   if (is_android) {
     sources += [
+      "android/gl_jni_registrar.cc",
+      "android/gl_jni_registrar.h",
+      "android/scoped_java_surface.cc",
+      "android/scoped_java_surface.h",
+      "android/surface_texture.cc",
+      "android/surface_texture.h",
+      "android/surface_texture_listener.cc",
+      "android/surface_texture_listener.h",
       "egl_util.cc",
       "egl_util.h",
       "gl_bindings_autogen_egl.cc",
       "gl_bindings_autogen_egl.h",
+      "gl_context_android.cc",
       "gl_context_egl.cc",
       "gl_context_egl.h",
       "gl_egl_api_implementation.cc",
       "gl_egl_api_implementation.h",
+      "gl_implementation_android.cc",
+      "gl_surface_android.cc",
       "gl_surface_egl.cc",
       "gl_surface_egl.h",
     ]
@@ -142,48 +131,14 @@ source_set("gl") {
 
     deps += [ ":gl_jni_headers" ]
   }
-  if (is_ios || is_mac) {
-    sources = []
-    sources = [
-      "gl_bindings_autogen_gl.cc",
-      "gl_bindings_autogen_gl.h",
-      "gl_bindings_skia_in_process.cc",
-      "gl_bindings_skia_in_process.h",
-      "gl_context.cc",
-      "gl_context.h",
+
+  if (is_ios) {
+    sources += [
       "gl_context_ios.h",
       "gl_context_ios.mm",
-      "gl_context_mac.h",
-      "gl_context_mac.mm",
-      "gl_context_stub.cc",
-      "gl_context_stub.h",
-      "gl_context_stub_with_extensions.cc",
-      "gl_context_stub_with_extensions.h",
-      "gl_enums.cc",
-      "gl_enums.h",
-      "gl_enums_implementation_autogen.h",
-      "gl_gl_api_implementation.cc",
-      "gl_gl_api_implementation.h",
-      "gl_implementation.cc",
-      "gl_implementation.h",
       "gl_implementation_ios.cc",
-      "gl_implementation_mac.cc",
-      "gl_share_group.cc",
-      "gl_share_group.h",
-      "gl_surface.cc",
-      "gl_surface.h",
       "gl_surface_ios.h",
       "gl_surface_ios.mm",
-      "gl_surface_mac.h",
-      "gl_surface_mac.mm",
-      "gl_surface_stub.cc",
-      "gl_surface_stub.h",
-      "gl_switches.cc",
-      "gl_switches.h",
-      "gl_version_info.cc",
-      "gl_version_info.h",
-      "gpu_timing.cc",
-      "gpu_timing.h",
     ]
   }
 
@@ -191,6 +146,11 @@ source_set("gl") {
     sources += [
       "gl_context_cgl.cc",
       "gl_context_cgl.h",
+      "gl_context_mac.h",
+      "gl_context_mac.mm",
+      "gl_implementation_mac.cc",
+      "gl_surface_mac.h",
+      "gl_surface_mac.mm",
       "gpu_switching_manager.cc",
       "gpu_switching_manager.h",
     ]


### PR DESCRIPTION
//ui/gl/BUILD.gn specified its sources in a confusing way. First it had a sources list that contained most
(but not all) source files including ones for windows and ozone that don't exist in the tree. Then it added
some files for android and linux, then completely replaced the sources list for mac/ios.  Each of these
replacements implicitly depended on the sources assignment filter.

This puts all of the source files used on every platform in the top-level sources list and then adds files
that are platform-specific only to the platforms that they apply on. This makes it much easier to figure out
whether a particular source file is used on a particular platform.