### PR TITLE
Refactor rendering_tester

### DIFF
--- a/sky/unit/test/examples/sector_layout_test.dart
+++ b/sky/unit/test/examples/sector_layout_test.dart
@@ -5,7 +5,6 @@ import '../../../../examples/rendering/sector_layout.dart';
 
 void main() {
   test('Sector layout can paint', () {
-    RenderingTester tester = new RenderingTester(root: buildSectorExample());
-    tester.pumpFrame();
+    layout(buildSectorExample(), phase: EnginePhase.composite);
   });
 }

--- a/sky/unit/test/rendering/grid_test.dart
+++ b/sky/unit/test/rendering/grid_test.dart
@@ -13,7 +13,7 @@ void main() {
     ];
 
     RenderGrid grid = new RenderGrid(children: children, maxChildExtent: 100.0);
-    RenderingTester tester = layout(grid, constraints: const BoxConstraints(maxWidth: 200.0));
+    layout(grid, constraints: const BoxConstraints(maxWidth: 200.0));
 
     children.forEach((child) {
       expect(child.size.width, equals(100.0), reason: "child width");
@@ -27,7 +27,7 @@ void main() {
     grid.maxChildExtent = 60.0;
     expect(grid.needsLayout, equals(true));
 
-    tester.pumpFrame(phase: EnginePhase.layout);
+    pumpFrame();
 
     children.forEach((child) {
       expect(child.size.width, equals(50.0), reason: "child width");

--- a/sky/unit/test/rendering/positioned_box_test.dart
+++ b/sky/unit/test/rendering/positioned_box_test.dart
@@ -22,19 +22,19 @@ void main() {
       child: new RenderDecoratedBox(decoration: new BoxDecoration())
     );
     RenderPositionedBox positioner = new RenderPositionedBox(child: sizer, shrinkWrap: ShrinkWrap.width);
-    RenderingTester tester = layout(positioner, constraints: new BoxConstraints.loose(new Size(200.0, 200.0)));
+    layout(positioner, constraints: new BoxConstraints.loose(new Size(200.0, 200.0)));
 
     expect(positioner.size.width, equals(100.0), reason: "positioner width");
     expect(positioner.size.height, equals(200.0), reason: "positioner height");
 
     positioner.shrinkWrap = ShrinkWrap.height;
-    tester.pumpFrame(phase: EnginePhase.layout);
+    pumpFrame();
 
     expect(positioner.size.width, equals(200.0), reason: "positioner width");
     expect(positioner.size.height, equals(100.0), reason: "positioner height");
 
     positioner.shrinkWrap = ShrinkWrap.both;
-    tester.pumpFrame(phase: EnginePhase.layout);
+    pumpFrame();
 
     expect(positioner.size.width, equals(100.0), reason: "positioner width");
     expect(positioner.size.height, equals(100.0), reason: "positioner height");

--- a/sky/unit/test/rendering/viewport_test.dart
+++ b/sky/unit/test/rendering/viewport_test.dart
@@ -15,16 +15,16 @@ void main() {
       child: size);
 
     RenderViewport viewport = new RenderViewport(child: red, scrollOffset: new Offset(0.0, -10.0));
-    RenderingTester tester = layout(viewport);
+    layout(viewport);
 
     HitTestResult result;
 
     result = new HitTestResult();
-    tester.renderView.hitTest(result, position: new Point(15.0, 0.0));
+    renderView.hitTest(result, position: new Point(15.0, 0.0));
     expect(result.path.first.target, equals(viewport));
 
     result = new HitTestResult();
-    tester.renderView.hitTest(result, position: new Point(15.0, 15.0));
+    renderView.hitTest(result, position: new Point(15.0, 15.0));
     expect(result.path.first.target, equals(size));
   });
 }


### PR DESCRIPTION
RenderView has to be a singleton for sanity during tests, otherwise they
all end up in the dirty lists and we end up pumping all of them each frame.