### PR TITLE
Delete document view when view manager is disconnected.

### DIFF
--- a/services/sky/document_view.cc
+++ b/services/sky/document_view.cc
@@ -137,7 +137,9 @@ void DocumentView::OnEmbed(
 }
 
 void DocumentView::OnViewManagerDisconnected(mojo::ViewManager* view_manager) {
-  // TODO(aa): Need to figure out how shutdown works.
+  // TODO(ksimbili): Need to figure out how to shutdown when view manager
+  // doesn't connect.
+  delete this;
 }
 
 void DocumentView::LoadFromSnapshotStream(


### PR DESCRIPTION
Document view will be deleted when view manager is disconnected.
There is still a leak when view manager never connected to document view.