### PR TITLE
Remove init.dart

### DIFF
--- a/sky/packages/sky/bin/init.dart
+++ b/sky/packages/sky/bin/init.dart
@@ -1,6 +1,0 @@
-// Copyright 2015 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
-main(List<String> arguments) {
-}


### PR DESCRIPTION
We haven't used init.dart in several releases. We can safely remove this no-op
script now.