### PR TITLE
Actually make the raw examples work again

### DIFF
--- a/examples/raw/baseline.dart
+++ b/examples/raw/baseline.dart
@@ -66,7 +66,9 @@ sky.Scene composite(sky.Picture picture, sky.Rect paintBounds) {
   sky.Rect sceneBounds = new sky.Rect.fromLTWH(0.0, 0.0, sky.view.width * devicePixelRatio, sky.view.height * devicePixelRatio);
   Float32List deviceTransform = new Float32List(16)
     ..[0] = devicePixelRatio
-    ..[5] = devicePixelRatio;
+    ..[5] = devicePixelRatio
+    ..[10] = 1.0
+    ..[15] = 1.0;
   sky.SceneBuilder sceneBuilder = new sky.SceneBuilder(sceneBounds)
     ..pushTransform(deviceTransform)
     ..addPicture(sky.Offset.zero, picture, paintBounds)

--- a/examples/raw/hello_world.dart
+++ b/examples/raw/hello_world.dart
@@ -25,7 +25,9 @@ sky.Scene composite(sky.Picture picture, sky.Rect paintBounds) {
   sky.Rect sceneBounds = new sky.Rect.fromLTWH(0.0, 0.0, sky.view.width * devicePixelRatio, sky.view.height * devicePixelRatio);
   Float32List deviceTransform = new Float32List(16)
     ..[0] = devicePixelRatio
-    ..[5] = devicePixelRatio;
+    ..[5] = devicePixelRatio
+    ..[10] = 1.0
+    ..[15] = 1.0;
   sky.SceneBuilder sceneBuilder = new sky.SceneBuilder(sceneBounds)
     ..pushTransform(deviceTransform)
     ..addPicture(sky.Offset.zero, picture, paintBounds)

--- a/examples/raw/mutating-dom.dart
+++ b/examples/raw/mutating-dom.dart
@@ -220,7 +220,9 @@ sky.Scene composite(sky.Picture picture, sky.Rect paintBounds) {
   sky.Rect sceneBounds = new sky.Rect.fromLTWH(0.0, 0.0, sky.view.width * devicePixelRatio, sky.view.height * devicePixelRatio);
   Float32List deviceTransform = new Float32List(16)
     ..[0] = devicePixelRatio
-    ..[5] = devicePixelRatio;
+    ..[5] = devicePixelRatio
+    ..[10] = 1.0
+    ..[15] = 1.0;
   sky.SceneBuilder sceneBuilder = new sky.SceneBuilder(sceneBounds)
     ..pushTransform(deviceTransform)
     ..addPicture(sky.Offset.zero, picture, paintBounds)
@@ -233,6 +235,7 @@ void beginFrame(double timeStamp) {
   sky.Picture picture = paint(paintBounds);
   sky.Scene scene = composite(picture, paintBounds);
   sky.view.scene = scene;
+  sky.view.scheduleFrame();
 }
 
 void main() {

--- a/examples/raw/painting.dart
+++ b/examples/raw/painting.dart
@@ -85,7 +85,9 @@ sky.Scene composite(sky.Picture picture, sky.Rect paintBounds) {
   sky.Rect sceneBounds = new sky.Rect.fromLTWH(0.0, 0.0, sky.view.width * devicePixelRatio, sky.view.height * devicePixelRatio);
   Float32List deviceTransform = new Float32List(16)
     ..[0] = devicePixelRatio
-    ..[5] = devicePixelRatio;
+    ..[5] = devicePixelRatio
+    ..[10] = 1.0
+    ..[15] = 1.0;
   sky.SceneBuilder sceneBuilder = new sky.SceneBuilder(sceneBounds)
     ..pushTransform(deviceTransform)
     ..addPicture(sky.Offset.zero, picture, paintBounds)

--- a/examples/raw/shadow.dart
+++ b/examples/raw/shadow.dart
@@ -42,7 +42,9 @@ sky.Scene composite(sky.Picture picture, sky.Rect paintBounds) {
   sky.Rect sceneBounds = new sky.Rect.fromLTWH(0.0, 0.0, sky.view.width * devicePixelRatio, sky.view.height * devicePixelRatio);
   Float32List deviceTransform = new Float32List(16)
     ..[0] = devicePixelRatio
-    ..[5] = devicePixelRatio;
+    ..[5] = devicePixelRatio
+    ..[10] = 1.0
+    ..[15] = 1.0;
   sky.SceneBuilder sceneBuilder = new sky.SceneBuilder(sceneBounds)
     ..pushTransform(deviceTransform)
     ..addPicture(sky.Offset.zero, picture, paintBounds)

--- a/examples/raw/spinning_arabic.dart
+++ b/examples/raw/spinning_arabic.dart
@@ -33,7 +33,9 @@ sky.Scene composite(sky.Picture picture, sky.Rect paintBounds) {
   sky.Rect sceneBounds = new sky.Rect.fromLTWH(0.0, 0.0, sky.view.width * devicePixelRatio, sky.view.height * devicePixelRatio);
   Float32List deviceTransform = new Float32List(16)
     ..[0] = devicePixelRatio
-    ..[5] = devicePixelRatio;
+    ..[5] = devicePixelRatio
+    ..[10] = 1.0
+    ..[15] = 1.0;
   sky.SceneBuilder sceneBuilder = new sky.SceneBuilder(sceneBounds)
     ..pushTransform(deviceTransform)
     ..addPicture(sky.Offset.zero, picture, paintBounds)
@@ -49,6 +51,7 @@ void beginFrame(double timeStamp) {
   sky.Picture picture = paint(paintBounds, delta);
   sky.Scene scene = composite(picture, paintBounds);
   sky.view.scene = scene;
+  sky.view.scheduleFrame();
 }
 
 void main() {
@@ -59,6 +62,7 @@ void main() {
   block.style['display'] = 'paragraph';
   block.style['direction'] = 'rtl';
   block.style['unicode-bidi'] = 'plaintext';
+  block.style['color'] = 'black';
   block.appendChild(arabic);
   block.appendChild(more);
 

--- a/examples/raw/spinning_image.dart
+++ b/examples/raw/spinning_image.dart
@@ -46,7 +46,9 @@ sky.Scene composite(sky.Picture picture, sky.Rect paintBounds) {
   sky.Rect sceneBounds = new sky.Rect.fromLTWH(0.0, 0.0, sky.view.width * devicePixelRatio, sky.view.height * devicePixelRatio);
   Float32List deviceTransform = new Float32List(16)
     ..[0] = devicePixelRatio
-    ..[5] = devicePixelRatio;
+    ..[5] = devicePixelRatio
+    ..[10] = 1.0
+    ..[15] = 1.0;
   sky.SceneBuilder sceneBuilder = new sky.SceneBuilder(sceneBounds)
     ..pushTransform(deviceTransform)
     ..addPicture(sky.Offset.zero, picture, paintBounds)
@@ -62,6 +64,7 @@ void beginFrame(double timeStamp) {
   sky.Picture picture = paint(paintBounds, delta);
   sky.Scene scene = composite(picture, paintBounds);
   sky.view.scene = scene;
+  sky.view.scheduleFrame();
 }
 
 

--- a/examples/raw/spinning_square.dart
+++ b/examples/raw/spinning_square.dart
@@ -29,7 +29,9 @@ void beginFrame(double timeStamp) {
   sky.Rect sceneBounds = new sky.Rect.fromLTWH(0.0, 0.0, sky.view.width * devicePixelRatio, sky.view.height * devicePixelRatio);
   Float32List deviceTransform = new Float32List(16)
     ..[0] = devicePixelRatio
-    ..[5] = devicePixelRatio;
+    ..[5] = devicePixelRatio
+    ..[10] = 1.0
+    ..[15] = 1.0;
   sky.SceneBuilder sceneBuilder = new sky.SceneBuilder(sceneBounds)
     ..pushTransform(deviceTransform)
     ..addPicture(sky.Offset.zero, picture, paintBounds)
@@ -37,6 +39,7 @@ void beginFrame(double timeStamp) {
   sky.view.scene = sceneBuilder.build();
 
   sky.tracing.end('beginFrame');
+  sky.view.scheduleFrame();
 }
 
 void main() {


### PR DESCRIPTION
In my previous patch, I forgot to fill in the other diagonal entries in the
device transform matrix.