### PR TITLE
Improve the debugging information for Widget

### DIFF
--- a/sky/packages/sky/lib/rendering.dart
+++ b/sky/packages/sky/lib/rendering.dart
@@ -11,6 +11,7 @@ export 'package:sky/src/rendering/auto_layout.dart';
 export 'package:sky/src/rendering/block.dart';
 export 'package:sky/src/rendering/box.dart';
 export 'package:sky/src/rendering/debug.dart';
+export 'package:sky/src/rendering/error.dart';
 export 'package:sky/src/rendering/flex.dart';
 export 'package:sky/src/rendering/grid.dart';
 export 'package:sky/src/rendering/hit_test.dart';

--- a/sky/packages/sky/lib/src/rendering/debug.dart
+++ b/sky/packages/sky/lib/src/rendering/debug.dart
@@ -21,22 +21,28 @@ bool _initInDebugBuild() {
 bool debugPaintSizeEnabled = false;
 
 /// The color to use when painting RenderObject bounds.
-const sky.Color debugPaintSizeColor = const sky.Color(0xFF00FFFF);
+sky.Color debugPaintSizeColor = const sky.Color(0xFF00FFFF);
 
 /// Causes each RenderBox to paint a line at each of its baselines.
 bool debugPaintBaselinesEnabled = false;
 
 /// The color to use when painting alphabetic baselines.
-const sky.Color debugPaintAlphabeticBaselineColor = const sky.Color(0xFF00FF00);
+sky.Color debugPaintAlphabeticBaselineColor = const sky.Color(0xFF00FF00);
 
 /// The color ot use when painting ideographic baselines.
-const sky.Color debugPaintIdeographicBaselineColor = const sky.Color(0xFFFFD000);
+sky.Color debugPaintIdeographicBaselineColor = const sky.Color(0xFFFFD000);
 
 /// Causes each Layer to paint a box around its bounds.
 bool debugPaintLayerBordersEnabled = false;
 
 /// The color to use when painting Layer borders.
-const sky.Color debugPaintLayerBordersColor = const sky.Color(0xFFFF9800);
+sky.Color debugPaintLayerBordersColor = const sky.Color(0xFFFF9800);
 
 /// Causes RenderObjects to paint warnings when painting outside their bounds.
 bool debugPaintBoundsEnabled = false;
+
+/// The color to use when painting RenderError boxes in checked mode.
+sky.Color debugErrorBoxColor = const sky.Color(0xFFFF0000);
+
+/// How many lines of debugging output to include when an exception is reported.
+int debugRenderObjectDumpMaxLength = 10;

--- a/sky/packages/sky/lib/src/rendering/error.dart
+++ b/sky/packages/sky/lib/src/rendering/error.dart
@@ -1,0 +1,40 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:sky/src/rendering/box.dart';
+import 'package:sky/src/rendering/debug.dart';
+import 'package:sky/src/rendering/object.dart';
+
+const double _kMaxWidth = 100000.0;
+const double _kMaxHeight = 100000.0;
+
+class RenderErrorBox extends RenderBox {
+
+  double getMinIntrinsicWidth(BoxConstraints constraints) {
+    return constraints.constrainWidth(0.0);
+  }
+
+  double getMaxIntrinsicWidth(BoxConstraints constraints) {
+    return constraints.constrainWidth(_kMaxWidth);
+  }
+
+  double getMinIntrinsicHeight(BoxConstraints constraints) {
+    return constraints.constrainHeight(0.0);
+  }
+
+  double getMaxIntrinsicHeight(BoxConstraints constraints) {
+    return constraints.constrainHeight(_kMaxHeight);
+  }
+
+  bool get sizedByParent => true;
+
+  void performResize() {
+    size = constraints.constrain(const Size(_kMaxWidth, _kMaxHeight));
+  }
+
+  void paint(PaintingContext context, Offset offset) {
+    context.canvas.drawRect(offset & size, new Paint() .. color = debugErrorBoxColor);
+  }
+
+}


### PR DESCRIPTION
If the build stack got long before, it would get cropped.

This adds lots more detail to the exception handling.

I also made the constants in debug.dart mutable so that users can change the colours if they want, to aid debugging.

This is intended to supersede #1132. 