### PR TITLE
Fix Rect intersection; add test

### DIFF
--- a/sky/engine/core/painting/Rect.dart
+++ b/sky/engine/core/painting/Rect.dart
@@ -63,8 +63,8 @@ class Rect {
     return new Rect.fromLTRB(
       math.max(left, other.left),
       math.max(top, other.top),
-      math.max(right, other.right),
-      math.max(bottom, other.bottom));
+      math.min(right, other.right),
+      math.min(bottom, other.bottom));
   }
 
   /// The distance between the left and right edges of this rectangle

--- a/sky/unit/test/engine/rect_test_disabled.dart
+++ b/sky/unit/test/engine/rect_test_disabled.dart
@@ -1,0 +1,33 @@
+import 'dart:sky';
+
+import 'package:test/test.dart';
+
+void main() {
+  test("rect accessors", () {
+    Rect r = new Rect.fromLTRB(1.0, 3.0, 5.0, 7.0);
+    expect(r.left, equals(1.0));
+    expect(r.top, equals(3.0));
+    expect(r.right, equals(5.0));
+    expect(r.bottom, equals(7.0));
+  });
+
+  test("rect created by width and height", () {
+    Rect r = new Rect.fromLTWH(1.0, 3.0, 5.0, 7.0);
+    expect(r.left, equals(1.0));
+    expect(r.top, equals(3.0));
+    expect(r.right, equals(6.0));
+    expect(r.bottom, equals(10.0));
+  });
+
+  test("rect intersection", () {
+    Rect r1 = new Rect.fromLTRB(0.0, 0.0, 100.0, 100.0);
+    Rect r2 = new Rect.fromLTRB(50.0, 50.0, 200.0, 200.0);
+    Rect r3 = r1.intersect(r2);
+    expect(r3.left, equals(50.0));
+    expect(r3.top, equals(50.0));
+    expect(r3.right, equals(100.0));
+    expect(r3.bottom, equals(100.0));
+    Rect r4 = r2.intersect(r1);
+    expect(r4, equals(r3));
+  });
+}


### PR DESCRIPTION
Rect's intersection method was erroneously using max instead of min for right and bottom.  Added tests (disabled for now) for Rect construction, accessors, and intersection.