### PR TITLE
Revert "MultiChildRenderObjectWrapper should take an Iterable instead of a List"

### DIFF
--- a/sky/packages/sky/lib/src/rendering/auto_layout.dart
+++ b/sky/packages/sky/lib/src/rendering/auto_layout.dart
@@ -126,7 +126,7 @@ class RenderAutoLayout extends RenderBox
          RenderBoxContainerDefaultsMixin<RenderBox, AutoLayoutParentData>,
          _AutoLayoutParamMixin {
 
-  RenderAutoLayout({ Iterable<RenderBox> children }) {
+  RenderAutoLayout({ List<RenderBox> children }) {
     _setupLayoutParameters(this);
     _setupEditVariablesInSolver(_solver, al.Priority.required - 1);
     addAll(children);

--- a/sky/packages/sky/lib/src/rendering/block.dart
+++ b/sky/packages/sky/lib/src/rendering/block.dart
@@ -35,7 +35,7 @@ abstract class RenderBlockBase extends RenderBox with ContainerRenderObjectMixin
                                                       RenderBoxContainerDefaultsMixin<RenderBox, BlockParentData> {
 
   RenderBlockBase({
-    Iterable<RenderBox> children,
+    List<RenderBox> children,
     BlockDirection direction: BlockDirection.vertical,
     double itemExtent,
     double minExtent: 0.0
@@ -123,7 +123,7 @@ abstract class RenderBlockBase extends RenderBox with ContainerRenderObjectMixin
 class RenderBlock extends RenderBlockBase {
 
   RenderBlock({
-    Iterable<RenderBox> children,
+    List<RenderBox> children,
     BlockDirection direction: BlockDirection.vertical,
     double itemExtent,
     double minExtent: 0.0
@@ -231,7 +231,7 @@ class RenderBlockViewport extends RenderBlockBase {
     double itemExtent,
     double minExtent: 0.0,
     double startOffset: 0.0,
-    Iterable<RenderBox> children
+    List<RenderBox> children
   }) : _callback = callback,
        _totalExtentCallback = totalExtentCallback,
        _maxCrossAxisExtentCallback = maxCrossAxisDimensionCallback,

--- a/sky/packages/sky/lib/src/rendering/flex.dart
+++ b/sky/packages/sky/lib/src/rendering/flex.dart
@@ -85,7 +85,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
                                         RenderBoxContainerDefaultsMixin<RenderBox, FlexParentData> {
 
   RenderFlex({
-    Iterable<RenderBox> children,
+    List<RenderBox> children,
     FlexDirection direction: FlexDirection.horizontal,
     FlexJustifyContent justifyContent: FlexJustifyContent.start,
     FlexAlignItems alignItems: FlexAlignItems.center,

--- a/sky/packages/sky/lib/src/rendering/grid.dart
+++ b/sky/packages/sky/lib/src/rendering/grid.dart
@@ -52,7 +52,7 @@ class GridParentData extends BoxParentData with ContainerParentDataMixin<RenderB
 /// the given [maxChildExtent].
 class RenderGrid extends RenderBox with ContainerRenderObjectMixin<RenderBox, GridParentData>,
                                         RenderBoxContainerDefaultsMixin<RenderBox, GridParentData> {
-  RenderGrid({ Iterable<RenderBox> children, double maxChildExtent }) {
+  RenderGrid({ List<RenderBox> children, double maxChildExtent }) {
     addAll(children);
     _maxChildExtent = maxChildExtent;
   }

--- a/sky/packages/sky/lib/src/rendering/object.dart
+++ b/sky/packages/sky/lib/src/rendering/object.dart
@@ -1230,7 +1230,7 @@ abstract class ContainerRenderObjectMixin<ChildType extends RenderObject, Parent
   }
 
   /// Add all the children to the end of this render object's child list
-  void addAll(Iterable<ChildType> children) {
+  void addAll(List<ChildType> children) {
     if (children != null)
       for (ChildType child in children)
         add(child);

--- a/sky/packages/sky/lib/src/rendering/stack.dart
+++ b/sky/packages/sky/lib/src/rendering/stack.dart
@@ -68,7 +68,7 @@ class StackParentData extends BoxParentData with ContainerParentDataMixin<Render
 class RenderStack extends RenderBox with ContainerRenderObjectMixin<RenderBox, StackParentData>,
                                          RenderBoxContainerDefaultsMixin<RenderBox, StackParentData> {
   RenderStack({
-    Iterable<RenderBox> children
+    List<RenderBox> children
   }) {
     addAll(children);
   }

--- a/sky/packages/sky/lib/src/widgets/basic.dart
+++ b/sky/packages/sky/lib/src/widgets/basic.dart
@@ -473,7 +473,7 @@ class Container extends Component {
 // LAYOUT NODES
 
 class BlockBody extends MultiChildRenderObjectWrapper {
-  BlockBody(Iterable<Widget> children, {
+  BlockBody(List<Widget> children, {
     Key key,
     this.direction: BlockDirection.vertical
   }) : super(key: key, children: children) {
@@ -492,7 +492,7 @@ class BlockBody extends MultiChildRenderObjectWrapper {
 }
 
 class Stack extends MultiChildRenderObjectWrapper {
-  Stack(Iterable<Widget> children, { Key key })
+  Stack(List<Widget> children, { Key key })
     : super(key: key, children: children);
 
   RenderStack createNode() => new RenderStack();
@@ -555,7 +555,7 @@ class Positioned extends ParentDataNode {
 }
 
 class Grid extends MultiChildRenderObjectWrapper {
-  Grid(Iterable<Widget> children, { Key key, this.maxChildExtent })
+  Grid(List<Widget> children, { Key key, this.maxChildExtent })
     : super(key: key, children: children) {
     assert(maxChildExtent != null);
   }
@@ -572,7 +572,7 @@ class Grid extends MultiChildRenderObjectWrapper {
 }
 
 class Flex extends MultiChildRenderObjectWrapper {
-  Flex(Iterable<Widget> children, {
+  Flex(List<Widget> children, {
     Key key,
     this.direction: FlexDirection.horizontal,
     this.justifyContent: FlexJustifyContent.start,
@@ -615,7 +615,7 @@ class Flex extends MultiChildRenderObjectWrapper {
 }
 
 class Row extends Flex {
-  Row(Iterable<Widget> children, {
+  Row(List<Widget> children, {
     Key key,
     justifyContent: FlexJustifyContent.start,
     alignItems: FlexAlignItems.center,
@@ -624,7 +624,7 @@ class Row extends Flex {
 }
 
 class Column extends Flex {
-  Column(Iterable<Widget> children, {
+  Column(List<Widget> children, {
     Key key,
     justifyContent: FlexJustifyContent.start,
     alignItems: FlexAlignItems.center,


### PR DESCRIPTION
This reverts commit 7592213df29066cd357eaa4fffe4a19ed3bae189.