### PR TITLE
Allow route transitions to be more flexible

### DIFF
--- a/sky/packages/sky/lib/src/animation/animated_value.dart
+++ b/sky/packages/sky/lib/src/animation/animated_value.dart
@@ -30,9 +30,9 @@ abstract class AnimatedVariable {
 /// can be made to take longer in one direction that the other.
 class AnimationTiming {
   AnimationTiming({
-    this.interval,
+    this.interval: const Interval(0.0, 1.0),
     this.reverseInterval,
-    this.curve,
+    this.curve: linear,
     this.reverseCurve
   });
 

--- a/sky/packages/sky/lib/src/animation/curves.dart
+++ b/sky/packages/sky/lib/src/animation/curves.dart
@@ -27,14 +27,9 @@ class Linear implements Curve {
   double transform(double t) => t;
 }
 
-/// A curve that is initially 0.0, then linear, then 1.0
+/// A curve that is 0.0 until start, then linear from 0.0 to 1.0 at end, then 1.0
 class Interval implements Curve {
-  Interval(this.start, this.end) {
-    assert(start >= 0.0);
-    assert(start <= 1.0);
-    assert(end >= 0.0);
-    assert(end <= 1.0);
-  }
+  const Interval(this.start, this.end);
 
   /// The smallest value for which this interval is 0.0
   final double start;
@@ -43,6 +38,10 @@ class Interval implements Curve {
   final double end;
 
   double transform(double t) {
+    assert(start >= 0.0);
+    assert(start <= 1.0);
+    assert(end >= 0.0);
+    assert(end <= 1.0);
     return ((t - start) / (end - start)).clamp(0.0, 1.0);
   }
 }

--- a/sky/packages/sky/lib/src/widgets/dialog.dart
+++ b/sky/packages/sky/lib/src/widgets/dialog.dart
@@ -139,20 +139,18 @@ class DialogRoute extends RouteBase {
   final Completer completer;
   final RouteBuilder builder;
 
-  Widget build(Navigator navigator, RouteBase route) => builder(navigator, route);
-  bool get isOpaque => false;
-
-  void popState([dynamic result]) {
-    completer.complete(result);
-  }
-
   Duration get transitionDuration => _kTransitionDuration;
-  TransitionBase buildTransition({ Key key, Widget child, WatchableAnimationPerformance performance }) {
+  bool get isOpaque => false;
+  Widget build(Key key, Navigator navigator, RouteBase route, WatchableAnimationPerformance performance) {
     return new FadeTransition(
       performance: performance,
       opacity: new AnimatedValue<double>(0.0, end: 1.0, curve: easeOut),
-      child: child
+      child: builder(navigator, route)
     );
+  }
+
+  void popState([dynamic result]) {
+    completer.complete(result);
   }
 }
 

--- a/sky/packages/sky/lib/src/widgets/popup_menu.dart
+++ b/sky/packages/sky/lib/src/widgets/popup_menu.dart
@@ -15,7 +15,7 @@ import 'package:sky/src/widgets/scrollable.dart';
 import 'package:sky/src/widgets/transitions.dart';
 
 const Duration _kMenuDuration = const Duration(milliseconds: 300);
-double _kMenuCloseIntervalEnd = 2.0 / 3.0;
+const double _kMenuCloseIntervalEnd = 2.0 / 3.0;
 const double _kMenuWidthStep = 56.0;
 const double _kMenuMargin = 16.0; // 24.0 on tablet
 const double _kMenuMinWidth = 2.0 * _kMenuWidthStep;


### PR DESCRIPTION
- Fix AnimationTiming to have defaults for 'interval' and 'curve' since
  that seems to be how we use it.

- Merge RouteBase.build and RouteBase.buildTransition

- Get rid of HistoryEntry, since it added nothing

- Broke out RouteBase.createPerformance() so subclasses can change what
  is created.

- Build the routes backwards so that we more efficiently avoid building
  hidden routes.

- Introduce an explicit way (!hasContent) for RouteState to avoid
  building, rather than the implicit "build returns null" we had before.