### PR TITLE
Disentangle FontSize from Settings

### DIFF
--- a/sky/engine/core/css/FontSize.h
+++ b/sky/engine/core/css/FontSize.h
@@ -38,14 +38,11 @@ private:
     }
 
 public:
-    static float getComputedSizeFromSpecifiedSize(const Document*, bool isAbsoluteSize, float specifiedSize, ESmartMinimumForFontSize = UseSmartMinimumForFontFize);
+    static float getComputedSizeFromSpecifiedSize(bool isAbsoluteSize, float specifiedSize, ESmartMinimumForFontSize = UseSmartMinimumForFontFize);
 
     // Given a CSS keyword in the range (xx-small to -webkit-xxx-large), this function will return
     // the correct font size scaled relative to the user's default (medium).
-    static float fontSizeForKeyword(const Document*, CSSValueID keyword, FixedPitchFontType);
-
-    // Given a font size in pixel, this function will return legacy font size between 1 and 7.
-    static int legacyFontSize(const Document*, int pixelFontSize, FixedPitchFontType);
+    static float fontSizeForKeyword(CSSValueID keyword, FixedPitchFontType);
 };
 
 } // namespace blink

--- a/sky/engine/core/css/resolver/FontBuilder.cpp
+++ b/sky/engine/core/css/resolver/FontBuilder.cpp
@@ -101,7 +101,7 @@ void FontBuilder::setInitial()
     scope.reset();
     setFontFamilyToStandard(scope.fontDescription(), m_document);
     scope.fontDescription().setKeywordSize(CSSValueMedium - CSSValueXxSmall + 1);
-    setSize(scope.fontDescription(), FontSize::fontSizeForKeyword(m_document, CSSValueMedium, NonFixedPitchFont));
+    setSize(scope.fontDescription(), FontSize::fontSizeForKeyword(CSSValueMedium, NonFixedPitchFont));
 }
 
 void FontBuilder::inheritFrom(const FontDescription& fontDescription)
@@ -125,12 +125,6 @@ void FontBuilder::fromSystemFont(CSSValueID valueId)
 
     // Double-check and see if the theme did anything. If not, don't bother updating the font.
     if (!fontDescription.isAbsoluteSize())
-        return;
-
-    // Make sure the rendering mode and printer font settings are updated.
-    const Settings* settings = m_document->settings();
-    ASSERT(settings); // If we're doing style resolution, this document should always be in a frame and thus have settings
-    if (!settings)
         return;
 
     fontDescription.setComputedSize(getComputedSizeFromSpecifiedSize(fontDescription, fontDescription.specifiedSize()));
@@ -231,8 +225,8 @@ void FontBuilder::setFontFamilyValue(CSSValue* value)
         return;
 
     if (scope.fontDescription().keywordSize() && scope.fontDescription().fixedPitchFontType() != oldFixedPitchFontType) {
-        scope.fontDescription().setSpecifiedSize(FontSize::fontSizeForKeyword(m_document,
-        static_cast<CSSValueID>(CSSValueXxSmall + scope.fontDescription().keywordSize() - 1), scope.fontDescription().fixedPitchFontType()));
+        scope.fontDescription().setSpecifiedSize(FontSize::fontSizeForKeyword(
+          static_cast<CSSValueID>(CSSValueXxSmall + scope.fontDescription().keywordSize() - 1), scope.fontDescription().fixedPitchFontType()));
     }
 }
 
