### PR TITLE
ParagraphBuilder should be able to build a paragraph

### DIFF
--- a/sky/engine/core/css/CSSFontSelector.cpp
+++ b/sky/engine/core/css/CSSFontSelector.cpp
@@ -43,14 +43,13 @@ namespace blink {
 
 CSSFontSelector::CSSFontSelector(Document* document)
     : m_document(document)
-    , m_genericFontFamilySettings(document->frame()->settings()->genericFontFamilySettings())
 {
+    if (m_document)
+        m_genericFontFamilySettings = document->frame()->settings()->genericFontFamilySettings();
     // FIXME: An old comment used to say there was no need to hold a reference to m_document
     // because "we are guaranteed to be destroyed before the document". But there does not
     // seem to be any such guarantee.
 
-    ASSERT(m_document);
-    ASSERT(m_document->frame());
     FontCache::fontCache()->addClient(this);
 }
 

--- a/sky/engine/core/css/FontSize.cpp
+++ b/sky/engine/core/css/FontSize.cpp
@@ -53,7 +53,7 @@ float FontSize::getComputedSizeFromSpecifiedSize(const Document* document, bool 
     // However we always allow the page to set an explicit pixel size that is smaller,
     // since sites will mis-render otherwise (e.g., http://www.gamespot.com with a 9px minimum).
 
-    Settings* settings = document->settings();
+    Settings* settings = document ? document->settings() : nullptr;
     if (!settings)
         return 1.0f;
 
@@ -112,7 +112,7 @@ static int inline rowFromMediumFontSizeInRange(const Settings* settings, FixedPi
 float FontSize::fontSizeForKeyword(const Document* document, CSSValueID keyword, FixedPitchFontType fixedPitchFontType)
 {
     ASSERT(keyword >= CSSValueXxSmall && keyword <= CSSValueWebkitXxxLarge);
-    const Settings* settings = document->settings();
+    const Settings* settings = document ? document->settings() : nullptr;
     if (!settings)
         return 1.0f;
 

--- a/sky/engine/core/css/resolver/FontBuilder.cpp
+++ b/sky/engine/core/css/resolver/FontBuilder.cpp
@@ -67,10 +67,10 @@ FontBuilder::FontBuilder()
 {
 }
 
-void FontBuilder::initForStyleResolve(const Document& document, RenderStyle* style)
+void FontBuilder::initForStyleResolve(Document* document, RenderStyle* style)
 {
-    ASSERT(document.frame());
-    m_document = &document;
+    ASSERT(!document || document->frame());
+    m_document = document;
     m_style = style;
     m_fontDirty = false;
 }

--- a/sky/engine/core/css/resolver/FontBuilder.h
+++ b/sky/engine/core/css/resolver/FontBuilder.h
@@ -44,7 +44,7 @@ public:
     FontBuilder();
 
     // FIXME: The name is probably wrong, but matches StyleResolverState callsite for consistency.
-    void initForStyleResolve(const Document&, RenderStyle*);
+    void initForStyleResolve(Document*, RenderStyle*);
 
     void setInitial();
 

--- a/sky/engine/core/css/resolver/StyleResolver.cpp
+++ b/sky/engine/core/css/resolver/StyleResolver.cpp
@@ -177,7 +177,7 @@ PassRefPtr<RenderStyle> StyleResolver::styleForElement(Element* element, RenderS
         state.setParentStyle(RenderStyle::clone(state.style()));
     }
 
-    state.fontBuilder().initForStyleResolve(state.document(), state.style());
+    state.fontBuilder().initForStyleResolve(&state.document(), state.style());
 
     {
         ElementRuleCollector collector(state.elementContext(), state.style());
@@ -204,7 +204,7 @@ PassRefPtr<RenderStyle> StyleResolver::defaultStyleForElement()
 {
     StyleResolverState state(m_document, nullptr);
     state.setStyle(RenderStyle::create());
-    state.fontBuilder().initForStyleResolve(m_document, state.style());
+    state.fontBuilder().initForStyleResolve(&m_document, state.style());
     state.style()->setLineHeight(RenderStyle::initialLineHeight());
     state.setLineHeightValue(0);
     state.fontBuilder().setInitial();
@@ -415,7 +415,7 @@ void StyleResolver::applyPropertiesToStyle(const CSSPropertyValue* properties, s
     StyleResolverState state(m_document, nullptr, style);
     state.setStyle(style);
 
-    state.fontBuilder().initForStyleResolve(m_document, style);
+    state.fontBuilder().initForStyleResolve(&m_document, style);
 
     for (size_t i = 0; i < count; ++i) {
         if (properties[i].value) {

--- a/sky/engine/core/dom/Document.cpp
+++ b/sky/engine/core/dom/Document.cpp
@@ -627,7 +627,7 @@ void Document::scheduleVisualUpdate()
 void Document::setupFontBuilder(RenderStyle* documentStyle)
 {
     FontBuilder fontBuilder;
-    fontBuilder.initForStyleResolve(*this, documentStyle);
+    fontBuilder.initForStyleResolve(this, documentStyle);
     RefPtr<CSSFontSelector> selector = m_styleEngine->fontSelector();
     fontBuilder.createFontForDocument(selector, documentStyle);
 }

--- a/sky/engine/core/rendering/RenderObject.cpp
+++ b/sky/engine/core/rendering/RenderObject.cpp
@@ -186,7 +186,7 @@ bool RenderObject::isDescendantOf(const RenderObject* obj) const
 
 void RenderObject::addChild(RenderObject* newChild, RenderObject* beforeChild)
 {
-    ASSERT(isAllowedToModifyRenderTreeStructure(document()));
+    ASSERT(!m_node || isAllowedToModifyRenderTreeStructure(document()));
 
     RenderObjectChildList* children = virtualChildren();
     ASSERT(children);
@@ -195,7 +195,7 @@ void RenderObject::addChild(RenderObject* newChild, RenderObject* beforeChild)
 
 void RenderObject::removeChild(RenderObject* oldChild)
 {
-    ASSERT(isAllowedToModifyRenderTreeStructure(document()));
+  ASSERT(!m_node || isAllowedToModifyRenderTreeStructure(document()));
 
     RenderObjectChildList* children = virtualChildren();
     ASSERT(children);

--- a/sky/engine/core/rendering/RenderObject.h
+++ b/sky/engine/core/rendering/RenderObject.h
@@ -774,7 +774,7 @@ DEFINE_COMPARISON_OPERATORS_WITH_REFERENCES(RenderObject)
 
 inline bool RenderObject::documentBeingDestroyed() const
 {
-    return !document().isActive();
+    return m_node && !document().isActive();
 }
 
 // setNeedsLayout() won't cause full paint invalidations as

--- a/sky/engine/core/rendering/RenderText.cpp
+++ b/sky/engine/core/rendering/RenderText.cpp
@@ -76,7 +76,7 @@ RenderText::RenderText(Node* node, PassRefPtr<StringImpl> str)
     , m_lastTextBox(0)
 {
     ASSERT(m_text);
-    ASSERT(node && !node->isDocumentNode());
+    ASSERT(!node || !node->isDocumentNode());
 
     m_isAllASCII = m_text.containsOnlyASCII();
     m_canUseSimpleFontCodePath = computeCanUseSimpleFontCodePath();

--- a/sky/engine/core/rendering/RenderView.cpp
+++ b/sky/engine/core/rendering/RenderView.cpp
@@ -37,7 +37,7 @@ namespace blink {
 
 RenderView::RenderView(Document* document)
     : RenderFlexibleBox(document)
-    , m_frameView(document->view())
+    , m_frameView(document ? document->view() : nullptr)
     , m_selectionStart(nullptr)
     , m_selectionEnd(nullptr)
     , m_selectionStartPos(-1)
@@ -356,14 +356,14 @@ int RenderView::viewHeight() const
 {
     if (m_frameView)
         return m_frameView->layoutSize().height();
-    return 0;
+    return m_frameViewSize.height();
 }
 
 int RenderView::viewWidth() const
 {
     if (m_frameView)
         return m_frameView->layoutSize().width();
-    return 0;
+    return m_frameViewSize.width();
 }
 
 int RenderView::viewLogicalHeight() const

--- a/sky/engine/core/rendering/RenderView.h
+++ b/sky/engine/core/rendering/RenderView.h
@@ -77,6 +77,7 @@ public:
     virtual void absoluteQuads(Vector<FloatQuad>&) const override;
 
     virtual LayoutRect viewRect() const override;
+    void setFrameViewSize(const IntSize& frameViewSize) { m_frameViewSize = frameViewSize; }
 
     IntRect unscaledDocumentRect() const;
     LayoutRect backgroundRect(RenderBox* backgroundRenderer) const;
@@ -95,6 +96,7 @@ private:
     void positionDialogs();
 
     FrameView* m_frameView;
+    IntSize m_frameViewSize;
 
     RawPtr<RenderObject> m_selectionStart;
     RawPtr<RenderObject> m_selectionEnd;

--- a/sky/engine/core/rendering/SubtreeLayoutScope.cpp
+++ b/sky/engine/core/rendering/SubtreeLayoutScope.cpp
@@ -38,7 +38,7 @@ namespace blink {
 SubtreeLayoutScope::SubtreeLayoutScope(RenderObject& root)
     : m_root(root)
 {
-    RELEASE_ASSERT(m_root.document().view()->isInPerformLayout());
+    RELEASE_ASSERT(!m_root.node() || m_root.document().view()->isInPerformLayout());
 }
 
 SubtreeLayoutScope::~SubtreeLayoutScope()

--- a/sky/engine/core/text/FontStyle.h
+++ b/sky/engine/core/text/FontStyle.h
@@ -6,10 +6,9 @@
 #define SKY_ENGINE_CORE_TEXT_FONTSTYLE_H_
 
 #include "sky/engine/tonic/dart_converter.h"
+#include "sky/engine/platform/fonts/FontTraits.h"
 
 namespace blink {
-
-class FontStyle {};
 
 template <>
 struct DartConverter<FontStyle>

--- a/sky/engine/core/text/FontWeight.h
+++ b/sky/engine/core/text/FontWeight.h
@@ -6,10 +6,9 @@
 #define SKY_ENGINE_CORE_TEXT_FONTWEIGHT_H_
 
 #include "sky/engine/tonic/dart_converter.h"
+#include "sky/engine/platform/fonts/FontTraits.h"
 
 namespace blink {
-
-class FontWeight {};
 
 template <>
 struct DartConverter<FontWeight>

--- a/sky/engine/core/text/Paragraph.cpp
+++ b/sky/engine/core/text/Paragraph.cpp
@@ -4,9 +4,12 @@
 
 #include "sky/engine/core/text/ParagraphBuilder.h"
 
+#include "sky/engine/core/rendering/style/RenderStyle.h"
+
 namespace blink {
 
-Paragraph::Paragraph()
+Paragraph::Paragraph(PassOwnPtr<RenderView> renderView)
+    : m_renderView(renderView)
 {
 }
 
@@ -16,12 +19,12 @@ Paragraph::~Paragraph()
 
 double Paragraph::width()
 {
-    return 0.0;
+    return m_renderView->firstChildBox()->width();
 }
 
 double Paragraph::height()
 {
-    return 0.0;
+    return m_renderView->firstChildBox()->height();
 }
 
 double Paragraph::minIntrinsicWidth()
@@ -46,6 +49,12 @@ double Paragraph::ideographicBaseline()
 
 void Paragraph::layout()
 {
+    LayoutUnit maxWidth = std::max(m_minWidth, m_maxWidth);
+    LayoutUnit maxHeight = std::max(m_minHeight, m_maxHeight);
+    IntSize maxSize(maxWidth, maxHeight);
+
+    m_renderView->setFrameViewSize(maxSize);
+    m_renderView->layout();
 }
 
 void Paragraph::paint(Canvas* canvas, const Offset& offset)

--- a/sky/engine/core/text/Paragraph.h
+++ b/sky/engine/core/text/Paragraph.h
@@ -10,29 +10,30 @@
 #include "sky/engine/wtf/RefCounted.h"
 #include "sky/engine/core/painting/Canvas.h"
 #include "sky/engine/core/painting/Offset.h"
+#include "sky/engine/core/rendering/RenderView.h"
 
 namespace blink {
 
 class Paragraph : public RefCounted<Paragraph>, public DartWrappable {
     DEFINE_WRAPPERTYPEINFO();
 public:
-    static PassRefPtr<Paragraph> create() {
-      return adoptRef(new Paragraph());
+    static PassRefPtr<Paragraph> create(PassOwnPtr<RenderView> renderView) {
+      return adoptRef(new Paragraph(renderView));
     }
 
     ~Paragraph() override;
 
-    double minWidth() const { return m_minWidth; }
-    void setMinWidth(double value) { m_minWidth = value; }
+    LayoutUnit minWidth() const { return m_minWidth; }
+    void setMinWidth(LayoutUnit width) { m_minWidth = width; }
 
-    double maxWidth() const { return m_maxWidth; }
-    void setMaxWidth(double value) { m_maxWidth = value; }
+    LayoutUnit maxWidth() const { return m_maxWidth; }
+    void setMaxWidth(LayoutUnit width) { m_maxWidth = width; }
 
-    double minHeight() const { return m_minHeight; }
-    void setMinHeight(double value) { m_minHeight = value; }
+    LayoutUnit minHeight() const { return m_minHeight; }
+    void setMinHeight(LayoutUnit height) { m_minHeight = height; }
 
-    double maxHeight() const { return m_maxHeight; }
-    void setMaxHeight(double value) { m_maxHeight = value; }
+    LayoutUnit maxHeight() const { return m_maxHeight; }
+    void setMaxHeight(LayoutUnit height) { m_maxHeight = height; }
 
     double width();
     double height();
@@ -44,13 +45,17 @@ public:
     void layout();
     void paint(Canvas* canvas, const Offset& offset);
 
-private:
-    double m_minWidth;
-    double m_maxWidth;
-    double m_minHeight;
-    double m_maxHeight;
+    RenderView* renderView() const { return m_renderView.get(); }
 
-    explicit Paragraph();
+private:
+    LayoutUnit m_minWidth;
+    LayoutUnit m_maxWidth;
+    LayoutUnit m_minHeight;
+    LayoutUnit m_maxHeight;
+
+    explicit Paragraph(PassOwnPtr<RenderView> renderView);
+
+    OwnPtr<RenderView> m_renderView;
 };
 
 } // namespace blink

--- a/sky/engine/core/text/ParagraphBuilder.cpp
+++ b/sky/engine/core/text/ParagraphBuilder.cpp
@@ -4,10 +4,52 @@
 
 #include "sky/engine/core/text/ParagraphBuilder.h"
 
+#include "sky/engine/core/css/CSSFontSelector.h"
+#include "sky/engine/core/css/resolver/FontBuilder.h"
+#include "sky/engine/core/rendering/RenderParagraph.h"
+#include "sky/engine/core/rendering/RenderText.h"
+#include "sky/engine/core/rendering/style/RenderStyle.h"
+
 namespace blink {
+namespace {
+
+PassOwnPtr<RenderView> createRenderView()
+{
+    RefPtr<RenderStyle> style = RenderStyle::create();
+    style->setRTLOrdering(LogicalOrder);
+    style->setZIndex(0);
+    style->setUserModify(READ_ONLY);
+
+    FontBuilder fontBuilder;
+    fontBuilder.initForStyleResolve(nullptr, style.get());
+    RefPtr<CSSFontSelector> selector = CSSFontSelector::create(nullptr);
+    fontBuilder.createFontForDocument(selector.release(), style.get());
+
+    OwnPtr<RenderView> renderView = adoptPtr(new RenderView(nullptr));
+    renderView->setStyle(style.release());
+    return renderView.release();
+}
+
+RenderParagraph* createRenderParagraph(RenderStyle* parentStyle)
+{
+    RefPtr<RenderStyle> style = RenderStyle::create();
+    style->inheritFrom(parentStyle);
+    style->setDisplay(PARAGRAPH);
+
+    RenderParagraph* renderParagraph = new RenderParagraph(nullptr);
+    renderParagraph->setStyle(style.release());
+    return renderParagraph;
+}
+
+}  // namespace
 
 ParagraphBuilder::ParagraphBuilder()
 {
+    m_renderView = createRenderView();
+    m_parentStyle = RenderStyle::clone(m_renderView->style());
+    m_renderParagraph = createRenderParagraph(m_parentStyle.get());
+    m_parentStyle = RenderStyle::clone(m_renderParagraph->style());
+    m_renderView->addChild(m_renderParagraph);
 }
 
 ParagraphBuilder::~ParagraphBuilder()
@@ -24,11 +66,18 @@ void ParagraphBuilder::pop()
 
 void ParagraphBuilder::addText(const String& text)
 {
+    RenderText* renderText = new RenderText(nullptr, text.impl());
+    RefPtr<RenderStyle> style = RenderStyle::create();
+    style->inheritFrom(m_parentStyle.get());
+    renderText->setStyle(style.release());
+    m_renderParagraph->addChild(renderText);
 }
 
 PassRefPtr<Paragraph> ParagraphBuilder::build(ParagraphStyle* style)
 {
-    return nullptr;
+    m_parentStyle = nullptr;
+    m_renderParagraph = nullptr;
+    return Paragraph::create(m_renderView.release());
 }
 
 } // namespace blink

--- a/sky/engine/core/text/ParagraphBuilder.h
+++ b/sky/engine/core/text/ParagraphBuilder.h
@@ -32,6 +32,11 @@ public:
 
 private:
     explicit ParagraphBuilder();
+
+    OwnPtr<RenderView> m_renderView;
+
+    RefPtr<RenderStyle> m_parentStyle;
+    RenderParagraph* m_renderParagraph;
 };
 
 } // namespace blink

--- a/sky/engine/core/text/TextAlign.h
+++ b/sky/engine/core/text/TextAlign.h
@@ -6,10 +6,9 @@
 #define SKY_ENGINE_CORE_TEXT_TEXTALIGN_H_
 
 #include "sky/engine/tonic/dart_converter.h"
+#include "sky/engine/platform/graphics/GraphicsTypes.h"
 
 namespace blink {
-
-class TextAlign {};
 
 template <>
 struct DartConverter<TextAlign>

--- a/sky/engine/core/text/TextBaseline.h
+++ b/sky/engine/core/text/TextBaseline.h
@@ -6,10 +6,9 @@
 #define SKY_ENGINE_CORE_TEXT_TEXTBASELINE_H_
 
 #include "sky/engine/tonic/dart_converter.h"
+#include "sky/engine/platform/graphics/GraphicsTypes.h"
 
 namespace blink {
-
-class TextBaseline {};
 
 template <>
 struct DartConverter<TextBaseline>

--- a/sky/unit/test/engine/paragraph_builder_test_disabled.dart
+++ b/sky/unit/test/engine/paragraph_builder_test_disabled.dart
@@ -1,0 +1,13 @@
+import 'dart:sky';
+
+import 'package:test/test.dart';
+
+void main() {
+  test("Should be able to build and layout a paragraph", () {
+    ParagraphBuilder builder = new ParagraphBuilder();
+    builder.addText('Hello');
+    Paragraph paragraph = builder.build(new ParagraphStyle());
+    expect(paragraph, isNotNull);
+    paragraph.layout();
+  });
+}


### PR DESCRIPTION
This patch start down the road of implementing text layout and painting without
the DOM. We can construct a basic paragraph consisting of a single run of text
and we can get through layout without crashing.