### PR TITLE
Center and Align should expand by default

### DIFF
--- a/sky/packages/sky/lib/src/widgets/basic.dart
+++ b/sky/packages/sky/lib/src/widgets/basic.dart
@@ -32,6 +32,7 @@ export 'package:sky/src/rendering/box.dart' show BoxConstraints;
 export 'package:sky/src/rendering/flex.dart' show FlexJustifyContent, FlexAlignItems, FlexDirection;
 export 'package:sky/src/rendering/object.dart' show Point, Offset, Size, Rect, Color, Paint, Path;
 export 'package:sky/src/rendering/proxy_box.dart' show BackgroundImage, BoxDecoration, BoxDecorationPosition, BoxShadow, Border, BorderSide, EdgeDims, Shape;
+export 'package:sky/src/rendering/shifted_box.dart' show ShrinkWrap;
 export 'package:sky/src/rendering/toggleable.dart' show ValueChanged;
 export 'package:sky/src/rendering/viewport.dart' show ScrollDirection;
 
@@ -200,28 +201,36 @@ class Padding extends OneChildRenderObjectWrapper {
 }
 
 class Align extends OneChildRenderObjectWrapper {
-  Align({ Key key, this.horizontal: 0.5, this.vertical: 0.5, Widget child })
-    : super(key: key, child: child) {
+  Align({
+    Key key,
+    this.horizontal: 0.5,
+    this.vertical: 0.5,
+    this.shrinkWrap: ShrinkWrap.none,
+    Widget child
+  }) : super(key: key, child: child) {
     assert(horizontal != null);
     assert(vertical != null);
+    assert(shrinkWrap != null);
   }
 
   final double horizontal;
   final double vertical;
+  final ShrinkWrap shrinkWrap;
 
-  RenderPositionedBox createNode() => new RenderPositionedBox(horizontal: horizontal, vertical: vertical);
+  RenderPositionedBox createNode() => new RenderPositionedBox(horizontal: horizontal, vertical: vertical, shrinkWrap: shrinkWrap);
   RenderPositionedBox get renderObject => super.renderObject;
 
   void syncRenderObject(Align old) {
     super.syncRenderObject(old);
     renderObject.horizontal = horizontal;
     renderObject.vertical = vertical;
+    renderObject.shrinkWrap = shrinkWrap;
   }
 }
 
 class Center extends Align {
-  Center({ Key key, Widget child })
-    : super(key: key, child: child);
+  Center({ Key key, ShrinkWrap shrinkWrap: ShrinkWrap.none, Widget child })
+    : super(key: key, shrinkWrap: shrinkWrap, child: child);
 }
 
 class SizedBox extends OneChildRenderObjectWrapper {

--- a/sky/packages/sky/lib/src/widgets/date_picker.dart
+++ b/sky/packages/sky/lib/src/widgets/date_picker.dart
@@ -98,7 +98,13 @@ class DatePicker extends StatefulComponent {
         );
         break;
     }
-    return new BlockBody([header, new Container(height: _calendarHeight, child: picker)]);
+    return new Column([
+      header,
+      new Container(
+        height: _calendarHeight,
+        child: picker
+      )
+    ], alignItems: FlexAlignItems.stretch);
   }
 
 }
@@ -143,28 +149,22 @@ class DatePickerHeader extends Component {
     TextStyle yearStyle = headerTheme.headline.copyWith(color: yearColor, height: 1.0);
 
     return new Container(
-      child: new BlockBody([
-        new Center(
-          child: new GestureDetector(
-            child: new Text(new DateFormat("MMM").format(selectedDate).toUpperCase(), style: monthStyle),
-            onTap: () => _handleChangeMode(DatePickerMode.day)
-          )
-        ),
-        new Center(
-          child: new GestureDetector(
-            child: new Text(new DateFormat("d").format(selectedDate), style: dayStyle),
-            onTap: () => _handleChangeMode(DatePickerMode.day)
-          )
-        ),
-        new Center(
-          child: new GestureDetector(
-            child: new Text(new DateFormat("yyyy").format(selectedDate), style: yearStyle),
-            onTap: () => _handleChangeMode(DatePickerMode.year)
-          )
-        )
-      ]),
       padding: new EdgeDims.all(10.0),
-      decoration: new BoxDecoration(backgroundColor: theme.primaryColor)
+      decoration: new BoxDecoration(backgroundColor: theme.primaryColor),
+      child: new Column([
+        new GestureDetector(
+          onTap: () => _handleChangeMode(DatePickerMode.day),
+          child: new Text(new DateFormat("MMM").format(selectedDate).toUpperCase(), style: monthStyle)
+        ),
+        new GestureDetector(
+          onTap: () => _handleChangeMode(DatePickerMode.day),
+          child: new Text(new DateFormat("d").format(selectedDate), style: dayStyle)
+        ),
+        new GestureDetector(
+          onTap: () => _handleChangeMode(DatePickerMode.year),
+          child: new Text(new DateFormat("yyyy").format(selectedDate), style: yearStyle)
+        )
+      ])
     );
   }
 }
