### PR TITLE
SkySprites should import the public libraries

### DIFF
--- a/examples/game/lib/game_demo.dart
+++ b/examples/game/lib/game_demo.dart
@@ -5,8 +5,8 @@ import 'dart:math' as math;
 import 'dart:sky' as sky;
 
 import 'package:sky/painting.dart';
-import 'package:sky/src/rendering/object.dart';
-import 'package:sky/src/widgets/framework.dart';
+import 'package:sky/rendering.dart';
+import 'package:sky/widgets.dart';
 import 'package:skysprites/skysprites.dart';
 import 'package:vector_math/vector_math.dart';
 

--- a/examples/game/lib/main.dart
+++ b/examples/game/lib/main.dart
@@ -6,14 +6,9 @@ import 'dart:async';
 
 import 'package:sky/material.dart';
 import 'package:sky/painting.dart';
+import 'package:sky/rendering.dart';
 import 'package:sky/services.dart';
-import 'package:sky/src/rendering/object.dart';
-import 'package:sky/src/widgets/basic.dart';
-import 'package:sky/src/widgets/button_base.dart';
-import 'package:sky/src/widgets/framework.dart';
-import 'package:sky/src/widgets/navigator.dart';
-import 'package:sky/src/widgets/theme.dart';
-import 'package:sky/src/widgets/title.dart';
+import 'package:sky/widgets.dart';
 import 'package:skysprites/skysprites.dart';
 
 import 'game_demo.dart';

