### PR TITLE
Pass the sky::LayerTree to the GPU thread for drawing

### DIFF
--- a/services/sky/document_view.cc
+++ b/services/sky/document_view.cc
@@ -209,7 +209,9 @@ mojo::Shell* DocumentView::GetShell() {
 
 void DocumentView::BeginFrame(base::TimeTicks frame_time) {
   if (sky_view_) {
-    sky_view_->BeginFrame(frame_time);
+    std::unique_ptr<LayerTree> layer_tree = sky_view_->BeginFrame(frame_time);
+    if (layer_tree)
+      current_layer_tree_ = std::move(layer_tree);
     root_layer_->SetSize(sky_view_->display_metrics().physical_size);
   }
 }
@@ -220,13 +222,8 @@ void DocumentView::OnSurfaceIdAvailable(mojo::SurfaceIdPtr surface_id) {
 }
 
 void DocumentView::PaintContents(SkCanvas* canvas, const gfx::Rect& clip) {
-  blink::WebRect rect(clip.x(), clip.y(), clip.width(), clip.height());
-
-  if (sky_view_) {
-    RefPtr<SkPicture> picture = sky_view_->Paint();
-    if (picture)
-      canvas->drawPicture(picture.get());
-  }
+  if (current_layer_tree_)
+    current_layer_tree_->root_layer()->Paint(canvas);
 }
 
 float DocumentView::GetDevicePixelRatio() const {

--- a/services/sky/document_view.h
+++ b/services/sky/document_view.h
@@ -22,6 +22,7 @@
 #include "mojo/services/view_manager/public/cpp/view_observer.h"
 #include "services/sky/compositor/layer_client.h"
 #include "services/sky/compositor/layer_host_client.h"
+#include "sky/compositor/layer_tree.h"
 #include "sky/engine/public/platform/ServiceProvider.h"
 #include "sky/engine/public/sky/sky_view.h"
 #include "sky/engine/public/sky/sky_view_client.h"
@@ -128,6 +129,7 @@ class DocumentView : public blink::ServiceProvider,
   scoped_ptr<DartLibraryProviderImpl> library_provider_;
   scoped_ptr<LayerHost> layer_host_;
   scoped_refptr<TextureLayer> root_layer_;
+  std::unique_ptr<LayerTree> current_layer_tree_;  // TODO(abarth): Integrate //sky/compositor and //services/sky/compositor.
   RasterizerBitmap* bitmap_rasterizer_;  // Used for pixel tests.
   mojo::ServiceRegistryPtr service_registry_;
   scoped_ptr<mojo::StrongBinding<mojo::ServiceProvider>>

--- a/sky/compositor/BUILD.gn
+++ b/sky/compositor/BUILD.gn
@@ -4,6 +4,8 @@
 
 source_set("compositor") {
   sources = [
+    "layer_tree.cc",
+    "layer_tree.h",
     "layer.cc",
     "layer.h",
   ]

--- a/sky/compositor/layer.h
+++ b/sky/compositor/layer.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef SKY_COMPOSITOR_H_
-#define SKY_COMPOSITOR_H_
+#ifndef SKY_COMPOSITOR_LAYER_H_
+#define SKY_COMPOSITOR_LAYER_H_
 
 #include <memory>
 #include <vector>
@@ -170,4 +170,4 @@ class ColorFilterLayer : public ContainerLayer {
 
 }  // namespace sky
 
-#endif  // SKY_COMPOSITOR_H_
+#endif  // SKY_COMPOSITOR_LAYER_H_

--- a/sky/compositor/layer_tree.cc
+++ b/sky/compositor/layer_tree.cc
@@ -1,0 +1,17 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "sky/compositor/layer_tree.h"
+
+#include "sky/compositor/layer.h"
+
+namespace sky {
+
+LayerTree::LayerTree() {
+}
+
+LayerTree::~LayerTree() {
+}
+
+}  // namespace sky

--- a/sky/compositor/layer_tree.h
+++ b/sky/compositor/layer_tree.h
@@ -1,0 +1,38 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SKY_COMPOSITOR_LAYER_TREE_H_
+#define SKY_COMPOSITOR_LAYER_TREE_H_
+
+#include <memory>
+
+#include "base/macros.h"
+#include "sky/compositor/layer.h"
+#include "third_party/skia/include/core/SkSize.h"
+
+namespace sky {
+
+class LayerTree {
+ public:
+  LayerTree();
+  ~LayerTree();
+
+  Layer* root_layer() const { return root_layer_.get(); }
+  void set_root_layer(std::unique_ptr<Layer> root_layer) {
+    root_layer_ = std::move(root_layer);
+  }
+
+  const SkISize& frame_size() const { return frame_size_; }
+  void set_frame_size(const SkISize& frame_size) { frame_size_ = frame_size; }
+
+ private:
+  SkISize frame_size_; // Physical pixels.
+  std::unique_ptr<Layer> root_layer_;
+
+  DISALLOW_COPY_AND_ASSIGN(LayerTree);
+};
+
+}  // namespace sky
+
+#endif  // SKY_COMPOSITOR_LAYER_TREE_H_

--- a/sky/engine/core/compositing/Scene.cpp
+++ b/sky/engine/core/compositing/Scene.cpp
@@ -16,22 +16,17 @@ PassRefPtr<Scene> Scene::create(std::unique_ptr<sky::Layer> rootLayer)
 }
 
 Scene::Scene(std::unique_ptr<sky::Layer> rootLayer)
-    : m_rootLayer(std::move(rootLayer))
+    : m_layerTree(new sky::LayerTree())
 {
+    m_layerTree->set_root_layer(std::move(rootLayer));
 }
 
 Scene::~Scene()
 {
 }
 
-PassRefPtr<SkPicture> Scene::createPicture() const
-{
-    SkRTreeFactory rtreeFactory;
-    SkPictureRecorder pictureRecorder;
-    SkCanvas* canvas = pictureRecorder.beginRecording(m_rootLayer->paint_bounds(),
-        &rtreeFactory, SkPictureRecorder::kComputeSaveLayerInfo_RecordFlag);
-    m_rootLayer->Paint(canvas);
-    return adoptRef(pictureRecorder.endRecording());
+std::unique_ptr<sky::LayerTree> Scene::takeLayerTree() {
+  return std::move(m_layerTree);
 }
 
 } // namespace blink

--- a/sky/engine/core/compositing/Scene.h
+++ b/sky/engine/core/compositing/Scene.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "sky/compositor/layer.h"
+#include "sky/compositor/layer_tree.h"
 #include "sky/engine/tonic/dart_wrappable.h"
 #include "sky/engine/wtf/PassRefPtr.h"
 #include "sky/engine/wtf/RefCounted.h"
@@ -21,14 +22,12 @@ public:
     ~Scene() override;
     static PassRefPtr<Scene> create(std::unique_ptr<sky::Layer> rootLayer);
 
-    // While bootstraping the compositing system, we use an SkPicture instead
-    // of a layer tree to back the scene.
-    PassRefPtr<SkPicture> createPicture() const;
+    std::unique_ptr<sky::LayerTree> takeLayerTree();
 
 private:
     explicit Scene(std::unique_ptr<sky::Layer> rootLayer);
 
-    std::unique_ptr<sky::Layer> m_rootLayer;
+    std::unique_ptr<sky::LayerTree> m_layerTree;
 };
 
 } // namespace blink

