### PR TITLE
Improve debugging aids for widgets, rendering.

### DIFF
--- a/sky/packages/sky/lib/src/rendering/flex.dart
+++ b/sky/packages/sky/lib/src/rendering/flex.dart
@@ -588,8 +588,8 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     });
   }
 
-  String toStringName() {
-    String header = super.toStringName();
+  String toString() {
+    String header = super.toString();
     if (_overflow is double && _overflow > 0.0)
       header += ' OVERFLOWING';
     return header;

--- a/sky/packages/sky/lib/src/rendering/object.dart
+++ b/sky/packages/sky/lib/src/rendering/object.dart
@@ -1041,18 +1041,8 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   // You must not add yourself to /result/ if you return false.
 
 
-  String toString([String prefix = '']) {
-    RenderObject debugPreviousActiveLayout = _debugActiveLayout;
-    _debugActiveLayout = null;
-    String header = toStringName();
-    prefix += '  ';
-    String result = '${header}\n${debugDescribeSettings(prefix)}${debugDescribeChildren(prefix)}';
-    _debugActiveLayout = debugPreviousActiveLayout;
-    return result;
-  }
-
   /// Returns a human understandable name
-  String toStringName() {
+  String toString() {
     String header = '${runtimeType}';
     if (_relayoutSubtreeRoot != null && _relayoutSubtreeRoot != this) {
       int count = 1;
@@ -1070,7 +1060,25 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
     return header;
   }
 
+  /// Returns a description of the tree rooted at this node.
+  /// If the prefix argument is provided, then every line in the output
+  /// will be prefixed by that string.
+  String toStringDeep([String prefix = '']) {
+    RenderObject debugPreviousActiveLayout = _debugActiveLayout;
+    _debugActiveLayout = null;
+    prefix += '  ';
+    String result = '$this\n${debugDescribeSettings(prefix)}${debugDescribeChildren(prefix)}';
+    _debugActiveLayout = debugPreviousActiveLayout;
+    return result;
+  }
+
+  /// Returns a string describing the current node's fields, one field per line,
+  /// with each line prefixed by the prefix argument. Subclasses should override
+  /// this to have their information included in toStringDeep().
   String debugDescribeSettings(String prefix) => '${prefix}parentData: ${parentData}\n${prefix}constraints: ${constraints}\n';
+
+  /// Returns a string describing the current node's descendants. Each line of
+  /// the subtree in the output should be indented by the prefix argument.
   String debugDescribeChildren(String prefix) => '';
 
 }
@@ -1112,7 +1120,7 @@ abstract class RenderObjectWithChildMixin<ChildType extends RenderObject> implem
   }
   String debugDescribeChildren(String prefix) {
     if (child != null)
-      return '${prefix}child: ${child.toString(prefix)}';
+      return '${prefix}child: ${child.toStringDeep(prefix)}';
     return '';
   }
 }
@@ -1352,7 +1360,7 @@ abstract class ContainerRenderObjectMixin<ChildType extends RenderObject, Parent
     int count = 1;
     ChildType child = _firstChild;
     while (child != null) {
-      result += '${prefix}child ${count}: ${child.toString(prefix)}';
+      result += '${prefix}child ${count}: ${child.toStringDeep(prefix)}';
       count += 1;
       child = child.parentData.nextSibling;
     }

--- a/sky/packages/sky/lib/src/rendering/sky_binding.dart
+++ b/sky/packages/sky/lib/src/rendering/sky_binding.dart
@@ -171,12 +171,9 @@ class SkyBinding extends HitTestTarget {
       GestureArena.instance.close(event.pointer);
     return EventDisposition.processed;
   }
+}
 
-  String toString() => 'Render Tree:\n${_renderView}';
-
-  /// Prints a textual representation of the entire render tree
-  void debugDumpRenderTree() {
-    toString().split('\n').forEach(print);
-  }
-
+/// Prints a textual representation of the entire render tree
+void debugDumpRenderTree() {
+  SkyBinding.instance.renderView.toStringDeep().split('\n').forEach(print);
 }

--- a/sky/packages/sky/lib/src/widgets/focus.dart
+++ b/sky/packages/sky/lib/src/widgets/focus.dart
@@ -235,8 +235,10 @@ class Focus extends StatefulComponent {
     }
   }
 
-  String toStringName() {
-    return '${super.toStringName()}(focusedScope=$_focusedScope; focusedWidget=$_focusedWidget)';
+  void debugAddDetails(List<String> details) {
+    super.debugAddDetails(details);
+    details.add('focusedScope=$_focusedScope');
+    details.add('focusedWidget=$_focusedWidget');
   }
 
 }

--- a/sky/packages/sky/lib/src/widgets/scaffold.dart
+++ b/sky/packages/sky/lib/src/widgets/scaffold.dart
@@ -171,7 +171,7 @@ class RenderScaffold extends RenderBox {
   }
 
   String debugDescribeChildren(String prefix) {
-    return _slots.keys.map((slot) => '${prefix}${slot}: ${_slots[slot].toString(prefix)}').join();
+    return _slots.keys.map((slot) => '${prefix}${slot}: ${_slots[slot].toStringDeep(prefix)}').join();
   }
 }
 


### PR DESCRIPTION
We need a short name more often than a tree dump, so toString() should
be the short name.

Make debugDumpRenderTree() a global like debugDumpApp(), for
consistency. It's hard to remember the
SkyBinding.instance.dumpRenderTree() incantation.

Fixes #1179.