### PR TITLE
ancestor is Flex assert in widgets/basic.dart

### DIFF
--- a/sky/packages/sky/lib/src/widgets/framework.dart
+++ b/sky/packages/sky/lib/src/widgets/framework.dart
@@ -823,7 +823,6 @@ abstract class Component extends Widget {
       assert(_child == null);
     }
 
-    String _debugPreviousComponent;
     assert(() {
       _debugIsBuilding = true;
       _debugComponentBuildTree.add(this);
@@ -1137,7 +1136,8 @@ abstract class RenderObjectWrapper extends Widget {
           Widget ancestor = current.parent;
           while (ancestor != null && ancestor is Component)
             ancestor = ancestor.parent;
-          current.debugValidateAncestor(ancestor);
+          if (ancestor != null)
+            current.debugValidateAncestor(ancestor);
         }
         return true;
       });


### PR DESCRIPTION
We didn't mean to flag null ancestors for this debugging check.

Fixes #1140