--- a/skysprites/lib/image_map.dart
+++ b/skysprites/lib/image_map.dart
@@ -8,18 +8,18 @@ class ImageMap {
   ImageMap(AssetBundle bundle) : _bundle = bundle;
 
   final AssetBundle _bundle;
-  final Map<String, Image> _images = new Map<String, Image>();
+  final Map<String, sky.Image> _images = new Map<String, sky.Image>();
 
-  Future<List<Image>> load(List<String> urls) {
+  Future<List<sky.Image>> load(List<String> urls) {
     return Future.wait(urls.map(_loadImage));
   }
 
-  Future<Image> _loadImage(String url) async {
-    Image image = await _bundle.loadImage(url).first;
+  Future<sky.Image> _loadImage(String url) async {
+    sky.Image image = await _bundle.loadImage(url).first;
     _images[url] = image;
     return image;
   }
 
-  Image getImage(String url) => _images[url];
-  Image operator [](String url) => _images[url];
+  sky.Image getImage(String url) => _images[url];
+  sky.Image operator [](String url) => _images[url];
 }

--- a/skysprites/lib/layer.dart
+++ b/skysprites/lib/layer.dart
@@ -22,7 +22,7 @@ class Layer extends Node with SpritePaint {
   Layer([Rect this.layerRect = null]);
 
   Paint _cachedPaint = new Paint()
-    ..filterQuality = FilterQuality.low
+    ..filterQuality = sky.FilterQuality.low
     ..isAntiAlias = false;
 
   void _prePaint(PaintingCanvas canvas, Matrix4 matrix) {

--- a/skysprites/lib/particle_system.dart
+++ b/skysprites/lib/particle_system.dart
@@ -144,7 +144,7 @@ class ParticleSystem extends Node {
 
   /// The transfer mode used to draw the particle system. Default is
   /// [TransferMode.plus].
-  TransferMode transferMode;
+  sky.TransferMode transferMode;
 
   List<_Particle> _particles;
 
@@ -152,7 +152,7 @@ class ParticleSystem extends Node {
   int _numEmittedParticles = 0;
 
   static Paint _paint = new Paint()
-    ..filterQuality = FilterQuality.low
+    ..filterQuality = sky.FilterQuality.low
     ..isAntiAlias = false;
 
   ParticleSystem(this.texture,
@@ -184,7 +184,7 @@ class ParticleSystem extends Node {
                   this.redVar: 0,
                   this.greenVar: 0,
                   this.blueVar: 0,
-                  this.transferMode: TransferMode.plus,
+                  this.transferMode: sky.TransferMode.plus,
                   this.numParticlesToEmit: 0,
                   this.autoRemoveOnFinish: true}) {
     _particles = new List<_Particle>();
@@ -359,7 +359,7 @@ class ParticleSystem extends Node {
 
   void paint(PaintingCanvas canvas) {
 
-    List<RSTransform> transforms = [];
+    List<sky.RSTransform> transforms = [];
     List<Rect> rects = [];
     List<Color> colors = [];
 
@@ -388,7 +388,7 @@ class ParticleSystem extends Node {
       double ay = rect.height / 2;
       double tx = particle.pos[0] + -scos * ax + ssin * ay;
       double ty = particle.pos[1] + -ssin * ax - scos * ay;
-      RSTransform transform = new RSTransform(scos, ssin, tx, ty);
+      sky.RSTransform transform = new sky.RSTransform(scos, ssin, tx, ty);
       transforms.add(transform);
 
       // Color
@@ -411,7 +411,7 @@ class ParticleSystem extends Node {
     }
 
     canvas.drawAtlas(texture.image, transforms, rects, colors,
-      TransferMode.modulate, null, _paint);
+      sky.TransferMode.modulate, null, _paint);
   }
 }
 

--- a/skysprites/lib/skysprites.dart
+++ b/skysprites/lib/skysprites.dart
@@ -8,16 +8,15 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:math' as math;
 import 'dart:typed_data';
-import 'dart:sky';
+import 'dart:sky' as sky;
 
 import 'package:mojo/core.dart';
+import 'package:sky_services/media/media.mojom.dart';
 import 'package:sky/animation.dart';
 import 'package:sky/painting.dart';
+import 'package:sky/rendering.dart';
 import 'package:sky/services.dart';
-import 'package:sky/src/rendering/box.dart';
-import 'package:sky/src/rendering/object.dart';
-import 'package:sky/src/widgets/framework.dart';
-import 'package:sky_services/media/media.mojom.dart';
+import 'package:sky/widgets.dart';
 import 'package:vector_math/vector_math.dart';
 
 part 'action.dart';

--- a/skysprites/lib/sprite.dart
+++ b/skysprites/lib/sprite.dart
@@ -17,7 +17,7 @@ class Sprite extends NodeWithSize with SpritePaint {
   bool constrainProportions = false;
 
   Paint _cachedPaint = new Paint()
-    ..filterQuality = FilterQuality.low
+    ..filterQuality = sky.FilterQuality.low
     ..isAntiAlias = false;
 
   /// Creates a new sprite from the provided [texture].
@@ -35,7 +35,7 @@ class Sprite extends NodeWithSize with SpritePaint {
   /// Creates a new sprite from the provided [image].
   ///
   /// var mySprite = new Sprite.fromImage(myImage);
-  Sprite.fromImage(Image image) : super(Size.zero) {
+  Sprite.fromImage(sky.Image image) : super(Size.zero) {
     assert(image != null);
 
     texture = new Texture(image);
@@ -107,13 +107,13 @@ abstract class SpritePaint {
   ///
   ///     // Add the colors of the sprite with the colors of the background
   ///     mySprite.transferMode = TransferMode.plusMode;
-  TransferMode transferMode;
+  sky.TransferMode transferMode;
 
   void _updatePaint(Paint paint) {
     paint.color = new Color.fromARGB((255.0*_opacity).toInt(), 255, 255, 255);
 
     if (colorOverlay != null) {
-      paint.colorFilter = new ColorFilter.mode(colorOverlay, TransferMode.srcATop);
+      paint.colorFilter = new sky.ColorFilter.mode(colorOverlay, sky.TransferMode.srcATop);
     }
 
     if (transferMode != null) {

--- a/skysprites/lib/sprite_box.dart
+++ b/skysprites/lib/sprite_box.dart
@@ -178,11 +178,11 @@ class SpriteBox extends RenderBox {
     }
   }
 
-  EventDisposition handleEvent(Event event, _SpriteBoxHitTestEntry entry) {
+  EventDisposition handleEvent(sky.Event event, _SpriteBoxHitTestEntry entry) {
     if (!attached)
       return EventDisposition.ignored;
 
-    if (event is PointerEvent) {
+    if (event is sky.PointerEvent) {
 
       if (event.type == 'pointerdown') {
         // Build list of event targets

--- a/skysprites/lib/spritesheet.dart
+++ b/skysprites/lib/spritesheet.dart
@@ -8,7 +8,7 @@ part of skysprites;
 /// the sprite sheet definition are used to reference the different textures.
 class SpriteSheet {
 
-  Image _image;
+  sky.Image _image;
   Map<String, Texture> _textures = new Map();
 
   /// Creates a new sprite sheet from an [_image] and a sprite sheet [jsonDefinition].
@@ -65,7 +65,7 @@ class SpriteSheet {
   /// The image used by the sprite sheet.
   ///
   ///     var spriteSheetImage = mySpriteSheet.image;
-  Image get image => _image;
+  sky.Image get image => _image;
 
   /// Returns a texture by its name.
   ///

--- a/skysprites/lib/texture.dart
+++ b/skysprites/lib/texture.dart
@@ -7,7 +7,7 @@ class Texture {
   /// The image that this texture is a part of.
   ///
   ///     var textureImage = myTexture.image;
-  final Image image;
+  final sky.Image image;
 
   /// The logical size of the texture, before being trimmed by the texture packer.
   ///
@@ -51,7 +51,7 @@ class Texture {
   /// Creates a new texture from an [Image] object.
   ///
   ///     var myTexture = new Texture(myImage);
-  Texture(Image image) :
+  Texture(sky.Image image) :
     size = new Size(image.width.toDouble(), image.height.toDouble()),
     image = image,
     trimmed = false,

--- a/skysprites/lib/textured_line.dart
+++ b/skysprites/lib/textured_line.dart
@@ -38,8 +38,8 @@ class TexturedLinePainter {
       _cachedPaint = new Paint();
     } else {
       Matrix4 matrix = new Matrix4.identity();
-      ImageShader shader = new ImageShader(texture.image,
-        TileMode.repeated, TileMode.repeated, matrix.storage);
+      sky.ImageShader shader = new sky.ImageShader(texture.image,
+        sky.TileMode.repeated, sky.TileMode.repeated, matrix.storage);
 
       _cachedPaint = new Paint();
       _cachedPaint.setShader(shader);
@@ -163,7 +163,7 @@ class TexturedLinePainter {
       lastMiter = currentMiter;
     }
 
-    canvas.drawVertices(VertexMode.triangles, vertices, textureCoordinates, verticeColors, TransferMode.modulate, indicies, _cachedPaint);
+    canvas.drawVertices(sky.VertexMode.triangles, vertices, textureCoordinates, verticeColors, sky.TransferMode.modulate, indicies, _cachedPaint);
   }
 
   double _xPosForStop(double stop) {

--- a/skysprites/lib/virtual_joystick.dart
+++ b/skysprites/lib/virtual_joystick.dart
@@ -14,7 +14,7 @@ class VirtualJoystick extends NodeWithSize {
     _paintControl = new Paint()
       ..color=new Color(0xffffffff)
       ..strokeWidth = 1.0
-      ..setStyle(PaintingStyle.stroke);
+      ..setStyle(sky.PaintingStyle.stroke);
   }
 
   Point _value = Point.origin;


### PR DESCRIPTION
Importing the public libraries caused a name conflict with dart:sky because we
assume people will import dart:sky into a namespace, so I've also changed
skysprites to import dart:sky into a namespace.