### PR TITLE
Remove reference to oblique

### DIFF
--- a/sky/packages/sky/lib/src/painting/text_style.dart
+++ b/sky/packages/sky/lib/src/painting/text_style.dart
@@ -183,7 +183,6 @@ class TextStyle {
       cssStyle['font-style'] = const {
         FontStyle.normal: 'normal',
         FontStyle.italic: 'italic',
-        FontStyle.oblique: 'oblique',
       }[fontStyle];
     }
     if (decoration != null) {


### PR DESCRIPTION
We removed this value from the engine because it's not useful.