### PR TITLE
Replace Scroll with Drag in names in GestureRecognizer et al

### DIFF
--- a/sky/packages/sky/lib/gestures/scroll.dart
+++ b/sky/packages/sky/lib/gestures/scroll.dart
@@ -8,15 +8,15 @@ import 'package:sky/gestures/arena.dart';
 import 'package:sky/gestures/recognizer.dart';
 import 'package:sky/gestures/constants.dart';
 
-enum ScrollState {
+enum DragState {
   ready,
   possible,
   accepted
 }
 
-typedef void GestureScrollStartCallback();
-typedef void GestureScrollUpdateCallback(double scrollDelta);
-typedef void GestureScrollEndCallback();
+typedef void GestureDragStartCallback();
+typedef void GestureDragUpdateCallback(double scrollDelta);
+typedef void GestureDragEndCallback();
 
 typedef void GesturePanStartCallback();
 typedef void GesturePanUpdateCallback(sky.Offset scrollDelta);
@@ -24,39 +24,39 @@ typedef void GesturePanEndCallback();
 
 typedef void _GesturePolymorphicUpdateCallback<T>(T scrollDelta);
 
-abstract class _ScrollGestureRecognizer<T extends dynamic> extends GestureRecognizer {
-  _ScrollGestureRecognizer({ PointerRouter router, this.onStart, this.onUpdate, this.onEnd })
+abstract class _DragGestureRecognizer<T extends dynamic> extends GestureRecognizer {
+  _DragGestureRecognizer({ PointerRouter router, this.onStart, this.onUpdate, this.onEnd })
     : super(router: router);
 
-  GestureScrollStartCallback onStart;
+  GestureDragStartCallback onStart;
   _GesturePolymorphicUpdateCallback<T> onUpdate;
-  GestureScrollEndCallback onEnd;
+  GestureDragEndCallback onEnd;
 
-  ScrollState _state = ScrollState.ready;
-  T _pendingScrollDelta;
+  DragState _state = DragState.ready;
+  T _pendingDragDelta;
 
-  T get _initialPendingScrollDelta;
-  T _getScrollDelta(sky.PointerEvent event);
-  bool get _hasSufficientPendingScrollDeltaToAccept;
+  T get _initialPendingDragDelta;
+  T _getDragDelta(sky.PointerEvent event);
+  bool get _hasSufficientPendingDragDeltaToAccept;
 
   void addPointer(sky.PointerEvent event) {
     startTrackingPointer(event.pointer);
-    if (_state == ScrollState.ready) {
-      _state = ScrollState.possible;
-      _pendingScrollDelta = _initialPendingScrollDelta;
+    if (_state == DragState.ready) {
+      _state = DragState.possible;
+      _pendingDragDelta = _initialPendingDragDelta;
     }
   }
 
   void handleEvent(sky.PointerEvent event) {
-    assert(_state != ScrollState.ready);
+    assert(_state != DragState.ready);
     if (event.type == 'pointermove') {
-      T delta = _getScrollDelta(event);
-      if (_state == ScrollState.accepted) {
+      T delta = _getDragDelta(event);
+      if (_state == DragState.accepted) {
         if (onUpdate != null)
           onUpdate(delta);
       } else {
-        _pendingScrollDelta += delta;
-        if (_hasSufficientPendingScrollDeltaToAccept)
+        _pendingDragDelta += delta;
+        if (_hasSufficientPendingDragDeltaToAccept)
           resolve(GestureDisposition.accepted);
       }
     }
@@ -64,58 +64,58 @@ abstract class _ScrollGestureRecognizer<T extends dynamic> extends GestureRecogn
   }
 
   void acceptGesture(int pointer) {
-    if (_state != ScrollState.accepted) {
-      _state = ScrollState.accepted;
-      T delta = _pendingScrollDelta;
-      _pendingScrollDelta = null;
+    if (_state != DragState.accepted) {
+      _state = DragState.accepted;
+      T delta = _pendingDragDelta;
+      _pendingDragDelta = null;
       if (onStart != null)
         onStart();
-      if (delta != _initialPendingScrollDelta && onUpdate != null)
+      if (delta != _initialPendingDragDelta && onUpdate != null)
         onUpdate(delta);
     }
   }
 
   void didStopTrackingLastPointer() {
-    if (_state == ScrollState.possible) {
+    if (_state == DragState.possible) {
       resolve(GestureDisposition.rejected);
-      _state = ScrollState.ready;
+      _state = DragState.ready;
       return;
     }
-    bool wasAccepted = (_state == ScrollState.accepted);
-    _state = ScrollState.ready;
+    bool wasAccepted = (_state == DragState.accepted);
+    _state = DragState.ready;
     if (wasAccepted && onEnd != null)
       onEnd();
   }
 }
 
-class VerticalScrollGestureRecognizer extends _ScrollGestureRecognizer<double> {
-  VerticalScrollGestureRecognizer({
+class VerticalDragGestureRecognizer extends _DragGestureRecognizer<double> {
+  VerticalDragGestureRecognizer({
     PointerRouter router,
-    GestureScrollStartCallback onStart,
-    GestureScrollUpdateCallback onUpdate,
-    GestureScrollEndCallback onEnd
+    GestureDragStartCallback onStart,
+    GestureDragUpdateCallback onUpdate,
+    GestureDragEndCallback onEnd
   }) : super(router: router, onStart: onStart, onUpdate: onUpdate, onEnd: onEnd);
 
-  double get _initialPendingScrollDelta => 0.0;
+  double get _initialPendingDragDelta => 0.0;
   // Notice that we negate dy because scroll offsets go in the opposite direction.
-  double _getScrollDelta(sky.PointerEvent event) => -event.dy;
-  bool get _hasSufficientPendingScrollDeltaToAccept => _pendingScrollDelta.abs() > kTouchSlop;
+  double _getDragDelta(sky.PointerEvent event) => -event.dy;
+  bool get _hasSufficientPendingDragDeltaToAccept => _pendingDragDelta.abs() > kTouchSlop;
 }
 
-class HorizontalScrollGestureRecognizer extends _ScrollGestureRecognizer<double> {
-  HorizontalScrollGestureRecognizer({
+class HorizontalDragGestureRecognizer extends _DragGestureRecognizer<double> {
+  HorizontalDragGestureRecognizer({
     PointerRouter router,
-    GestureScrollStartCallback onStart,
-    GestureScrollUpdateCallback onUpdate,
-    GestureScrollEndCallback onEnd
+    GestureDragStartCallback onStart,
+    GestureDragUpdateCallback onUpdate,
+    GestureDragEndCallback onEnd
   }) : super(router: router, onStart: onStart, onUpdate: onUpdate, onEnd: onEnd);
 
-  double get _initialPendingScrollDelta => 0.0;
-  double _getScrollDelta(sky.PointerEvent event) => -event.dx;
-  bool get _hasSufficientPendingScrollDeltaToAccept => _pendingScrollDelta.abs() > kTouchSlop;
+  double get _initialPendingDragDelta => 0.0;
+  double _getDragDelta(sky.PointerEvent event) => -event.dx;
+  bool get _hasSufficientPendingDragDeltaToAccept => _pendingDragDelta.abs() > kTouchSlop;
 }
 
-class PanGestureRecognizer extends _ScrollGestureRecognizer<sky.Offset> {
+class PanGestureRecognizer extends _DragGestureRecognizer<sky.Offset> {
   PanGestureRecognizer({
     PointerRouter router,
     GesturePanStartCallback onStart,
@@ -123,10 +123,10 @@ class PanGestureRecognizer extends _ScrollGestureRecognizer<sky.Offset> {
     GesturePanEndCallback onEnd
   }) : super(router: router, onStart: onStart, onUpdate: onUpdate, onEnd: onEnd);
 
-  sky.Offset get _initialPendingScrollDelta => sky.Offset.zero;
+  sky.Offset get _initialPendingDragDelta => sky.Offset.zero;
   // Notice that we negate dy because scroll offsets go in the opposite direction.
-  sky.Offset _getScrollDelta(sky.PointerEvent event) => new sky.Offset(event.dx, -event.dy);
-  bool get _hasSufficientPendingScrollDeltaToAccept {
-    return _pendingScrollDelta.dx.abs() > kTouchSlop || _pendingScrollDelta.dy.abs() > kTouchSlop;
+  sky.Offset _getDragDelta(sky.PointerEvent event) => new sky.Offset(event.dx, -event.dy);
+  bool get _hasSufficientPendingDragDeltaToAccept {
+    return _pendingDragDelta.dx.abs() > kTouchSlop || _pendingDragDelta.dy.abs() > kTouchSlop;
   }
 }

--- a/sky/packages/sky/lib/src/widgets/dismissable.dart
+++ b/sky/packages/sky/lib/src/widgets/dismissable.dart
@@ -119,7 +119,7 @@ class Dismissable extends StatefulComponent {
       _maybeCallOnResized();
   }
 
-  void _handleScrollStart() {
+  void _handleDragStart() {
     if (_fadePerformance.isAnimating)
       return;
     _dragUnderway = true;
@@ -127,7 +127,7 @@ class Dismissable extends StatefulComponent {
     _fadePerformance.progress = 0.0;
   }
 
-  void _handleScrollUpdate(double scrollOffset) {
+  void _handleDragUpdate(double scrollOffset) {
     if (!_isActive || _fadePerformance.isAnimating)
       return;
 
@@ -157,7 +157,7 @@ class Dismissable extends StatefulComponent {
       _fadePerformance.progress = _dragExtent.abs() / (_size.width * _kDismissCardThreshold);
   }
 
-  _handleScrollEnd() {
+  _handleDragEnd() {
     if (!_isActive || _fadePerformance.isAnimating)
       return;
     _dragUnderway = false;
@@ -238,12 +238,12 @@ class Dismissable extends StatefulComponent {
     }
 
     return new GestureDetector(
-      onHorizontalScrollStart: _directionIsYAxis ? null : _handleScrollStart,
-      onHorizontalScrollUpdate: _directionIsYAxis ? null : _handleScrollUpdate,
-      onHorizontalScrollEnd: _directionIsYAxis ? null : _handleScrollEnd,
-      onVerticalScrollStart: _directionIsYAxis ? _handleScrollStart : null,
-      onVerticalScrollUpdate: _directionIsYAxis ? _handleScrollUpdate : null,
-      onVerticalScrollEnd: _directionIsYAxis ? _handleScrollEnd : null,
+      onHorizontalDragStart: _directionIsYAxis ? null : _handleDragStart,
+      onHorizontalDragUpdate: _directionIsYAxis ? null : _handleDragUpdate,
+      onHorizontalDragEnd: _directionIsYAxis ? null : _handleDragEnd,
+      onVerticalDragStart: _directionIsYAxis ? _handleDragStart : null,
+      onVerticalDragUpdate: _directionIsYAxis ? _handleDragUpdate : null,
+      onVerticalDragEnd: _directionIsYAxis ? _handleDragEnd : null,
       child: new Listener(
         onGestureFlingStart: _handleFlingStart,
         child: new SizeObserver(

--- a/sky/packages/sky/lib/src/widgets/gesture_detector.dart
+++ b/sky/packages/sky/lib/src/widgets/gesture_detector.dart
@@ -19,12 +19,12 @@ class GestureDetector extends StatefulComponent {
     this.onTap,
     this.onShowPress,
     this.onLongPress,
-    this.onVerticalScrollStart,
-    this.onVerticalScrollUpdate,
-    this.onVerticalScrollEnd,
-    this.onHorizontalScrollStart,
-    this.onHorizontalScrollUpdate,
-    this.onHorizontalScrollEnd,
+    this.onVerticalDragStart,
+    this.onVerticalDragUpdate,
+    this.onVerticalDragEnd,
+    this.onHorizontalDragStart,
+    this.onHorizontalDragUpdate,
+    this.onHorizontalDragEnd,
     this.onPanStart,
     this.onPanUpdate,
     this.onPanEnd
@@ -35,13 +35,13 @@ class GestureDetector extends StatefulComponent {
   GestureShowPressListener onShowPress;
   GestureLongPressListener onLongPress;
 
-  GestureScrollStartCallback onVerticalScrollStart;
-  GestureScrollUpdateCallback onVerticalScrollUpdate;
-  GestureScrollEndCallback onVerticalScrollEnd;
+  GestureDragStartCallback onVerticalDragStart;
+  GestureDragUpdateCallback onVerticalDragUpdate;
+  GestureDragEndCallback onVerticalDragEnd;
 
-  GestureScrollStartCallback onHorizontalScrollStart;
-  GestureScrollUpdateCallback onHorizontalScrollUpdate;
-  GestureScrollEndCallback onHorizontalScrollEnd;
+  GestureDragStartCallback onHorizontalDragStart;
+  GestureDragUpdateCallback onHorizontalDragUpdate;
+  GestureDragEndCallback onHorizontalDragEnd;
 
   GesturePanStartCallback onPanStart;
   GesturePanUpdateCallback onPanUpdate;
@@ -52,12 +52,12 @@ class GestureDetector extends StatefulComponent {
     onTap = source.onTap;
     onShowPress = source.onShowPress;
     onLongPress = source.onLongPress;
-    onVerticalScrollStart = source.onVerticalScrollStart;
-    onVerticalScrollUpdate = source.onVerticalScrollUpdate;
-    onVerticalScrollEnd = source.onVerticalScrollEnd;
-    onHorizontalScrollStart = source.onHorizontalScrollStart;
-    onHorizontalScrollUpdate = source.onHorizontalScrollUpdate;
-    onHorizontalScrollEnd = source.onHorizontalScrollEnd;
+    onVerticalDragStart = source.onVerticalDragStart;
+    onVerticalDragUpdate = source.onVerticalDragUpdate;
+    onVerticalDragEnd = source.onVerticalDragEnd;
+    onHorizontalDragStart = source.onHorizontalDragStart;
+    onHorizontalDragUpdate = source.onHorizontalDragUpdate;
+    onHorizontalDragEnd = source.onHorizontalDragEnd;
     onPanStart = source.onPanStart;
     onPanUpdate = source.onPanUpdate;
     onPanEnd = source.onPanEnd;
@@ -87,18 +87,18 @@ class GestureDetector extends StatefulComponent {
     return _longPress;
   }
 
-  VerticalScrollGestureRecognizer _verticalScroll;
-  VerticalScrollGestureRecognizer _ensureVerticalScroll() {
-    if (_verticalScroll == null)
-      _verticalScroll = new VerticalScrollGestureRecognizer(router: _router);
-    return _verticalScroll;
+  VerticalDragGestureRecognizer _verticalDrag;
+  VerticalDragGestureRecognizer _ensureVerticalDrag() {
+    if (_verticalDrag == null)
+      _verticalDrag = new VerticalDragGestureRecognizer(router: _router);
+    return _verticalDrag;
   }
 
-  HorizontalScrollGestureRecognizer _horizontalScroll;
-  HorizontalScrollGestureRecognizer _ensureHorizontalScroll() {
-    if (_horizontalScroll == null)
-      _horizontalScroll = new HorizontalScrollGestureRecognizer(router: _router);
-    return _horizontalScroll;
+  HorizontalDragGestureRecognizer _horizontalDrag;
+  HorizontalDragGestureRecognizer _ensureHorizontalDrag() {
+    if (_horizontalDrag == null)
+      _horizontalDrag = new HorizontalDragGestureRecognizer(router: _router);
+    return _horizontalDrag;
   }
 
   PanGestureRecognizer _pan;
@@ -118,8 +118,8 @@ class GestureDetector extends StatefulComponent {
     _tap = _ensureDisposed(_tap);
     _showPress = _ensureDisposed(_showPress);
     _longPress = _ensureDisposed(_longPress);
-    _verticalScroll = _ensureDisposed(_verticalScroll);
-    _horizontalScroll = _ensureDisposed(_horizontalScroll);
+    _verticalDrag = _ensureDisposed(_verticalDrag);
+    _horizontalDrag = _ensureDisposed(_horizontalDrag);
     _pan = _ensureDisposed(_pan);
   }
 
@@ -127,8 +127,8 @@ class GestureDetector extends StatefulComponent {
     _syncTap();
     _syncShowPress();
     _syncLongPress();
-    _syncVerticalScroll();
-    _syncHorizontalScroll();
+    _syncVerticalDrag();
+    _syncHorizontalDrag();
     _syncPan();
   }
 
@@ -153,25 +153,25 @@ class GestureDetector extends StatefulComponent {
       _ensureLongPress().onLongPress = onLongPress;
   }
 
-  void _syncVerticalScroll() {
-    if (onVerticalScrollStart == null && onVerticalScrollUpdate == null && onVerticalScrollEnd == null) {
-      _verticalScroll = _ensureDisposed(_verticalScroll);
+  void _syncVerticalDrag() {
+    if (onVerticalDragStart == null && onVerticalDragUpdate == null && onVerticalDragEnd == null) {
+      _verticalDrag = _ensureDisposed(_verticalDrag);
     } else {
-      _ensureVerticalScroll()
-        ..onStart = onVerticalScrollStart
-        ..onUpdate = onVerticalScrollUpdate
-        ..onEnd = onVerticalScrollEnd;
+      _ensureVerticalDrag()
+        ..onStart = onVerticalDragStart
+        ..onUpdate = onVerticalDragUpdate
+        ..onEnd = onVerticalDragEnd;
     }
   }
 
-  void _syncHorizontalScroll() {
-    if (onHorizontalScrollStart == null && onHorizontalScrollUpdate == null && onHorizontalScrollEnd == null) {
-      _horizontalScroll = _ensureDisposed(_horizontalScroll);
+  void _syncHorizontalDrag() {
+    if (onHorizontalDragStart == null && onHorizontalDragUpdate == null && onHorizontalDragEnd == null) {
+      _horizontalDrag = _ensureDisposed(_horizontalDrag);
     } else {
-      _ensureHorizontalScroll()
-        ..onStart = onHorizontalScrollStart
-        ..onUpdate = onHorizontalScrollUpdate
-        ..onEnd = onHorizontalScrollEnd;
+      _ensureHorizontalDrag()
+        ..onStart = onHorizontalDragStart
+        ..onUpdate = onHorizontalDragUpdate
+        ..onEnd = onHorizontalDragEnd;
     }
   }
 
@@ -198,10 +198,10 @@ class GestureDetector extends StatefulComponent {
       _showPress.addPointer(event);
     if (_longPress != null)
       _longPress.addPointer(event);
-    if (_verticalScroll != null)
-      _verticalScroll.addPointer(event);
-    if (_horizontalScroll != null)
-      _horizontalScroll.addPointer(event);
+    if (_verticalDrag != null)
+      _verticalDrag.addPointer(event);
+    if (_horizontalDrag != null)
+      _horizontalDrag.addPointer(event);
     if (_pan != null)
       _pan.addPointer(event);
     return EventDisposition.processed;

--- a/sky/packages/sky/lib/src/widgets/scrollable.dart
+++ b/sky/packages/sky/lib/src/widgets/scrollable.dart
@@ -85,10 +85,10 @@ abstract class Scrollable extends StatefulComponent {
 
   Widget build() {
     return new GestureDetector(
-      onVerticalScrollUpdate: scrollDirection == ScrollDirection.vertical ? scrollBy : null,
-      onVerticalScrollEnd: scrollDirection == ScrollDirection.vertical ? _maybeSettleScrollOffset : null,
-      onHorizontalScrollUpdate: scrollDirection == ScrollDirection.horizontal ? scrollBy : null,
-      onHorizontalScrollEnd: scrollDirection == ScrollDirection.horizontal ? _maybeSettleScrollOffset : null,
+      onVerticalDragUpdate: scrollDirection == ScrollDirection.vertical ? scrollBy : null,
+      onVerticalDragEnd: scrollDirection == ScrollDirection.vertical ? _maybeSettleScrollOffset : null,
+      onHorizontalDragUpdate: scrollDirection == ScrollDirection.horizontal ? scrollBy : null,
+      onHorizontalDragEnd: scrollDirection == ScrollDirection.horizontal ? _maybeSettleScrollOffset : null,
       child: new Listener(
         child: buildContent(),
         onPointerDown: _handlePointerDown,

--- a/sky/unit/test/widget/dismissable_test.dart
+++ b/sky/unit/test/widget/dismissable_test.dart
@@ -77,6 +77,8 @@ void dismissItem(WidgetTester tester, int item, { DismissDirection gestureDirect
       downLocation = tester.getTopLeft(itemWidget);
       upLocation = tester.getBottomLeft(itemWidget);
       break;
+    default:
+      fail("unsupported gestureDirection");
   }
 
   TestPointer pointer = new TestPointer(5);

--- a/sky/unit/test/widget/gesture_detector_test.dart
+++ b/sky/unit/test/widget/gesture_detector_test.dart
@@ -9,49 +9,49 @@ void main() {
     WidgetTester tester = new WidgetTester();
     TestPointer pointer = new TestPointer(7);
 
-    bool didStartScroll = false;
-    double updatedScrollDelta;
-    bool didEndScroll = false;
+    bool didStartDrag = false;
+    double updatedDragDelta;
+    bool didEndDrag = false;
 
     Widget builder() {
       return new GestureDetector(
-        onVerticalScrollStart: () {
-          didStartScroll = true;
+        onVerticalDragStart: () {
+          didStartDrag = true;
         },
-        onVerticalScrollUpdate: (double scrollDelta) {
-          updatedScrollDelta = scrollDelta;
+        onVerticalDragUpdate: (double scrollDelta) {
+          updatedDragDelta = scrollDelta;
         },
-        onVerticalScrollEnd: () {
-          didEndScroll = true;
+        onVerticalDragEnd: () {
+          didEndDrag = true;
         },
         child: new Container()
       );
     }
 
     tester.pumpFrame(builder);
-    expect(didStartScroll, isFalse);
-    expect(updatedScrollDelta, isNull);
-    expect(didEndScroll, isFalse);
+    expect(didStartDrag, isFalse);
+    expect(updatedDragDelta, isNull);
+    expect(didEndDrag, isFalse);
 
     Point firstLocation = new Point(10.0, 10.0);
     tester.dispatchEvent(pointer.down(firstLocation), firstLocation);
-    expect(didStartScroll, isTrue);
-    didStartScroll = false;
-    expect(updatedScrollDelta, isNull);
-    expect(didEndScroll, isFalse);
+    expect(didStartDrag, isTrue);
+    didStartDrag = false;
+    expect(updatedDragDelta, isNull);
+    expect(didEndDrag, isFalse);
 
     Point secondLocation = new Point(10.0, 9.0);
     tester.dispatchEvent(pointer.move(secondLocation), firstLocation);
-    expect(didStartScroll, isFalse);
-    expect(updatedScrollDelta, 1.0);
-    updatedScrollDelta = null;
-    expect(didEndScroll, isFalse);
+    expect(didStartDrag, isFalse);
+    expect(updatedDragDelta, 1.0);
+    updatedDragDelta = null;
+    expect(didEndDrag, isFalse);
 
     tester.dispatchEvent(pointer.up(), firstLocation);
-    expect(didStartScroll, isFalse);
-    expect(updatedScrollDelta, isNull);
-    expect(didEndScroll, isTrue);
-    didEndScroll = false;
+    expect(didStartDrag, isFalse);
+    expect(updatedDragDelta, isNull);
+    expect(didEndDrag, isTrue);
+    didEndDrag = false;
 
     tester.pumpFrame(() => new Container());
   });
@@ -68,10 +68,10 @@ void main() {
 
     Widget builder() {
       return new GestureDetector(
-        onVerticalScrollUpdate: (double delta) { dragDistance += delta; },
-        onVerticalScrollEnd: () { gestureCount += 1; },
-        onHorizontalScrollUpdate: (_) { fail("gesture should not match"); },
-        onHorizontalScrollEnd: () { fail("gesture should not match"); },
+        onVerticalDragUpdate: (double delta) { dragDistance += delta; },
+        onVerticalDragEnd: () { gestureCount += 1; },
+        onHorizontalDragUpdate: (_) { fail("gesture should not match"); },
+        onHorizontalDragEnd: () { fail("gesture should not match"); },
         child: new Container()
       );
     }


### PR DESCRIPTION
The rationale for this name change is that gesture names should match their input pattern, not their use.