### PR TITLE
RenderFlex should handle overconstrainted constraints

### DIFF
--- a/sky/packages/sky/lib/src/rendering/flex.dart
+++ b/sky/packages/sky/lib/src/rendering/flex.dart
@@ -295,7 +295,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     int totalFlex = 0;
     int totalChildren = 0;
     assert(constraints != null);
-    final double mainSize = (_direction == FlexDirection.horizontal) ? constraints.maxWidth : constraints.maxHeight;
+    final double mainSize = (_direction == FlexDirection.horizontal) ? constraints.constrainWidth() : constraints.constrainHeight();
     final bool canFlex = mainSize < double.INFINITY;
     double crossSize = 0.0;  // This is determined as we lay out the children
     double freeSpace = canFlex ? mainSize : 0.0;

--- a/sky/unit/test/rendering/flex_test.dart
+++ b/sky/unit/test/rendering/flex_test.dart
@@ -1,0 +1,16 @@
+import 'package:sky/rendering.dart';
+import 'package:test/test.dart';
+
+import 'rendering_tester.dart';
+
+void main() {
+  test('Overconstrained flex', () {
+    RenderDecoratedBox box = new RenderDecoratedBox(decoration: new BoxDecoration());
+    RenderFlex flex = new RenderFlex(children: [ box ]);
+    layout(flex, constraints: const BoxConstraints(
+      minWidth: 200.0, maxWidth: 100.0, minHeight: 200.0, maxHeight: 100.0));
+
+    expect(flex.size.width, equals(200.0), reason: "flex width");
+    expect(flex.size.height, equals(200.0), reason: "flex height");
+  });
+}


### PR DESCRIPTION
Rather than reading out the maxWidth, we should call constrainWidth to factor
in the minWidth, which might be bigger.