### PR TITLE
Change how we decide if two nodes can sync.

### DIFF
--- a/sky/packages/sky/lib/src/widgets/homogeneous_viewport.dart
+++ b/sky/packages/sky/lib/src/widgets/homogeneous_viewport.dart
@@ -32,8 +32,10 @@ class HomogeneousViewport extends RenderObjectWrapper {
   ScrollDirection direction;
   double startOffset;
 
-  bool _layoutDirty = true;
   List<Widget> _children;
+  bool _layoutDirty = true;
+  int _layoutFirstIndex;
+  int _layoutItemCount;
 
   RenderBlockViewport get renderObject => super.renderObject;
 
@@ -56,10 +58,16 @@ class HomogeneousViewport extends RenderObjectWrapper {
     super.remove();
     _children.clear();
     _layoutDirty = true;
+    assert(() {
+      _layoutFirstIndex = null;
+      _layoutItemCount = null;
+      return true;
+    });
   }
 
   void walkChildren(WidgetTreeWalker walker) {
-    if (_children == null) return;
+    if (_children == null)
+      return;
     for (Widget child in _children)
       walker(child);
   }
@@ -112,9 +120,6 @@ class HomogeneousViewport extends RenderObjectWrapper {
       _updateChildren();
     }
   }
-
-  int _layoutFirstIndex;
-  int _layoutItemCount;
 
   void layout(BoxConstraints constraints) {
     LayoutCallbackBuilderHandle handle = enterLayoutCallbackBuilder();

--- a/sky/packages/sky/lib/src/widgets/mixed_viewport.dart
+++ b/sky/packages/sky/lib/src/widgets/mixed_viewport.dart
@@ -78,8 +78,9 @@ class MixedViewportLayoutState {
 }
 
 class MixedViewport extends RenderObjectWrapper {
-  MixedViewport({ Key key, this.startOffset, this.direction: ScrollDirection.vertical, this.builder, this.token, this.layoutState })
-    : super(key: key) {
+  MixedViewport({ this.startOffset, this.direction: ScrollDirection.vertical, this.builder, this.token, MixedViewportLayoutState layoutState })
+    : layoutState = layoutState, super(key: new ObjectKey(layoutState)) {
+    // using the layout state as the key is important to prevent us from being synced with someone with a different layout state
     assert(this.layoutState != null);
   }
 

--- a/sky/unit/test/widget/navigator_test.dart
+++ b/sky/unit/test/widget/navigator_test.dart
@@ -1,0 +1,81 @@
+import 'package:sky/animation.dart';
+import 'package:sky/widgets.dart';
+import 'package:test/test.dart';
+
+import 'widget_tester.dart';
+
+class SecondComponent extends StatefulComponent {
+  SecondComponent(this.navigator);
+
+  Navigator navigator;
+
+  void syncConstructorArguments(SecondComponent source) {
+    navigator = source.navigator;
+  }
+
+  Widget build() {
+    return new GestureDetector(
+      onTap: navigator.pop,
+      child: new Container(
+        decoration: new BoxDecoration(
+          backgroundColor: new Color(0xFFFF00FF)
+        ),
+        child: new Text('Y')
+      )
+    );
+  }
+}
+
+class FirstComponent extends Component {
+  FirstComponent(this.navigator);
+
+  final Navigator navigator;
+
+  Widget build() {
+    return new GestureDetector(
+      onTap: () {
+        navigator.pushNamed('/second');
+      },
+      child: new Container(
+        decoration: new BoxDecoration(
+          backgroundColor: new Color(0xFFFFFF00)
+        ),
+        child: new Text('X')
+      )
+    );
+  }
+}
+
+void main() {
+  test('Can navigator to and from a stateful component', () {
+    WidgetTester tester = new WidgetTester();
+
+    final NavigationState routes = new NavigationState([
+      new Route(
+        name: '/',
+        builder: (navigator, route) => new FirstComponent(navigator)
+      ),
+      new Route(
+        name: '/second',
+        builder: (navigator, route) => new SecondComponent(navigator)
+      )
+    ]);
+
+    tester.pumpFrame(() {
+      return new Navigator(routes);
+    });
+
+    tester.tap(tester.findText('X'));
+    scheduler.beginFrame(10.0);
+    scheduler.beginFrame(20.0);
+    scheduler.beginFrame(30.0);
+    scheduler.beginFrame(1000.0);
+
+    tester.tap(tester.findText('Y'));
+    scheduler.beginFrame(1010.0);
+    scheduler.beginFrame(1020.0);
+    scheduler.beginFrame(1030.0);
+    scheduler.beginFrame(2000.0);
+
+  });
+}


### PR DESCRIPTION
If it's a StatefulComponent, then it's ok to reuse it so long as it hasn't been initialised.
If it's a regular Component or a TagNode, then it's always ok to reuse.
If it's a RenderObjectWrapper, then it's ok to reuse so long as it doesn't have a renderObject.

To put it another way, this changes how we prevent the following nonsensical situations from arising:

 - Sync two stateful StatefulComponents together
 - Sync two RenderObjectWrappers with RenderObjects together

When either of those cases happen, we just drop the old one on the ground and use the new one unchanged.

This is implemented by having Widgets say whether they "have state", and preventing two objects that otherwise would sync with each other from syncing if they both have state.

Another change in this patch is that MixedViewport no longer takes a key; instead, it manufactures a key out of the layoutState it is given. This guarantees that you will never try to sync two MixedViewports together that have different state. Previously, if you happened to put two MixedViewports into the same place in the tree such that they might sync at some point, you'd get an assert. Now it'll just work.

I tweaked HomogeneousViewport to reset its state more fully in checked mode, so that we get exceptions if the state ends up being reused somehow.

Test from @abarth.