### PR TITLE
Allow setting of initial value in the Input component.

### DIFF
--- a/sky/packages/sky/lib/src/widgets/input.dart
+++ b/sky/packages/sky/lib/src/widgets/input.dart
@@ -22,16 +22,17 @@ class Input extends StatefulComponent {
 
   Input({
     GlobalKey key,
+    String initialValue: '',
     this.placeholder,
     this.onChanged,
     this.keyboardType : KeyboardType_TEXT
-  }): super(key: key);
+  }): _value = initialValue, super(key: key);
 
   int keyboardType;
   String placeholder;
   StringValueChanged onChanged;
 
-  String _value = '';
+  String _value;
   EditableString _editableValue;
   KeyboardHandle _keyboardHandle = KeyboardHandle.unattached;
 


### PR DESCRIPTION
As a customer of the Input API, I would find it helpful to set the input value in the constructor, as well as read and write it.
@abarth what do you think?