### PR TITLE
Add optional ignoring parameter to IgnorePointer

### DIFF
--- a/sky/packages/sky/lib/src/rendering/proxy_box.dart
+++ b/sky/packages/sky/lib/src/rendering/proxy_box.dart
@@ -671,8 +671,10 @@ class RenderCustomPaint extends RenderProxyBox {
 }
 
 class RenderIgnorePointer extends RenderProxyBox {
-  RenderIgnorePointer({ RenderBox child }) : super(child);
+  RenderIgnorePointer({ RenderBox child, bool ignoring: true }) : super(child);
+
+  bool ignoring;
   bool hitTest(HitTestResult result, { Point position }) {
-    return false;
+    return ignoring ? false : super.hitTest(result, position: position);
   }
 }

--- a/sky/packages/sky/lib/src/rendering/proxy_box.dart
+++ b/sky/packages/sky/lib/src/rendering/proxy_box.dart
@@ -674,6 +674,7 @@ class RenderIgnorePointer extends RenderProxyBox {
   RenderIgnorePointer({ RenderBox child, bool ignoring: true }) : super(child);
 
   bool ignoring;
+
   bool hitTest(HitTestResult result, { Point position }) {
     return ignoring ? false : super.hitTest(result, position: position);
   }

--- a/sky/packages/sky/lib/src/widgets/basic.dart
+++ b/sky/packages/sky/lib/src/widgets/basic.dart
@@ -899,8 +899,15 @@ class WidgetToRenderBoxAdapter extends LeafRenderObjectWrapper {
 // EVENT HANDLING
 
 class IgnorePointer extends OneChildRenderObjectWrapper {
-  IgnorePointer({ Key key, Widget child })
+  IgnorePointer({ Key key, Widget child, this.ignoring })
     : super(key: key, child: child);
-  RenderIgnorePointer createNode() => new RenderIgnorePointer();
+
+  final bool ignoring;
+  RenderIgnorePointer createNode() => new RenderIgnorePointer(ignoring: ignoring);
   RenderIgnorePointer get renderObject => super.renderObject;
+
+  void syncRenderObject(Widget old) {
+    super.syncRenderObject(old);
+    renderObject.ignoring = ignoring;
+  }
 }

--- a/sky/packages/sky/lib/src/widgets/basic.dart
+++ b/sky/packages/sky/lib/src/widgets/basic.dart
@@ -899,10 +899,11 @@ class WidgetToRenderBoxAdapter extends LeafRenderObjectWrapper {
 // EVENT HANDLING
 
 class IgnorePointer extends OneChildRenderObjectWrapper {
-  IgnorePointer({ Key key, Widget child, this.ignoring })
+  IgnorePointer({ Key key, Widget child, this.ignoring: true })
     : super(key: key, child: child);
 
   final bool ignoring;
+
   RenderIgnorePointer createNode() => new RenderIgnorePointer(ignoring: ignoring);
   RenderIgnorePointer get renderObject => super.renderObject;
 


### PR DESCRIPTION
This makes it easier for apps to control whether an IgnorePointer
widget is actively ignoring or not by changing a boolean instead of
the tree structure. `ignoring` defaults to true.