### PR TITLE
Various and sundry code cleanup

### DIFF
--- a/sky/packages/sky/lib/src/animation/animated_value.dart
+++ b/sky/packages/sky/lib/src/animation/animated_value.dart
@@ -22,7 +22,9 @@ abstract class AnimatedVariable {
   String toString();
 }
 
-///
+/// Used by [AnimationPerformance] to convert the timing of a performance to a different timescale.
+/// For example, by setting different values for the interval and reverseInterval, a performance
+/// can be made to take longer in one direction that the other.
 class AnimationTiming {
   AnimationTiming({
     this.interval,
@@ -36,7 +38,7 @@ class AnimationTiming {
 
   /// The interval during which this timing is active in the reverse direction
   ///
-  /// If this field is null, the timing defaules to using [interval] in both directions.
+  /// If this field is null, the timing defaults to using [interval] in both directions.
   Interval reverseInterval;
 
   /// The curve that this timing applies to the animation clock in the forward direction
@@ -44,7 +46,7 @@ class AnimationTiming {
 
   /// The curve that this timing applies to the animation clock in the reverse direction
   ///
-  /// If this field is null, the timing defaules to using [curve] in both directions.
+  /// If this field is null, the timing defaults to using [curve] in both directions.
   Curve reverseCurve;
 
   /// Applies this timing to the given animation clock value in the given direction

--- a/sky/packages/sky/lib/src/widgets/animated_component.dart
+++ b/sky/packages/sky/lib/src/widgets/animated_component.dart
@@ -20,7 +20,9 @@ abstract class AnimatedComponent extends StatefulComponent {
     });
   }
 
-  bool isWatching(performance) => _watchedPerformances.contains(performance);
+  bool isWatching(AnimationPerformance performance) {
+    return _watchedPerformances.contains(performance);
+  }
 
   void watch(AnimationPerformance performance) {
     assert(!isWatching(performance));

--- a/sky/packages/sky/lib/src/widgets/framework.dart
+++ b/sky/packages/sky/lib/src/widgets/framework.dart
@@ -511,9 +511,10 @@ abstract class Widget {
     return '$startPrefix${toStringName()}$suffix\n$childrenString';
   }
   String toStringName() {
-    if (key == null)
-      return '$runtimeType(unkeyed; hashCode=$hashCode)';
-    return '$runtimeType($key; hashCode=$hashCode)';
+    String keyString = key == null ? '' : '$key; ';
+    String hashCodeString = 'hashCode=$hashCode';
+    String mountedString = mounted ? '; mounted' : '; not mounted';
+    return '$runtimeType($keyString$hashCodeString$mountedString)';
   }
 
   // This function can be safely called when the layout is valid.
@@ -916,16 +917,15 @@ abstract class StatefulComponent extends Component {
   // because our retainStatefulNodeIfPossible() method returns true,
   // when _sync is called, our 'old' is actually the new instance that
   // we are to copy state from.
-  void _sync(Widget old, dynamic slot) {
+  void _sync(StatefulComponent old, dynamic slot) {
     if (old == null) {
       if (!_isStateInitialized) {
         initState();
         _isStateInitialized = true;
       }
-    }
-    if (old != null) {
+    } else {
       assert(_isStateInitialized);
-      assert(!(old as StatefulComponent)._isStateInitialized);
+      assert(!old._isStateInitialized);
       syncConstructorArguments(old);
     }
     super._sync(old, slot);

--- a/sky/packages/sky/lib/src/widgets/transitions.dart
+++ b/sky/packages/sky/lib/src/widgets/transitions.dart
@@ -60,8 +60,8 @@ class _AnchorTransition extends AnimatedComponent {
 abstract class TransitionBase extends AnimatedComponent {
   TransitionBase({
     Key key,
-    this.anchor,
     this.child,
+    this.anchor,
     this.direction,
     this.duration,
     this.performance,
@@ -84,9 +84,9 @@ abstract class TransitionBase extends AnimatedComponent {
     if (performance == null) {
       assert(duration != null);
       performance = new AnimationPerformance(duration: duration);
+      if (direction == Direction.reverse)
+        performance.progress = 1.0;
     }
-    if (direction == Direction.reverse)
-      performance.progress = 1.0;
     performance.addStatusListener(_checkStatusChanged);
 
     watch(performance);
@@ -127,8 +127,6 @@ abstract class TransitionBase extends AnimatedComponent {
 }
 
 class SlideTransition extends TransitionBase {
-  // TODO(mpcomplete): this constructor is mostly boilerplate, passing values
-  // to super. Is there a simpler way?
   SlideTransition({
     Key key,
     Anchor anchor,


### PR DESCRIPTION
- Add documentation for AnimationTiming.
- typo: defaules -> defaults.
- added type information to isWatching() signature.
- made Widget.toStringName() include more useful information.
- cleaned up StatefulComponent._sync(): more specific signature, change
  redundant if to else, remove redundant cast.
- change order of TransitionBase arguments for consistency.
- prevent TransitionBase from affecting the performance in its
  constructor when it didn't create it (but see #1103).
- remove TODO() from @mpcomplete... no, there is not currently a better
  way to inherit a constructor, unfortunately.