### PR TITLE
Move Drawer to GestureDetector

### DIFF
--- a/sky/packages/sky/lib/gestures/drag.dart
+++ b/sky/packages/sky/lib/gestures/drag.dart
@@ -15,14 +15,14 @@ enum DragState {
 }
 
 typedef void GestureDragStartCallback();
-typedef void GestureDragUpdateCallback(double scrollDelta);
+typedef void GestureDragUpdateCallback(double delta);
 typedef void GestureDragEndCallback(sky.Offset velocity);
 
 typedef void GesturePanStartCallback();
-typedef void GesturePanUpdateCallback(sky.Offset scrollDelta);
+typedef void GesturePanUpdateCallback(sky.Offset delta);
 typedef void GesturePanEndCallback(sky.Offset velocity);
 
-typedef void _GesturePolymorphicUpdateCallback<T>(T scrollDelta);
+typedef void _GesturePolymorphicUpdateCallback<T>(T delta);
 
 int _eventTime(sky.PointerEvent event) => (event.timeStamp * 1000.0).toInt(); // microseconds
 
@@ -121,8 +121,7 @@ class VerticalDragGestureRecognizer extends _DragGestureRecognizer<double> {
   }) : super(router: router, onStart: onStart, onUpdate: onUpdate, onEnd: onEnd);
 
   double get _initialPendingDragDelta => 0.0;
-  // Notice that we negate dy because scroll offsets go in the opposite direction.
-  double _getDragDelta(sky.PointerEvent event) => -event.dy;
+  double _getDragDelta(sky.PointerEvent event) => event.dy;
   bool get _hasSufficientPendingDragDeltaToAccept => _pendingDragDelta.abs() > kTouchSlop;
 }
 
@@ -135,7 +134,7 @@ class HorizontalDragGestureRecognizer extends _DragGestureRecognizer<double> {
   }) : super(router: router, onStart: onStart, onUpdate: onUpdate, onEnd: onEnd);
 
   double get _initialPendingDragDelta => 0.0;
-  double _getDragDelta(sky.PointerEvent event) => -event.dx;
+  double _getDragDelta(sky.PointerEvent event) => event.dx;
   bool get _hasSufficientPendingDragDeltaToAccept => _pendingDragDelta.abs() > kTouchSlop;
 }
 
@@ -148,8 +147,7 @@ class PanGestureRecognizer extends _DragGestureRecognizer<sky.Offset> {
   }) : super(router: router, onStart: onStart, onUpdate: onUpdate, onEnd: onEnd);
 
   sky.Offset get _initialPendingDragDelta => sky.Offset.zero;
-  // Notice that we negate dy because scroll offsets go in the opposite direction.
-  sky.Offset _getDragDelta(sky.PointerEvent event) => new sky.Offset(event.dx, -event.dy);
+  sky.Offset _getDragDelta(sky.PointerEvent event) => new sky.Offset(event.dx, event.dy);
   bool get _hasSufficientPendingDragDeltaToAccept {
     return _pendingDragDelta.dx.abs() > kTouchSlop || _pendingDragDelta.dy.abs() > kTouchSlop;
   }

--- a/sky/packages/sky/lib/src/widgets/dismissable.dart
+++ b/sky/packages/sky/lib/src/widgets/dismissable.dart
@@ -119,7 +119,7 @@ class Dismissable extends StatefulComponent {
     });
   }
 
-  void _handleDragUpdate(double scrollOffset) {
+  void _handleDragUpdate(double delta) {
     if (!_isActive || _fadePerformance.isAnimating)
       return;
 
@@ -127,19 +127,19 @@ class Dismissable extends StatefulComponent {
     switch(direction) {
       case DismissDirection.horizontal:
       case DismissDirection.vertical:
-        _dragExtent -= scrollOffset;
+        _dragExtent += delta;
         break;
 
       case DismissDirection.up:
       case DismissDirection.left:
-        if (_dragExtent - scrollOffset < 0)
-          _dragExtent -= scrollOffset;
+        if (_dragExtent + delta < 0)
+          _dragExtent += delta;
         break;
 
       case DismissDirection.down:
       case DismissDirection.right:
-        if (_dragExtent - scrollOffset > 0)
-          _dragExtent -= scrollOffset;
+        if (_dragExtent + delta > 0)
+          _dragExtent += delta;
         break;
     }
 

--- a/sky/packages/sky/lib/src/widgets/scrollable.dart
+++ b/sky/packages/sky/lib/src/widgets/scrollable.dart
@@ -83,7 +83,7 @@ abstract class Scrollable extends StatefulComponent {
   GestureDragUpdateCallback _getDragUpdateHandler(ScrollDirection direction) {
     if (scrollDirection != direction || !scrollBehavior.isScrollable)
       return null;
-    return scrollBy;
+    return _handleDragUpdate;
   }
 
   GestureDragEndCallback _getDragEndHandler(ScrollDirection direction) {
@@ -179,6 +179,12 @@ abstract class Scrollable extends StatefulComponent {
   EventDisposition _handlePointerDown(_) {
     _stopAnimations();
     return EventDisposition.processed;
+  }
+
+  void _handleDragUpdate(double delta) {
+    // We negate the delta here because a positive scroll offset moves the
+    // the content up (or to the left) rather than down (or the right).
+    scrollBy(-delta);
   }
 
   void _handleDragEnd(Offset velocity) {

--- a/sky/unit/test/gestures/scroll_test.dart
+++ b/sky/unit/test/gestures/scroll_test.dart
@@ -53,14 +53,14 @@ void main() {
     router.route(pointer.move(new Point(20.0, 20.0)));
     expect(didStartPan, isTrue);
     didStartPan = false;
-    expect(updatedScrollDelta, new sky.Offset(10.0, -10.0));
+    expect(updatedScrollDelta, new sky.Offset(10.0, 10.0));
     updatedScrollDelta = null;
     expect(didEndPan, isFalse);
     expect(didTap, isFalse);
 
     router.route(pointer.move(new Point(20.0, 25.0)));
     expect(didStartPan, isFalse);
-    expect(updatedScrollDelta, new sky.Offset(0.0, -5.0));
+    expect(updatedScrollDelta, new sky.Offset(0.0, 5.0));
     updatedScrollDelta = null;
     expect(didEndPan, isFalse);
     expect(didTap, isFalse);

--- a/sky/unit/test/widget/gesture_detector_test.dart
+++ b/sky/unit/test/widget/gesture_detector_test.dart
@@ -43,7 +43,7 @@ void main() {
     Point secondLocation = new Point(10.0, 9.0);
     tester.dispatchEvent(pointer.move(secondLocation), firstLocation);
     expect(didStartDrag, isFalse);
-    expect(updatedDragDelta, 1.0);
+    expect(updatedDragDelta, -1.0);
     updatedDragDelta = null;
     expect(didEndDrag, isFalse);
 
@@ -86,6 +86,6 @@ void main() {
     tester.dispatchEvent(pointer.up(), downLocation);
 
     expect(gestureCount, 2);
-    expect(dragDistance, -20.0);
+    expect(dragDistance, 20.0);
   });
 }


### PR DESCRIPTION
This fixes an issue in the stocks app in horizontal mode where you could both
scroll and drag the drawer at the same time.