@@ -267,11 +267,8 @@ class DayPicker extends Component {
     }
     for (int w = 0; w < weeksShown; w++) {
       int startIndex = w * days.length;
-      rows.add(new Container(
-        child: new Flex(
-          labels.sublist(startIndex, startIndex + days.length),
-          justifyContent: FlexJustifyContent.spaceAround
-        )
+      rows.add(new Row(
+        labels.sublist(startIndex, startIndex + days.length)
       ));
     }
 

--- a/sky/packages/sky/lib/src/widgets/dialog.dart
+++ b/sky/packages/sky/lib/src/widgets/dialog.dart
@@ -95,21 +95,22 @@ class Dialog extends Component {
       ));
     }
 
-    if (actions != null)
+    if (actions != null) {
       dialogBody.add(new Container(
         child: new Row(actions,
           justifyContent: FlexJustifyContent.end
         )
       ));
+    }
 
     return new Stack([
       new GestureDetector(
+        onTap: onDismiss,
         child: new Container(
           decoration: const BoxDecoration(
             backgroundColor: const Color(0x7F000000)
           )
-        ),
-        onTap: onDismiss
+        )
       ),
       new Center(
         child: new Container(

--- a/sky/packages/sky/lib/src/widgets/material_button.dart
+++ b/sky/packages/sky/lib/src/widgets/material_button.dart
@@ -36,7 +36,10 @@ abstract class MaterialButton extends ButtonBase {
   Widget buildContent() {
     Widget contents = new Container(
       padding: new EdgeDims.symmetric(horizontal: 8.0),
-      child: new Center(child: child) // TODO(ianh): figure out a way to compell the child to have gray text when disabled...
+      child: new Center(
+        shrinkWrap: ShrinkWrap.width,
+        child: child // TODO(ianh): figure out a way to compell the child to have gray text when disabled...
+      )
     );
     return new GestureDetector(
       onTap: enabled ? onPressed : null,

--- a/sky/unit/test/rendering/positioned_box_test.dart
+++ b/sky/unit/test/rendering/positioned_box_test.dart
@@ -1,0 +1,42 @@
+import 'package:sky/rendering.dart';
+import 'package:test/test.dart';
+
+import 'rendering_tester.dart';
+
+void main() {
+  test('RenderPositionedBox expands', () {
+    RenderConstrainedBox sizer = new RenderConstrainedBox(
+      additionalConstraints: new BoxConstraints.tight(new Size(100.0, 100.0)),
+      child: new RenderDecoratedBox(decoration: new BoxDecoration())
+    );
+    RenderPositionedBox positioner = new RenderPositionedBox(child: sizer);
+    layout(positioner, constraints: new BoxConstraints.loose(new Size(200.0, 200.0)));
+
+    expect(positioner.size.width, equals(200.0), reason: "positioner width");
+    expect(positioner.size.height, equals(200.0), reason: "positioner height");
+  });
+
+  test('RenderPositionedBox shrink wraps', () {
+    RenderConstrainedBox sizer = new RenderConstrainedBox(
+      additionalConstraints: new BoxConstraints.tight(new Size(100.0, 100.0)),
+      child: new RenderDecoratedBox(decoration: new BoxDecoration())
+    );
+    RenderPositionedBox positioner = new RenderPositionedBox(child: sizer, shrinkWrap: ShrinkWrap.width);
+    RenderingTester tester = layout(positioner, constraints: new BoxConstraints.loose(new Size(200.0, 200.0)));
+
+    expect(positioner.size.width, equals(100.0), reason: "positioner width");
+    expect(positioner.size.height, equals(200.0), reason: "positioner height");
+
+    positioner.shrinkWrap = ShrinkWrap.height;
+    tester.pumpFrame(phase: EnginePhase.layout);
+
+    expect(positioner.size.width, equals(200.0), reason: "positioner width");
+    expect(positioner.size.height, equals(100.0), reason: "positioner height");
+
+    positioner.shrinkWrap = ShrinkWrap.both;
+    tester.pumpFrame(phase: EnginePhase.layout);
+
+    expect(positioner.size.width, equals(100.0), reason: "positioner width");
+    expect(positioner.size.height, equals(100.0), reason: "positioner height");
+  });
+}


### PR DESCRIPTION
This patch makes Center and Align expand by default, which is usually what you
want. It also adds a ShrinkWrap option to let you shrink wrap in one or both
directions if that's really what you want to do.