--- a/sky/engine/core/view/View.cpp
+++ b/sky/engine/core/view/View.cpp
@@ -65,12 +65,13 @@ void View::handleInputEvent(PassRefPtr<Event> event)
         m_eventCallback->handleEvent(event.get());
 }
 
-void View::beginFrame(base::TimeTicks frameTime)
+std::unique_ptr<sky::LayerTree> View::beginFrame(base::TimeTicks frameTime)
 {
     if (!m_frameCallback)
-        return;
+        return nullptr;
     double frameTimeMS = (frameTime - base::TimeTicks()).InMillisecondsF();
     m_frameCallback->handleEvent(frameTimeMS);
+    return m_scene ? m_scene->takeLayerTree() : nullptr;
 }
 
 } // namespace blink

--- a/sky/engine/core/view/View.h
+++ b/sky/engine/core/view/View.h
@@ -35,9 +35,6 @@ public:
     double width() const;
     double height() const;
 
-    Picture* picture() const { return m_picture.get(); }
-    void setPicture(Picture* picture) { m_picture = picture; }
-
     Scene* scene() const { return m_scene.get(); }
     void setScene(Scene* scene) { m_scene = scene; }
 
@@ -50,7 +47,7 @@ public:
 
     void setDisplayMetrics(const SkyDisplayMetrics& metrics);
     void handleInputEvent(PassRefPtr<Event> event);
-    void beginFrame(base::TimeTicks frameTime);
+    std::unique_ptr<sky::LayerTree> beginFrame(base::TimeTicks frameTime);
 
 private:
     explicit View(const base::Closure& scheduleFrameCallback);
@@ -60,7 +57,6 @@ private:
     OwnPtr<EventCallback> m_eventCallback;
     OwnPtr<VoidCallback> m_metricsChangedCallback;
     OwnPtr<FrameCallback> m_frameCallback;
-    RefPtr<Picture> m_picture;
     RefPtr<Scene> m_scene;
 };
 

