### PR TITLE
Remove "disqualified" concept

### DIFF
--- a/sky/unit/test/widget/stateful_components_test.dart
+++ b/sky/unit/test/widget/stateful_components_test.dart
@@ -1,0 +1,66 @@
+import 'package:sky/animation.dart';
+import 'package:sky/widgets.dart';
+import 'package:test/test.dart';
+
+import 'widget_tester.dart';
+
+class InnerComponent extends StatefulComponent {
+  InnerComponent();
+
+  bool _didInitState = false;
+
+  void initState() {
+    _didInitState = true;
+  }
+
+  void syncConstructorArguments(InnerComponent source) {
+  }
+
+  Widget build() {
+    return new Container();
+  }
+}
+
+class OutterContainer extends StatefulComponent {
+  OutterContainer({ this.child });
+
+  InnerComponent child;
+
+  void syncConstructorArguments(OutterContainer source) {
+    child = source.child;
+  }
+
+  Widget build() {
+    return child;
+  }
+}
+
+void main() {
+  test('resync stateful widget', () {
+
+    WidgetTester tester = new WidgetTester();
+
+    InnerComponent inner;
+    OutterContainer outter;
+
+    tester.pumpFrame(() {
+      return new OutterContainer(child: new InnerComponent());
+    });
+
+    tester.pumpFrame(() {
+      inner = new InnerComponent();
+      outter = new OutterContainer(child: inner);
+      return outter;
+    });
+
+    expect(inner._didInitState, isFalse);
+    expect(inner.parent, isNull);
+
+    outter.setState(() {});
+    scheduler.beginFrame(0.0);
+
+    expect(inner._didInitState, isFalse);
+    expect(inner.parent, isNull);
+
+  });
+}


### PR DESCRIPTION
Allows a non-initialised stateful component to be used as a source of
settings more than once. Instead of asserting that it was only being
used once, we assert that once you are stateful you don't get used as a
bag of settings, which is the real thing we were trying to avoid.

A lot of code ends up using StatefulComponents as a source multiple
times in a row, and before this would fail.

Patch by Ian Hickson