### PR TITLE
Finish converting Dismissable and Scrollable from Listener to GestureDetector

### DIFF
--- a/sky/engine/core/events/VelocityTracker.cpp
+++ b/sky/engine/core/events/VelocityTracker.cpp
@@ -35,7 +35,6 @@ class VelocityTrackerStrategy {
 namespace {
 
 // From platform/frameworks/native/include/input/MotionPointer.h
-// TBD: put this in Pointer.h?
 enum { MAX_POINTER_ID = 31, MAX_TOUCH_POINT_COUNT = 16 };
 //COMPILE_ASSERT(MotionEvent::MAX_POINTER_ID < 32, max_pointer_id_too_large);
 
@@ -177,7 +176,7 @@ class IntegratingVelocityTrackerStrategy : public VelocityTrackerStrategy {
 
   const uint32_t degree_;
   BitSet32 pointer_id_bits_;
-  State mPointerState[/*MotionEvent::*/MAX_POINTER_ID + 1];
+  State mPointerState[MAX_POINTER_ID + 1];
 
   void InitState(State& state,
                  const TimeTicks& event_time,
@@ -220,14 +219,14 @@ VelocityTrackerStrategy* CreateStrategy(VelocityTracker::Strategy strategy) {
 
 // --- VelocityTracker.idl implementation ---
 
-void VelocityTracker::addPosition(long timeStamp, long pointerId, float x, float y) {
+void VelocityTracker::addPosition(int timeStamp, int pointerId, float x, float y) {
   TimeTicks event_time(TimeTicks::FromInternalValue(timeStamp));
   BitSet32 id_bits(BitSet32::value_for_bit(pointerId));
   PointerXY position = {x, y};
   AddMovement(event_time, id_bits, &position);
 }
 
-PassRefPtr<GestureVelocity> VelocityTracker::getVelocity(long pointerId) {
+PassRefPtr<GestureVelocity> VelocityTracker::getVelocity(int pointerId) {
   float vx = 0;
   float vy = 0;
   bool result = GetVelocity(pointerId, &vx, &vy);

--- a/sky/engine/core/events/VelocityTracker.h
+++ b/sky/engine/core/events/VelocityTracker.h
@@ -3,10 +3,9 @@
 // found in the LICENSE file.
 
 // This file is a largely a copy of ui/events/gesture_detection/velocity_tracker.h
-// from https://chromium.googlesource.com/chromium/src. The
-// VelocityTracker::AddMovement(const MotionEvent& event) method and a few of
-// its supporting definitions have been removed.
-
+// and ui/events/gesture_detection/bitset_32.h from https://chromium.googlesource.com.
+// The VelocityTracker::AddMovement(const MotionEvent& event) method and a
+// few of its supporting definitions have been removed.
 
 #ifndef SKY_ENGINE_CORE_EVENTS_VELOCITY_TRACKER_H_
 #define SKY_ENGINE_CORE_EVENTS_VELOCITY_TRACKER_H_
@@ -220,8 +219,8 @@ public:
     return adoptRef(new VelocityTracker());
   }
   void reset();
-  void addPosition(long timeStamp, long pointerId, float x, float y);
-  PassRefPtr<GestureVelocity> getVelocity(long pointerId);
+  void addPosition(int timeStamp, int pointerId, float x, float y);
+  PassRefPtr<GestureVelocity> getVelocity(int pointerId);
 
 
   // Creates a velocity tracker using the default strategy for the platform.

--- a/sky/packages/sky/lib/gestures/scroll.dart
+++ b/sky/packages/sky/lib/gestures/scroll.dart
@@ -24,9 +24,6 @@ typedef void GesturePanEndCallback(sky.Offset velocity);
 
 typedef void _GesturePolymorphicUpdateCallback<T>(T scrollDelta);
 
-// Fling velocities are logical pixels per second.
-typedef void GestureFlingCallback(sky.Offset velocity);
-
 int _eventTime(sky.PointerEvent event) => (event.timeStamp * 1000.0).toInt(); // microseconds
 
 bool _isFlingGesture(sky.GestureVelocity velocity) {

--- a/sky/unit/test/widget/dismissable_test.dart
+++ b/sky/unit/test/widget/dismissable_test.dart
@@ -204,4 +204,30 @@ void main() {
     expect(tester.findText('0'), isNull);
     expect(dismissedItems, equals([0]));
   });
+
+  // This is a regression test for
+  // https://github.com/domokit/sky_engine/issues/1068
+  /*
+  test('Verify that drag-move events do not assert', () {
+    WidgetTester tester = new WidgetTester();
+    scrollDirection = ScrollDirection.horizontal;
+    dismissDirection = DismissDirection.down;
+
+    tester.pumpFrame(widgetBuilder);
+    Widget itemWidget = tester.findText('0');
+
+    TestPointer pointer = new TestPointer(5);
+    Point location = tester.getTopLeft(itemWidget);
+    Offset offset = new Offset(0.0, 5.0);
+    tester.dispatchEvent(pointer.down(location), location);
+    tester.dispatchEvent(pointer.move(location + offset), location);
+    tester.pumpFrame(widgetBuilder);
+    tester.dispatchEvent(pointer.move(location + (offset * 2.0)), location);
+    tester.pumpFrame(widgetBuilder);
+    tester.dispatchEvent(pointer.move(location + (offset * 3.0)), location);
+    tester.pumpFrame(widgetBuilder);
+    tester.dispatchEvent(pointer.move(location + (offset * 4.0)), location);
+    tester.pumpFrame(widgetBuilder);
+  });
+  */
 }


### PR DESCRIPTION
Finish converting Dismissable from Listener to GestureDetector

Dismissable now only depends on GestureDetector.

Added a unit test that verifies that issue #1068 has been fixed. It's commented out for now.

Cleaned up VelocityTracker.cc et al a little.