### PR TITLE
Prepend mojo shebang to skyx files

### DIFF
--- a/sky/tools/skyx/bin/skyx.dart
+++ b/sky/tools/skyx/bin/skyx.dart
@@ -135,5 +135,6 @@ main(List<String> argv) async {
   }
 
   File outputFile = new File(args['output-file']);
-  await outputFile.writeAsBytes(new ZipEncoder().encode(archive));
+  await outputFile.writeAsString('#!mojo mojo:sky_viewer\n');
+  await outputFile.writeAsBytes(new ZipEncoder().encode(archive), mode: FileMode.APPEND);
 }


### PR DESCRIPTION
skyx files are zips, so they can have anything at the start. Having
a shebang line at the start makes it easier to run skyx files in a mojo
environment.