### PR TITLE
Remove use of some deprecated functions on sky.Paint

### DIFF
--- a/examples/game/lib/star_field.dart
+++ b/examples/game/lib/star_field.dart
@@ -15,9 +15,9 @@ class StarField extends NodeWithSize {
   Size _paddedSize = Size.zero;
 
   Paint _paint = new Paint()
-    ..setFilterQuality(sky.FilterQuality.low)
+    ..filterQuality = sky.FilterQuality.low
     ..isAntiAlias = false
-    ..setTransferMode(sky.TransferMode.plus);
+    ..transferMode = sky.TransferMode.plus;
 
   StarField(this._spriteSheet, this._numStars, [this._autoScroll = false]) : super(Size.zero) {
     _image = _spriteSheet.image;

--- a/examples/game/test_drawatlas.dart
+++ b/examples/game/test_drawatlas.dart
@@ -75,7 +75,9 @@ class TestDrawAtlas extends NodeWithSize {
       colors,
       TransferMode.src,
       null,
-      new Paint()..setFilterQuality(FilterQuality.low)..isAntiAlias=false
+      new Paint()
+        ..filterQuality = FilterQuality.low
+        ..isAntiAlias = false
     );
   }
 }

--- a/examples/game/test_performance.dart
+++ b/examples/game/test_performance.dart
@@ -209,7 +209,7 @@ class TestPerformanceAtlas extends PerformanceTest {
   double rotation = 0.0;
   List<Rect> rects = [];
   Paint cachedPaint = new Paint()
-    ..setFilterQuality(sky.FilterQuality.low)
+    ..filterQuality = sky.FilterQuality.low
     ..isAntiAlias = false;
 
   TestPerformanceAtlas() {
@@ -262,7 +262,7 @@ class TestPerformanceAtlas2 extends PerformanceTest {
   double rotation = 0.0;
   List<Rect> rects = [];
   Paint cachedPaint = new Paint()
-    ..setFilterQuality(sky.FilterQuality.low)
+    ..filterQuality = sky.FilterQuality.low
     ..isAntiAlias = false;
 
   TestPerformanceAtlas2() {

--- a/examples/raw/painting.dart
+++ b/examples/raw/painting.dart
@@ -53,28 +53,28 @@ sky.Picture paint(sky.Rect paintBounds) {
             ..setPaintBits(sky.PaintBits.all),
           new sky.Paint()
             ..color = const sky.Color.fromARGB(128, 255, 255, 0)
-            ..setColorFilter(new sky.ColorFilter.mode(
-              const sky.Color.fromARGB(128, 0, 0, 255), sky.TransferMode.srcIn))
-            ..setMaskFilter(new sky.MaskFilter.blur(
-              sky.BlurStyle.normal, 3.0, highQuality: true)))
+            ..colorFilter = new sky.ColorFilter.mode(
+              const sky.Color.fromARGB(128, 0, 0, 255), sky.TransferMode.srcIn)
+            ..maskFilter = new sky.MaskFilter.blur(
+              sky.BlurStyle.normal, 3.0, highQuality: true))
       ..addLayerOnTop(
           new sky.DrawLooperLayerInfo()
             ..setOffset(const sky.Offset(75.0, 75.0))
             ..setColorMode(sky.TransferMode.src)
             ..setPaintBits(sky.PaintBits.shader),
           new sky.Paint()
-            ..setShader(new sky.Gradient.radial(
+            ..shader = new sky.Gradient.radial(
                 new sky.Point(0.0, 0.0), radius/3.0,
                 [const sky.Color(0xFFFFFF00), const sky.Color(0xFFFF0000)],
-                null, sky.TileMode.mirror))
+                null, sky.TileMode.mirror)
             // Since we're don't set sky.PaintBits.maskFilter, this has no effect.
-            ..setMaskFilter(new sky.MaskFilter.blur(
-              sky.BlurStyle.normal, 50.0, highQuality: true)))
+            ..maskFilter = new sky.MaskFilter.blur(
+                sky.BlurStyle.normal, 50.0, highQuality: true))
       ..addLayerOnTop(
           new sky.DrawLooperLayerInfo()..setOffset(const sky.Offset(225.0, 75.0)),
           // Since this layer uses a DST color mode, this has no effect.
           new sky.Paint()..color = const sky.Color.fromARGB(128, 255, 0, 0));
-  paint.setDrawLooper(builder.build());
+  paint.drawLooper = builder.build();
   canvas.drawCircle(sky.Point.origin, radius, paint);
 
   return recorder.endRecording();

--- a/examples/raw/shadow.dart
+++ b/examples/raw/shadow.dart
@@ -23,12 +23,11 @@ sky.Picture paint(sky.Rect paintBounds) {
           ..setColorMode(sky.TransferMode.src),
         new sky.Paint()
           ..color = const sky.Color.fromARGB(128, 55, 55, 55)
-          ..setMaskFilter(
-            new sky.MaskFilter.blur(sky.BlurStyle.normal, 5.0))
+          ..maskFilter = new sky.MaskFilter.blur(sky.BlurStyle.normal, 5.0)
     )
     // Main layer.
     ..addLayerOnTop(new sky.DrawLooperLayerInfo(), new sky.Paint());
-  paint.setDrawLooper(builder.build());
+  paint.drawLooper = builder.build();
 
   canvas.drawPaint(
       new sky.Paint()..color = const sky.Color.fromARGB(255, 255, 255, 255));

--- a/sky/packages/sky/lib/src/painting/box_painter.dart
+++ b/sky/packages/sky/lib/src/painting/box_painter.dart
@@ -401,7 +401,7 @@ void paintImage({
   // TODO(abarth): Implement |repeat|.
   Paint paint = new Paint();
   if (colorFilter != null)
-    paint.setColorFilter(colorFilter);
+    paint.colorFilter = colorFilter;
   double dx = (bounds.width - destinationSize.width) * positionX;
   double dy = (bounds.height - destinationSize.height) * positionY;
   Point destinationPosition = rect.topLeft + new Offset(dx, dy);
@@ -605,11 +605,11 @@ class BoxPainter {
         var builder = new ShadowDrawLooperBuilder();
         for (BoxShadow boxShadow in _decoration.boxShadow)
           builder.addShadow(boxShadow.offset, boxShadow.color, boxShadow.blur);
-        paint.setDrawLooper(builder.build());
+        paint.drawLooper = builder.build();
       }
 
       if (_decoration.gradient != null)
-        paint.setShader(_decoration.gradient.createShader());
+        paint.shader = _decoration.gradient.createShader();
 
       _cachedBackgroundPaint = paint;
     }

--- a/sky/packages/sky/lib/src/painting/shadows.dart
+++ b/sky/packages/sky/lib/src/painting/shadows.dart
@@ -17,7 +17,7 @@ class ShadowDrawLooperBuilder {
             ..setColorMode(sky.TransferMode.src),
           new sky.Paint()
             ..color = color
-            ..setMaskFilter(new sky.MaskFilter.blur(sky.BlurStyle.normal, blur)));
+            ..maskFilter = new sky.MaskFilter.blur(sky.BlurStyle.normal, blur));
   }
 
   /// Returns the draw looper built for the added shadows

--- a/sky/packages/sky/lib/src/rendering/object.dart
+++ b/sky/packages/sky/lib/src/rendering/object.dart
@@ -265,7 +265,7 @@ class PaintingContext {
 
   static Paint _getPaintForColorFilter(Color color, sky.TransferMode transferMode) {
     return new Paint()
-      ..setColorFilter(new sky.ColorFilter.mode(color, transferMode))
+      ..colorFilter = new sky.ColorFilter.mode(color, transferMode)
       ..isAntiAlias = false;
   }
 

--- a/sky/packages/sky/lib/src/widgets/switch.dart
+++ b/sky/packages/sky/lib/src/widgets/switch.dart
@@ -113,8 +113,9 @@ class _RenderSwitch extends RenderToggleable {
     }
 
     // Draw the track rrect
-    sky.Paint paint = new sky.Paint()..color = trackColor;
-    paint.setStyle(sky.PaintingStyle.fill);
+    sky.Paint paint = new sky.Paint()
+      ..color = trackColor
+      ..style = sky.PaintingStyle.fill;
     sky.Rect rect = new sky.Rect.fromLTWH(offset.dx,
         offset.dy + _kSwitchHeight / 2.0 - _kTrackHeight / 2.0, _kTrackWidth,
         _kTrackHeight);
@@ -127,10 +128,10 @@ class _RenderSwitch extends RenderToggleable {
 
     // Draw the raised thumb with a shadow
     paint.color = thumbColor;
-    var builder = new ShadowDrawLooperBuilder();
-    for (BoxShadow boxShadow in shadows[1]) builder.addShadow(
-        boxShadow.offset, boxShadow.color, boxShadow.blur);
-    paint.setDrawLooper(builder.build());
+    ShadowDrawLooperBuilder builder = new ShadowDrawLooperBuilder();
+    for (BoxShadow boxShadow in shadows[1])
+      builder.addShadow(boxShadow.offset, boxShadow.color, boxShadow.blur);
+    paint.drawLooper = builder.build();
 
     // The thumb contracts slightly during the animation
     double inset = 2.0 - (position.value - 0.5).abs() * 2.0;

--- a/skysprites/lib/layer.dart
+++ b/skysprites/lib/layer.dart
@@ -22,7 +22,7 @@ class Layer extends Node with SpritePaint {
   Layer([Rect this.layerRect = null]);
 
   Paint _cachedPaint = new Paint()
-    ..setFilterQuality(FilterQuality.low)
+    ..filterQuality = FilterQuality.low
     ..isAntiAlias = false;
 
   void _prePaint(PaintingCanvas canvas, Matrix4 matrix) {

--- a/skysprites/lib/particle_system.dart
+++ b/skysprites/lib/particle_system.dart
@@ -152,7 +152,7 @@ class ParticleSystem extends Node {
   int _numEmittedParticles = 0;
 
   static Paint _paint = new Paint()
-    ..setFilterQuality(FilterQuality.low)
+    ..filterQuality = FilterQuality.low
     ..isAntiAlias = false;
 
   ParticleSystem(this.texture,

--- a/skysprites/lib/sprite.dart
+++ b/skysprites/lib/sprite.dart
@@ -17,7 +17,7 @@ class Sprite extends NodeWithSize with SpritePaint {
   bool constrainProportions = false;
 
   Paint _cachedPaint = new Paint()
-    ..setFilterQuality(FilterQuality.low)
+    ..filterQuality = FilterQuality.low
     ..isAntiAlias = false;
 
   /// Creates a new sprite from the provided [texture].
@@ -113,11 +113,11 @@ abstract class SpritePaint {
     paint.color = new Color.fromARGB((255.0*_opacity).toInt(), 255, 255, 255);
 
     if (colorOverlay != null) {
-      paint.setColorFilter(new ColorFilter.mode(colorOverlay, TransferMode.srcATop));
+      paint.colorFilter = new ColorFilter.mode(colorOverlay, TransferMode.srcATop);
     }
 
     if (transferMode != null) {
-      paint.setTransferMode(transferMode);
+      paint.transferMode = transferMode;
     }
   }
 }


### PR DESCRIPTION
We now expose idiomatic setters for these properties. Eventually we'll remove
the setter functions.