### PR TITLE
Fix breakage caused by sync-across-removal patch.

### DIFF
--- a/sky/unit/test/widget/syncing_test.dart
+++ b/sky/unit/test/widget/syncing_test.dart
@@ -59,40 +59,39 @@ void main() {
 
   });
 
-  // Requires _shouldReparentDuringSync
-  // test('remove one', () {
-  //
-  //   WidgetTester tester = new WidgetTester();
-  //
-  //   tester.pumpFrame(() {
-  //     return new Container(
-  //       child: new Container(
-  //         child: new TestState(
-  //           state: 10,
-  //           child: new Container()
-  //         )
-  //       )
-  //     );
-  //   });
-  //
-  //   TestState stateWidget = tester.findWidget((widget) => widget is TestState);
-  //
-  //   expect(stateWidget.state, equals(10));
-  //   expect(stateWidget.syncs, equals(0));
-  //
-  //   tester.pumpFrame(() {
-  //     return new Container(
-  //       child: new TestState(
-  //         state: 11,
-  //         child: new Container()
-  //       )
-  //     );
-  //   });
-  //
-  //   expect(stateWidget.state, equals(10));
-  //   expect(stateWidget.syncs, equals(1));
-  //
-  // });
+  test('remove one', () {
+
+    WidgetTester tester = new WidgetTester();
+
+    tester.pumpFrame(() {
+      return new Container(
+        child: new Container(
+          child: new TestState(
+            persistentState: 10,
+            child: new Container()
+          )
+        )
+      );
+    });
+
+    TestState stateWidget = tester.findWidget((widget) => widget is TestState);
+
+    expect(stateWidget.persistentState, equals(10));
+    expect(stateWidget.syncs, equals(0));
+
+    tester.pumpFrame(() {
+      return new Container(
+        child: new TestState(
+          persistentState: 11,
+          child: new Container()
+        )
+      );
+    });
+
+    expect(stateWidget.persistentState, equals(10));
+    expect(stateWidget.syncs, equals(1));
+
+  });
 
   test('swap instances around', () {
 


### PR DESCRIPTION
This makes the sync code stop if it would have to rearrange the
RenderObjects. I'll make it handle the cross-RenderObject case, as well
as the insertion-sync case, in subsequent patches.