--- a/sky/engine/core/view/View.idl
+++ b/sky/engine/core/view/View.idl
@@ -14,7 +14,6 @@ interface View {
   readonly attribute double width;
   readonly attribute double height;
 
-  attribute Picture picture;
   attribute Scene scene;
 
   void setEventCallback(EventCallback callback);

--- a/sky/engine/public/sky/BUILD.gn
+++ b/sky/engine/public/sky/BUILD.gn
@@ -8,6 +8,7 @@ source_set("sky") {
     "//mojo/public/cpp/system",
     "//mojo/services/network/public/interfaces",
     "//skia",
+    "//sky/compositor",
     "//sky/engine/core",
     "//sky/engine/platform",
     "//sky/engine/wtf",

--- a/sky/engine/public/sky/sky_view.cc
+++ b/sky/engine/public/sky/sky_view.cc
@@ -66,16 +66,8 @@ void SkyView::RunFromSnapshot(const WebString& name,
   dart_controller_->RunFromSnapshot(snapshot.Pass());
 }
 
-void SkyView::BeginFrame(base::TimeTicks frame_time) {
-  view_->beginFrame(frame_time);
-}
-
-PassRefPtr<SkPicture> SkyView::Paint() {
-  if (Scene* scene = view_->scene())
-    return scene->createPicture();
-  if (Picture* picture = view_->picture())
-    return picture->toSkia();
-  return nullptr;
+std::unique_ptr<sky::LayerTree> SkyView::BeginFrame(base::TimeTicks frame_time) {
+  return view_->beginFrame(frame_time);
 }
 
 void SkyView::HandleInputEvent(const WebInputEvent& inputEvent) {

--- a/sky/engine/public/sky/sky_view.h
+++ b/sky/engine/public/sky/sky_view.h
@@ -11,6 +11,7 @@
 #include "base/time/time.h"
 #include "mojo/public/cpp/system/data_pipe.h"
 #include "mojo/services/network/public/interfaces/url_loader.mojom.h"
+#include "sky/compositor/layer_tree.h"
 #include "sky/engine/public/platform/WebCommon.h"
 #include "sky/engine/public/platform/WebURL.h"
 #include "sky/engine/public/platform/sky_display_metrics.h"
@@ -33,7 +34,8 @@ class SkyView {
 
   const SkyDisplayMetrics& display_metrics() const { return display_metrics_; }
   void SetDisplayMetrics(const SkyDisplayMetrics& metrics);
-  void BeginFrame(base::TimeTicks frame_time);
+
+  std::unique_ptr<sky::LayerTree> BeginFrame(base::TimeTicks frame_time);
 
   void CreateView(const String& name);
 
@@ -42,7 +44,6 @@ class SkyView {
   void RunFromSnapshot(const WebString& name,
                        mojo::ScopedDataPipeConsumerHandle snapshot);
 
-  PassRefPtr<SkPicture> Paint();
   void HandleInputEvent(const WebInputEvent& event);
 
   void StartDartTracing();

--- a/sky/shell/BUILD.gn
+++ b/sky/shell/BUILD.gn
@@ -18,6 +18,7 @@ common_deps = [
   "//mojo/services/network/public/interfaces",
   "//services/asset_bundle:lib",
   "//skia",
+  "//sky/compositor",
   "//sky/engine",
   "//sky/engine/tonic",
   "//sky/engine/wtf",

--- a/sky/shell/gpu/rasterizer.h
+++ b/sky/shell/gpu/rasterizer.h
@@ -34,12 +34,11 @@ class Rasterizer : public GPUDelegate {
 
   void OnAcceleratedWidgetAvailable(gfx::AcceleratedWidget widget) override;
   void OnOutputSurfaceDestroyed() override;
-  void Draw(PassRefPtr<SkPicture> picture, gfx::Size size) override;
+  void Draw(scoped_ptr<LayerTree> layer_tree) override;
 
  private:
   void EnsureGLContext();
   void EnsureGaneshSurface(intptr_t window_fbo, const gfx::Size& size);
-  void DrawPicture(SkPicture* picture);
 
   scoped_refptr<gfx::GLShareGroup> share_group_;
   scoped_refptr<gfx::GLSurface> surface_;

--- a/sky/shell/gpu_delegate.h
+++ b/sky/shell/gpu_delegate.h
@@ -5,7 +5,10 @@
 #ifndef SKY_SHELL_GPU_DELEGATE_H_
 #define SKY_SHELL_GPU_DELEGATE_H_
 
-#include "sky/engine/wtf/PassRefPtr.h"
+#include <memory>
+
+#include "base/memory/scoped_ptr.h"
+#include "sky/compositor/layer_tree.h"
 #include "ui/gfx/geometry/size.h"
 #include "ui/gfx/native_widget_types.h"
 
@@ -18,7 +21,7 @@ class GPUDelegate {
  public:
   virtual void OnAcceleratedWidgetAvailable(gfx::AcceleratedWidget widget) = 0;
   virtual void OnOutputSurfaceDestroyed() = 0;
-  virtual void Draw(PassRefPtr<SkPicture> picture, gfx::Size size) = 0;
+  virtual void Draw(scoped_ptr<LayerTree> layer_tree) = 0;
 
  protected:
   virtual ~GPUDelegate();

--- a/sky/shell/ui/engine.h
+++ b/sky/shell/ui/engine.h
@@ -55,9 +55,7 @@ class Engine : public UIDelegate,
 
   static void Init();
 
-  void BeginFrame(base::TimeTicks frame_time);
-  PassRefPtr<SkPicture> Paint();
-  const gfx::Size& physical_size() { return physical_size_; }
+  std::unique_ptr<LayerTree> BeginFrame(base::TimeTicks frame_time);
 
   void StartDartTracing();
   void StopDartTracing(mojo::ScopedDataPipeProducerHandle producer);


### PR DESCRIPTION
Instead of squashing the layers down into a single SkPicture, we now pass the
tree to the GPU thread, which draws everything separately.