### PR TITLE
Update links to READMEs

### DIFF
--- a/sky/packages/sky/README.md
+++ b/sky/packages/sky/README.md
@@ -46,7 +46,7 @@ Execution starts in `main`, which in this example runs a new instance of the `He
 The `HelloWorldApp` builds a `Text` widget containing the traditional `Hello, world!`
 string and centers it on the screen using a `Center` widget. To learn more about
 the widget system, please see the
-[widgets tutorial](https://github.com/domokit/sky_engine/blob/master/sky/packages/sky/lib/widgets/README.md).
+[widgets tutorial](https://github.com/domokit/sky_engine/blob/master/sky/packages/sky/lib/src/widgets/README.md).
 
 Setting up your Android device
 -------------------------

--- a/sky/packages/sky/lib/src/rendering/box.dart
+++ b/sky/packages/sky/lib/src/rendering/box.dart
@@ -320,7 +320,7 @@ abstract class RenderBox extends RenderObject {
     assert(constraints != null);
     assert(_size != null);
     assert(() {
-      'See https://github.com/domokit/sky_engine/blob/master/sky/packages/sky/lib/widgets/sizing.md#user-content-unbounded-constraints';
+      'See https://github.com/domokit/sky_engine/blob/master/sky/packages/sky/lib/src/widgets/sizing.md#user-content-unbounded-constraints';
       return !_size.isInfinite;
     });
     bool result = constraints.contains(_size);

--- a/sky/packages/sky/lib/src/rendering/flex.dart
+++ b/sky/packages/sky/lib/src/rendering/flex.dart
@@ -308,7 +308,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
         // Flexible children can only be used when the RenderFlex box's container has a finite size.
         // When the container is infinite, for example if you are in a scrollable viewport, then
         // it wouldn't make any sense to have a flexible child.
-        assert(canFlex && 'See https://github.com/domokit/sky_engine/blob/master/sky/packages/sky/lib/widgets/sizing.md#user-content-flex' is String);
+        assert(canFlex && 'See https://github.com/domokit/sky_engine/blob/master/sky/packages/sky/lib/src/widgets/sizing.md#user-content-flex' is String);
         totalFlex += child.parentData.flex;
       } else {
         BoxConstraints innerConstraints;


### PR DESCRIPTION
These needed to be updated because we moved the widgets directory into the src
directory to hide it from dartdoc.