### PR TITLE
Minor cleanups (spelling mistakes, unneeded casts)

### DIFF
--- a/sky/packages/sky/lib/src/widgets/framework.dart
+++ b/sky/packages/sky/lib/src/widgets/framework.dart
@@ -916,7 +916,7 @@ abstract class StatefulComponent extends Component {
   // because our retainStatefulNodeIfPossible() method returns true,
   // when _sync is called, our 'old' is actually the new instance that
   // we are to copy state from.
-  void _sync(Widget old, dynamic slot) {
+  void _sync(StatefulComponent old, dynamic slot) {
     if (old == null) {
       if (!_isStateInitialized) {
         initState();
@@ -925,7 +925,7 @@ abstract class StatefulComponent extends Component {
     }
     if (old != null) {
       assert(_isStateInitialized);
-      assert(!(old as StatefulComponent)._isStateInitialized);
+      assert(!old._isStateInitialized);
       syncConstructorArguments(old);
     }
     super._sync(old, slot);

--- a/sky/unit/test/widget/stateful_components_test.dart
+++ b/sky/unit/test/widget/stateful_components_test.dart
@@ -21,12 +21,12 @@ class InnerComponent extends StatefulComponent {
   }
 }
 
-class OutterContainer extends StatefulComponent {
-  OutterContainer({ this.child });
+class OuterContainer extends StatefulComponent {
+  OuterContainer({ this.child });
 
   InnerComponent child;
 
-  void syncConstructorArguments(OutterContainer source) {
+  void syncConstructorArguments(OuterContainer source) {
     child = source.child;
   }
 
@@ -41,22 +41,22 @@ void main() {
     WidgetTester tester = new WidgetTester();
 
     InnerComponent inner;
-    OutterContainer outter;
+    OuterContainer outer;
 
     tester.pumpFrame(() {
-      return new OutterContainer(child: new InnerComponent());
+      return new OuterContainer(child: new InnerComponent());
     });
 
     tester.pumpFrame(() {
       inner = new InnerComponent();
-      outter = new OutterContainer(child: inner);
-      return outter;
+      outer = new OuterContainer(child: inner);
+      return outer;
     });
 
     expect(inner._didInitState, isFalse);
     expect(inner.parent, isNull);
 
-    outter.setState(() {});
+    outer.setState(() {});
     scheduler.beginFrame(0.0);
 
     expect(inner._didInitState, isFalse);


### PR DESCRIPTION
Rename Outter to Outer.

Change _sync() in StatefulComponent to assert the argument type in the
signature rather than in the code.