### PR TITLE
Ignore generation of child if child is unchanged

### DIFF
--- a/sky/unit/test/widget/navigator_test.dart
+++ b/sky/unit/test/widget/navigator_test.dart
@@ -4,6 +4,26 @@ import 'package:test/test.dart';
 
 import 'widget_tester.dart';
 
+class FirstComponent extends Component {
+  FirstComponent(this.navigator);
+
+  final Navigator navigator;
+
+  Widget build() {
+    return new GestureDetector(
+      onTap: () {
+        navigator.pushNamed('/second');
+      },
+      child: new Container(
+        decoration: new BoxDecoration(
+          backgroundColor: new Color(0xFFFFFF00)
+        ),
+        child: new Text('X')
+      )
+    );
+  }
+}
+
 class SecondComponent extends StatefulComponent {
   SecondComponent(this.navigator);
 
@@ -26,28 +46,8 @@ class SecondComponent extends StatefulComponent {
   }
 }
 
-class FirstComponent extends Component {
-  FirstComponent(this.navigator);
-
-  final Navigator navigator;
-
-  Widget build() {
-    return new GestureDetector(
-      onTap: () {
-        navigator.pushNamed('/second');
-      },
-      child: new Container(
-        decoration: new BoxDecoration(
-          backgroundColor: new Color(0xFFFFFF00)
-        ),
-        child: new Text('X')
-      )
-    );
-  }
-}
-
 void main() {
-  test('Can navigator to and from a stateful component', () {
+  test('Can navigator navigate to and from a stateful component', () {
     WidgetTester tester = new WidgetTester();
 
     final NavigationState routes = new NavigationState([
@@ -65,8 +65,15 @@ void main() {
       return new Navigator(routes);
     });
 
+    expect(tester.findText('X'), isNotNull);
+    expect(tester.findText('Y'), isNull);
+
     tester.tap(tester.findText('X'));
     scheduler.beginFrame(10.0);
+
+    expect(tester.findText('X'), isNotNull);
+    expect(tester.findText('Y'), isNotNull);
+
     scheduler.beginFrame(20.0);
     scheduler.beginFrame(30.0);
     scheduler.beginFrame(1000.0);
@@ -76,6 +83,9 @@ void main() {
     scheduler.beginFrame(1020.0);
     scheduler.beginFrame(1030.0);
     scheduler.beginFrame(2000.0);
+
+    expect(tester.findText('X'), isNotNull);
+    expect(tester.findText('Y'), isNull);
 
   });
 }

--- a/sky/unit/test/widget/set_state_test.dart
+++ b/sky/unit/test/widget/set_state_test.dart
@@ -1,0 +1,75 @@
+import 'package:sky/gestures/arena.dart';
+import 'package:sky/gestures/pointer_router.dart';
+import 'package:sky/gestures/tap.dart';
+import 'package:sky/widgets.dart';
+import 'package:test/test.dart';
+
+import '../engine/mock_events.dart';
+import 'widget_tester.dart';
+
+class Inside extends StatefulComponent {
+  void syncConstructorArguments(Inside source) {
+  }
+
+  Widget build() {
+    return new Listener(
+      onPointerDown: _handlePointerDown,
+      child: new Text('INSIDE')
+    );
+  }
+
+  EventDisposition _handlePointerDown(_) {
+    setState(() { });
+    return EventDisposition.processed;
+  }
+}
+
+class Middle extends StatefulComponent {
+  Inside child;
+
+  Middle({ this.child });
+
+  void syncConstructorArguments(Middle source) {
+    child = source.child;
+  }
+
+  Widget build() {
+    return new Listener(
+      onPointerDown: _handlePointerDown,
+      child: child
+    );
+  }
+
+  EventDisposition _handlePointerDown(_) {
+    setState(() { });
+    return EventDisposition.processed;
+  }
+
+}
+
+class Outside extends App {
+  Widget build() {
+    return new Middle(child: new Inside());
+  }
+}
+
+void main() {
+  test('setState() smoke test', () {
+    WidgetTester tester = new WidgetTester();
+
+    tester.pumpFrame(() {
+      return new Outside();
+    });
+
+    TestPointer pointer = new TestPointer(1);
+    Point location = tester.getCenter(tester.findText('INSIDE'));
+    tester.dispatchEvent(pointer.down(location), location);
+
+    tester.pumpFrameWithoutChange();
+
+    tester.dispatchEvent(pointer.up(), location);
+   
+    tester.pumpFrameWithoutChange();
+
+  });
+}

--- a/sky/unit/test/widget/stateful_components_test.dart
+++ b/sky/unit/test/widget/stateful_components_test.dart
@@ -40,27 +40,36 @@ void main() {
 
     WidgetTester tester = new WidgetTester();
 
-    InnerComponent inner;
+    InnerComponent inner1;
+    InnerComponent inner2;
     OuterContainer outer;
 
     tester.pumpFrame(() {
-      return new OuterContainer(child: new InnerComponent());
-    });
-
-    tester.pumpFrame(() {
-      inner = new InnerComponent();
-      outer = new OuterContainer(child: inner);
+      inner1 = new InnerComponent();
+      outer = new OuterContainer(child: inner1);
       return outer;
     });
 
-    expect(inner._didInitState, isFalse);
-    expect(inner.parent, isNull);
+    expect(inner1._didInitState, isTrue);
+    expect(inner1.parent, isNotNull);
+
+    tester.pumpFrame(() {
+      inner2 = new InnerComponent();
+      return new OuterContainer(child: inner2);
+    });
+
+    expect(inner1._didInitState, isTrue);
+    expect(inner1.parent, isNotNull);
+    expect(inner2._didInitState, isFalse);
+    expect(inner2.parent, isNull);
 
     outer.setState(() {});
-    scheduler.beginFrame(0.0);
+    tester.pumpFrameWithoutChange(0.0);
 
-    expect(inner._didInitState, isFalse);
-    expect(inner.parent, isNull);
+    expect(inner1._didInitState, isTrue);
+    expect(inner1.parent, isNotNull);
+    expect(inner2._didInitState, isFalse);
+    expect(inner2.parent, isNull);
 
   });
 }

--- a/sky/unit/test/widget/widget_tester.dart
+++ b/sky/unit/test/widget/widget_tester.dart
@@ -9,7 +9,6 @@ import '../engine/mock_events.dart';
 typedef Widget WidgetBuilder();
 
 class TestApp extends App {
-  TestApp();
 
   WidgetBuilder _builder;
   void set builder (WidgetBuilder value) {
@@ -29,6 +28,7 @@ class WidgetTester {
   WidgetTester() {
     _app = new TestApp();
     runApp(_app);
+    scheduler.beginFrame(0.0); // to initialise the app
   }
 
   TestApp _app;


### PR DESCRIPTION
Also:

 - don't mark a node as from the new generation if it is dirty, since we
   know it still has to be built.

 - establish the rule that you can't call setState() during initState()
   or build().

 - make syncChild() return early for unchanged children.

 - update the tests, including adding a new one.