### PR TITLE
Disable reparent during sync

### DIFF
--- a/sky/packages/sky/lib/src/widgets/framework.dart
+++ b/sky/packages/sky/lib/src/widgets/framework.dart
@@ -19,6 +19,7 @@ export 'package:sky/src/rendering/box.dart' show BoxConstraints, BoxDecoration, 
 export 'package:sky/src/rendering/object.dart' show Point, Offset, Size, Rect, Color, Paint, Path;
 
 final bool _shouldLogRenderDuration = false; // see also 'enableProfilingLoop' argument to runApp()
+final bool _shouldReparentDuringSync = false; // currently in development
 
 typedef Widget Builder();
 typedef void WidgetTreeWalker(Widget);
@@ -380,7 +381,7 @@ abstract class Widget {
         Widget candidate = oldNode.singleChild;
         assert(candidate == null || candidate.parent == oldNode);
         oldNode = null;
-        while (candidate != null) {
+        while (candidate != null && _shouldReparentDuringSync) {
           if (_canSync(newNode, candidate)) {
             assert(candidate.parent != null);
             assert(candidate.parent.singleChild == candidate);

--- a/sky/unit/test/widget/syncing_test.dart
+++ b/sky/unit/test/widget/syncing_test.dart
@@ -57,38 +57,39 @@ void main() {
 
   });
 
-  test('remove one', () {
-
-    WidgetTester tester = new WidgetTester();
-
-    tester.pumpFrame(() {
-      return new Container(
-        child: new Container(
-          child: new TestState(
-            state: 10,
-            child: new Container()
-          )
-        )
-      );
-    });
-
-    TestState stateWidget = tester.findWidget((widget) => widget is TestState);
-
-    expect(stateWidget.state, equals(10));
-    expect(stateWidget.syncs, equals(0));
-
-    tester.pumpFrame(() {
-      return new Container(
-        child: new TestState(
-          state: 11,
-          child: new Container()
-        )
-      );
-    });
-
-    expect(stateWidget.state, equals(10));
-    expect(stateWidget.syncs, equals(1));
-
-  });
+  // Requires _shouldReparentDuringSync
+  // test('remove one', () {
+  //
+  //   WidgetTester tester = new WidgetTester();
+  //
+  //   tester.pumpFrame(() {
+  //     return new Container(
+  //       child: new Container(
+  //         child: new TestState(
+  //           state: 10,
+  //           child: new Container()
+  //         )
+  //       )
+  //     );
+  //   });
+  //
+  //   TestState stateWidget = tester.findWidget((widget) => widget is TestState);
+  //
+  //   expect(stateWidget.state, equals(10));
+  //   expect(stateWidget.syncs, equals(0));
+  //
+  //   tester.pumpFrame(() {
+  //     return new Container(
+  //       child: new TestState(
+  //         state: 11,
+  //         child: new Container()
+  //       )
+  //     );
+  //   });
+  //
+  //   expect(stateWidget.state, equals(10));
+  //   expect(stateWidget.syncs, equals(1));
+  //
+  // });
 
 }


### PR DESCRIPTION
This feature is causing a bug because the widget tree isn't correctly
synchronized with the render tree.