@@ -240,7 +234,7 @@ void FontBuilder::setFontSizeInitial()
 {
     FontDescriptionChangeScope scope(this);
 
-    float size = FontSize::fontSizeForKeyword(m_document, CSSValueMedium, scope.fontDescription().fixedPitchFontType());
+    float size = FontSize::fontSizeForKeyword(CSSValueMedium, scope.fontDescription().fixedPitchFontType());
 
     if (size < 0)
         return;
@@ -305,7 +299,7 @@ void FontBuilder::setFontSizeValue(CSSValue* value, RenderStyle* parentStyle)
         case CSSValueXLarge:
         case CSSValueXxLarge:
         case CSSValueWebkitXxxLarge:
-            size = FontSize::fontSizeForKeyword(m_document, valueID, scope.fontDescription().fixedPitchFontType());
+            size = FontSize::fontSizeForKeyword(valueID, scope.fontDescription().fixedPitchFontType());
             scope.fontDescription().setKeywordSize(valueID - CSSValueXxSmall + 1);
             break;
         case CSSValueLarger:
@@ -429,7 +423,7 @@ void FontBuilder::setSize(FontDescription& fontDescription, float size)
 
 float FontBuilder::getComputedSizeFromSpecifiedSize(FontDescription& fontDescription, float specifiedSize)
 {
-    return FontSize::getComputedSizeFromSpecifiedSize(m_document, fontDescription.isAbsoluteSize(), specifiedSize);
+    return FontSize::getComputedSizeFromSpecifiedSize(fontDescription.isAbsoluteSize(), specifiedSize);
 }
 
 static void getFontAndGlyphOrientation(const RenderStyle* style, FontOrientation& fontOrientation, NonCJKGlyphOrientation& glyphOrientation)
@@ -476,7 +470,7 @@ void FontBuilder::checkForGenericFamilyChange(RenderStyle* style, const RenderSt
     // multiplying by our scale factor.
     float size;
     if (scope.fontDescription().keywordSize()) {
-        size = FontSize::fontSizeForKeyword(m_document, static_cast<CSSValueID>(CSSValueXxSmall + scope.fontDescription().keywordSize() - 1), scope.fontDescription().fixedPitchFontType());
+        size = FontSize::fontSizeForKeyword(static_cast<CSSValueID>(CSSValueXxSmall + scope.fontDescription().keywordSize() - 1), scope.fontDescription().fixedPitchFontType());
     } else {
         Settings* settings = m_document->settings();
         float fixedScaleFactor = (settings && settings->defaultFixedFontSize() && settings->defaultFontSize())
@@ -518,7 +512,7 @@ void FontBuilder::createFontForDocument(PassRefPtr<FontSelector> fontSelector, R
 
     setFontFamilyToStandard(fontDescription, m_document);
     fontDescription.setKeywordSize(CSSValueMedium - CSSValueXxSmall + 1);
-    int size = FontSize::fontSizeForKeyword(m_document, CSSValueMedium, NonFixedPitchFont);
+    int size = FontSize::fontSizeForKeyword(CSSValueMedium, NonFixedPitchFont);
     fontDescription.setSpecifiedSize(size);
     fontDescription.setComputedSize(getComputedSizeFromSpecifiedSize(fontDescription, size));
 

--- a/sky/engine/core/painting/LayoutRoot.cpp
+++ b/sky/engine/core/painting/LayoutRoot.cpp
@@ -27,10 +27,6 @@ LayoutRoot::LayoutRoot()
     , m_maxHeight(0)
 {
     m_settings = Settings::create();
-    // Using 14px default to match Material Design English Body1:
-    // http://www.google.com/design/spec/style/typography.html#typography-typeface
-    m_settings->setDefaultFixedFontSize(14);
-    m_settings->setDefaultFontSize(14);
     m_frameHost = FrameHost::createDummy(m_settings.get());
     m_frame = LocalFrame::create(nullptr, m_frameHost.get());
     m_frame->createView(IntSize(), Color::white, false);

--- a/sky/unit/test/engine/paragraph_builder_test_disabled.dart
+++ b/sky/unit/test/engine/paragraph_builder_test_disabled.dart
@@ -8,6 +8,14 @@ void main() {
     builder.addText('Hello');
     Paragraph paragraph = builder.build(new ParagraphStyle());
     expect(paragraph, isNotNull);
+
+    paragraph.minWidth = 0.0;
+    paragraph.maxWidth = 800.0;
+    paragraph.minHeight = 0.0;
+    paragraph.maxHeight = 600.0;
+
     paragraph.layout();
+    expect(paragraph.width, isNonZero);
+    expect(paragraph.height, isNonZero);
   });
 }


### PR DESCRIPTION
Instead, just store the default font sizes in statics. These statics are
constants for now, but we'll probably make them configurable at some point.