### PR TITLE
Fix minor problems in _ScrollGestureRecognizer, Dismissable

### DIFF
--- a/sky/engine/bindings/scripts/templates/dart_blink.template
+++ b/sky/engine/bindings/scripts/templates/dart_blink.template
@@ -27,7 +27,7 @@ View view;
 typedef EventListener(Event event);
 
 /// Linearly interpolate between two numbers.
-double lerpDouble(double a, double b, double t) {
+num lerpDouble(num a, num b, double t) {
   if (a == null && b == null)
     return null;
   if (a == null)

--- a/sky/packages/sky/lib/gestures/scroll.dart
+++ b/sky/packages/sky/lib/gestures/scroll.dart
@@ -78,6 +78,7 @@ abstract class _ScrollGestureRecognizer<T extends dynamic> extends GestureRecogn
   void didStopTrackingLastPointer() {
     if (_state == ScrollState.possible) {
       resolve(GestureDisposition.rejected);
+      _state = ScrollState.ready;
       return;
     }
     bool wasAccepted = (_state == ScrollState.accepted);

--- a/sky/packages/sky/lib/src/widgets/dismissable.dart
+++ b/sky/packages/sky/lib/src/widgets/dismissable.dart
@@ -18,7 +18,7 @@ final Interval _kCardDismissResizeInterval = new Interval(0.4, 1.0);
 const double _kMinFlingVelocity = 700.0;
 const double _kMinFlingVelocityDelta = 400.0;
 const double _kFlingVelocityScale = 1.0 / 300.0;
-const double _kDismissCardThreshold = 0.6;
+const double _kDismissCardThreshold = 0.4;
 
 typedef void ResizedCallback();
 typedef void DismissedCallback();
@@ -140,12 +140,11 @@ class Dismissable extends StatefulComponent {
       return EventDisposition.ignored;
 
     _dragUnderway = false;
-    if (_isHorizontalFlingGesture(event)) {
+    if (_fadePerformance.isCompleted) { // drag then fling
+      _startResizePerformance();
+    } else if (_isHorizontalFlingGesture(event)) {
       _dragX = event.velocityX.sign;
-      if (_fadePerformance.isCompleted)
-        _startResizePerformance();
-      else
-        _fadePerformance.fling(velocity: event.velocityX.abs() * _kFlingVelocityScale);
+      _fadePerformance.fling(velocity: event.velocityX.abs() * _kFlingVelocityScale);
     } else {
       _fadePerformance.reverse();
     }

--- a/sky/packages/sky/lib/src/widgets/gesture_detector.dart
+++ b/sky/packages/sky/lib/src/widgets/gesture_detector.dart
@@ -187,8 +187,7 @@ class GestureDetector extends StatefulComponent {
   }
 
   GestureRecognizer _ensureDisposed(GestureRecognizer recognizer) {
-    if (recognizer != null)
-      recognizer.dispose();
+    recognizer?.dispose();
     return null;
   }
 

--- a/sky/unit/test/widget/gesture_detector_test.dart
+++ b/sky/unit/test/widget/gesture_detector_test.dart
@@ -41,18 +41,51 @@ void main() {
     expect(didEndScroll, isFalse);
 
     Point secondLocation = new Point(10.0, 9.0);
-    tester.dispatchEvent(pointer.move(secondLocation), secondLocation);
+    tester.dispatchEvent(pointer.move(secondLocation), firstLocation);
     expect(didStartScroll, isFalse);
     expect(updatedScrollDelta, 1.0);
     updatedScrollDelta = null;
     expect(didEndScroll, isFalse);
 
-    tester.dispatchEvent(pointer.up(), secondLocation);
+    tester.dispatchEvent(pointer.up(), firstLocation);
     expect(didStartScroll, isFalse);
     expect(updatedScrollDelta, isNull);
     expect(didEndScroll, isTrue);
     didEndScroll = false;
 
     tester.pumpFrame(() => new Container());
+  });
+
+  test('Match two scroll gestures in succession', () {
+    WidgetTester tester = new WidgetTester();
+    TestPointer pointer = new TestPointer(7);
+
+    int gestureCount = 0;
+    double dragDistance = 0.0;
+
+    Point downLocation = new Point(10.0, 10.0);
+    Point upLocation = new Point(10.0, 20.0);
+
+    Widget builder() {
+      return new GestureDetector(
+        onVerticalScrollUpdate: (double delta) { dragDistance += delta; },
+        onVerticalScrollEnd: () { gestureCount += 1; },
+        onHorizontalScrollUpdate: (_) { fail("gesture should not match"); },
+        onHorizontalScrollEnd: () { fail("gesture should not match"); },
+        child: new Container()
+      );
+    }
+    tester.pumpFrame(builder);
+
+    tester.dispatchEvent(pointer.down(downLocation), downLocation);
+    tester.dispatchEvent(pointer.move(upLocation), downLocation);
+    tester.dispatchEvent(pointer.up(), downLocation);
+
+    tester.dispatchEvent(pointer.down(downLocation), downLocation);
+    tester.dispatchEvent(pointer.move(upLocation), downLocation);
+    tester.dispatchEvent(pointer.up(), downLocation);
+
+    expect(gestureCount, 2);
+    expect(dragDistance, -20.0);
   });
 }


### PR DESCRIPTION
Fix minor problems in _ScrollGestureRecognizer, Dismissable

Alternating scroll gestures would sometimes be ignored because _ScrollGestureRecognizer didn't always reset its _state when the pointer[s] went up.

A Dismissable dismiss triggered by a drag and then a fling could cause the next attempt to drag-dismiss to fail.
